### PR TITLE
Proper Dry run in Faros destination + fixes

### DIFF
--- a/cdk/src/destinations/destination-runner.ts
+++ b/cdk/src/destinations/destination-runner.ts
@@ -68,9 +68,9 @@ export class AirbyteDestinationRunner {
           this.logger.info('catalog: ' + JSON.stringify(catalog));
           this.logger.info('dryRun: ' + opts.dryRun);
 
-          process.stdin.setEncoding('utf-8');
-
           try {
+            process.stdin.setEncoding('utf-8');
+
             const iter = this.destination.write(
               config,
               catalog,

--- a/cdk/src/logger.ts
+++ b/cdk/src/logger.ts
@@ -39,29 +39,25 @@ export class AirbyteLogger {
    * @returns Pino Logger
    */
   asPino(level: Level = 'info'): Logger {
+    const detaultLevel = AirbyteLogLevel[level.toUpperCase()];
+
     const destination: DestinationStream = new stream.Writable({
       write: function (chunk, encoding, next): void {
         const msg = JSON.parse(chunk);
-        const lvl = AirbyteLogger.fromPinoLevel(msg.level);
+        const lvl = msg.level
+          ? AirbyteLogLevel[pino.levels.labels[msg.level].toUpperCase()]
+          : detaultLevel;
         AirbyteLogger.writeMessage(AirbyteLog.make(lvl, msg.msg));
         next();
       },
     });
+
     const logger = pino({level}, destination);
+
     return logger;
   }
 
   private static writeMessage(msg: AirbyteMessage): void {
     console.log(JSON.stringify(msg));
-  }
-
-  private static fromPinoLevel(
-    level: any,
-    defaultLevel: AirbyteLogLevel = AirbyteLogLevel.INFO
-  ): AirbyteLogLevel {
-    if (!level) {
-      return defaultLevel;
-    }
-    return AirbyteLogLevel[pino.levels.labels[level].toUpperCase()];
   }
 }

--- a/cdk/src/logger.ts
+++ b/cdk/src/logger.ts
@@ -39,14 +39,14 @@ export class AirbyteLogger {
    * @returns Pino Logger
    */
   asPino(level: Level = 'info'): Logger {
-    const detaultLevel = AirbyteLogLevel[level.toUpperCase()];
+    const defaultLevel = AirbyteLogLevel[level.toUpperCase()];
 
     const destination: DestinationStream = new stream.Writable({
       write: function (chunk, encoding, next): void {
         const msg = JSON.parse(chunk);
         const lvl = msg.level
           ? AirbyteLogLevel[pino.levels.labels[msg.level].toUpperCase()]
-          : detaultLevel;
+          : defaultLevel;
         AirbyteLogger.writeMessage(AirbyteLog.make(lvl, msg.msg));
         next();
       },

--- a/destinations/faros-destination/resources/spec.json
+++ b/destinations/faros-destination/resources/spec.json
@@ -42,6 +42,12 @@
         "default": "5 seconds",
         "examples": ["5 seconds"]
       },
+      "dry_run": {
+        "type": "boolean",
+        "title": "Dry run",
+        "description": "Process all input records but avoid writing into Faros API",
+        "default": false
+      },
       "jsonata_expression": {
         "type": "string",
         "title": "JSONata expression",

--- a/destinations/faros-destination/src/index.ts
+++ b/destinations/faros-destination/src/index.ts
@@ -183,8 +183,8 @@ class FarosDestination extends AirbyteDestination {
       // Having asynchronous operations between interface creation and asynchronous iteration may
       // result in missed lines.
       const input = readline.createInterface({
-        input: process.stdin,
-        terminal: process.stdin.isTTY,
+        input: stdin,
+        terminal: stdin.isTTY,
       });
       try {
         // Process input & write records

--- a/destinations/faros-destination/src/index.ts
+++ b/destinations/faros-destination/src/index.ts
@@ -207,8 +207,7 @@ class FarosDestination extends AirbyteDestination {
     stateMessages: AirbyteStateMessage[],
     writer?: Writable
   ): Promise<{recordsProcessed: number; recordsWritten: number}> {
-    let recordsProcessed = 0;
-    let recordsWritten = 0;
+    const res = {recordsProcessed: 0, recordsWritten: 0};
 
     // readline.createInterface() will start to consume the input stream once invoked.
     // Having asynchronous operations between interface creation and asynchronous iteration may
@@ -217,6 +216,7 @@ class FarosDestination extends AirbyteDestination {
       input: stdin,
       terminal: stdin.isTTY,
     });
+
     try {
       // Process input & write records
       for await (const line of input) {
@@ -235,12 +235,12 @@ class FarosDestination extends AirbyteDestination {
               throw new VError(`Undefined stream ${record.stream}`);
             }
             const converter = this.getConverter(record.stream);
-            recordsWritten += this.writeRecord(
+            res.recordsWritten += this.writeRecord(
               converter,
               recordMessage,
               writer
             );
-            recordsProcessed++;
+            res.recordsProcessed++;
           }
         } catch (e) {
           this.logger.error(`Error processing input: ${e}`);
@@ -252,7 +252,7 @@ class FarosDestination extends AirbyteDestination {
       writer?.end();
     }
 
-    return {recordsProcessed, recordsWritten};
+    return res;
   }
 
   private initStreamsCheckConverters(catalog: AirbyteConfiguredCatalog): {

--- a/destinations/faros-destination/src/index.ts
+++ b/destinations/faros-destination/src/index.ts
@@ -173,67 +173,86 @@ class FarosDestination extends AirbyteDestination {
       deleteModelEntries,
       logger: this.logger.asPino('debug'),
     };
+
     const stateMessages: AirbyteStateMessage[] = [];
 
-    await withEntryUploader(entryUploaderConfig, async (writer) => {
-      let processedRecords = 0;
-      let wroteRecords = 0;
-
-      // readline.createInterface() will start to consume the input stream once invoked.
-      // Having asynchronous operations between interface creation and asynchronous iteration may
-      // result in missed lines.
-      const input = readline.createInterface({
-        input: stdin,
-        terminal: stdin.isTTY,
-      });
-      try {
-        // Process input & write records
-        for await (const line of input) {
-          try {
-            const msg = parseAirbyteMessage(line);
-            if (msg.type === AirbyteMessageType.STATE) {
-              stateMessages.push(msg as AirbyteStateMessage);
-            } else if (msg.type === AirbyteMessageType.RECORD) {
-              const recordMessage = msg as AirbyteRecord;
-              if (!recordMessage.record) {
-                throw new VError('Empty record');
-              }
-              const record = recordMessage.record;
-              const stream = streams[record.stream];
-              if (!stream) {
-                throw new VError(`Undefined stream ${record.stream}`);
-              }
-              const converter = this.getConverter(record.stream);
-              wroteRecords += this.writeRecord(
-                writer,
-                converter,
-                recordMessage,
-                dryRun
-              );
-              processedRecords++;
-            }
-          } catch (e) {
-            this.logger.error(`Error processing input: ${e}`);
-            throw e;
-          }
-        }
-      } finally {
-        input.close();
-        writer.end();
-      }
-
-      this.logger.info(`Processed ${processedRecords} records`);
-      if (dryRun) {
-        this.logger.info(
-          `Would write ${wroteRecords} records, but dry run is enabled`
+    if (config.dry_run === true || dryRun) {
+      const res = await this.writeEntries(stdin, streams, stateMessages);
+      this.logger.info(`Processed ${res.recordsProcessed} records`);
+      this.logger.info(
+        `Would write ${res.recordsWritten} records, but dry run is enabled`
+      );
+    } else {
+      await withEntryUploader(entryUploaderConfig, async (writer) => {
+        const res = await this.writeEntries(
+          stdin,
+          streams,
+          stateMessages,
+          writer
         );
-      } else this.logger.info(`Wrote ${wroteRecords} records`);
-    });
+        this.logger.info(`Processed ${res.recordsProcessed} records`);
+        this.logger.info(`Wrote ${res.recordsWritten} records`);
+      });
+    }
 
     // Since we are writing all records in a single revision,
     // we should be ok to return all the state messages at the end,
     // once the revision has been closed.
     for (const state of stateMessages) yield state;
+  }
+
+  private async writeEntries(
+    stdin: NodeJS.ReadStream,
+    streams: Dictionary<AirbyteConfiguredStream>,
+    stateMessages: AirbyteStateMessage[],
+    writer?: Writable
+  ): Promise<{recordsProcessed: number; recordsWritten: number}> {
+    let recordsProcessed = 0;
+    let recordsWritten = 0;
+
+    // readline.createInterface() will start to consume the input stream once invoked.
+    // Having asynchronous operations between interface creation and asynchronous iteration may
+    // result in missed lines.
+    const input = readline.createInterface({
+      input: stdin,
+      terminal: stdin.isTTY,
+    });
+    try {
+      // Process input & write records
+      for await (const line of input) {
+        try {
+          const msg = parseAirbyteMessage(line);
+          if (msg.type === AirbyteMessageType.STATE) {
+            stateMessages.push(msg as AirbyteStateMessage);
+          } else if (msg.type === AirbyteMessageType.RECORD) {
+            const recordMessage = msg as AirbyteRecord;
+            if (!recordMessage.record) {
+              throw new VError('Empty record');
+            }
+            const record = recordMessage.record;
+            const stream = streams[record.stream];
+            if (!stream) {
+              throw new VError(`Undefined stream ${record.stream}`);
+            }
+            const converter = this.getConverter(record.stream);
+            recordsWritten += this.writeRecord(
+              converter,
+              recordMessage,
+              writer
+            );
+            recordsProcessed++;
+          }
+        } catch (e) {
+          this.logger.error(`Error processing input: ${e}`);
+          throw e;
+        }
+      }
+    } finally {
+      input.close();
+      writer?.end();
+    }
+
+    return {recordsProcessed, recordsWritten};
   }
 
   private initStreamsCheckConverters(catalog: AirbyteConfiguredCatalog): {
@@ -278,10 +297,9 @@ class FarosDestination extends AirbyteDestination {
   }
 
   private writeRecord(
-    writer: Writable,
     converter: Converter,
     recordMessage: AirbyteRecord,
-    dryRun: boolean
+    writer?: Writable
   ): number {
     // Apply conversion on the input record
     const results = converter.convert(recordMessage);
@@ -293,9 +311,7 @@ class FarosDestination extends AirbyteDestination {
       }
       const obj: Dictionary<any> = {};
       obj[result.model] = result.record;
-      if (!dryRun) {
-        writer.write(obj);
-      }
+      writer?.write(obj);
     }
 
     return results.length;


### PR DESCRIPTION
## Description

1. Dry run won create neither a revision nor write any records into Faros API
2. Minor rearrange in logger functions
3. Use stdin argument in destination

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
