### PR TITLE
Write stats by model in Faros destination + Airbyte container labels

### DIFF
--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Faros Destination for Airbyte",
   "keywords": [
@@ -30,7 +30,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "faros-airbyte-cdk": "^0.1.2",
+    "faros-airbyte-cdk": "^0.1.3",
     "faros-feeds-sdk": "^0.8.28",
     "jsonata": "^1.8.4",
     "verror": "^1.10.0"

--- a/destinations/faros-destination/test/converters/github.test.ts
+++ b/destinations/faros-destination/test/converters/github.test.ts
@@ -200,7 +200,8 @@ describe('github', () => {
 
     const stdout = await read(cli.stdout);
     logger.debug(stdout);
-    const recordsByStream = {
+
+    const processedByStream = {
       assignees: 12,
       branches: 4,
       collaborators: 12,
@@ -225,22 +226,55 @@ describe('github', () => {
       teams: 1,
       users: 24,
     };
-    const sorted = _(recordsByStream)
+    const processed = _(processedByStream)
       .toPairs()
       .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
       .orderBy(0, 'asc')
       .fromPairs()
       .value();
 
-    const total = _(recordsByStream).values().sum(); // total = 1073
-    expect(stdout).toMatch(`Processed ${total} records`);
-    expect(stdout).toMatch('Would write 817 records');
+    const writtenByModel = {
+      cicd_Release: 1,
+      cicd_ReleaseTagAssociation: 1,
+      tms_Label: 24,
+      tms_Project: 50,
+      tms_Task: 1,
+      tms_TaskAssignment: 1,
+      tms_TaskBoard: 50,
+      tms_TaskBoardProjectRelationship: 50,
+      tms_TaskBoardRelationship: 1,
+      tms_User: 14,
+      vcs_Branch: 4,
+      vcs_Commit: 77,
+      vcs_Membership: 12,
+      vcs_Organization: 1,
+      vcs_PullRequest: 38,
+      vcs_PullRequestComment: 87,
+      vcs_PullRequestReview: 121,
+      vcs_PullRequest__Update: 38,
+      vcs_Repository: 49,
+      vcs_Tag: 2,
+      vcs_User: 195,
+    };
+
+    const processedTotal = _(processedByStream).values().sum(); // total = 1073
+    const writtenTotal = _(writtenByModel).values().sum(); // total = 817
+    expect(stdout).toMatch(`Processed ${processedTotal} records`);
+    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(
           AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(sorted)}`
+          `Processed records by stream: ${JSON.stringify(processed)}`
+        )
+      )
+    );
+    expect(stdout).toMatch(
+      JSON.stringify(
+        AirbyteLog.make(
+          AirbyteLogLevel.INFO,
+          `Would write records by model: ${JSON.stringify(writtenByModel)}`
         )
       )
     );

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "bump": "lerna version --no-git-tag-version --preid rc",
+    "bump": "lerna version --force-publish --no-git-tag-version --preid rc",
     "build": "lerna run build",
     "clean": "lerna run clean && rm -rf node_modules out",
     "test-cov": "lerna run test -- -- --coverage --color",

--- a/scripts/publish-connector.sh
+++ b/scripts/publish-connector.sh
@@ -13,7 +13,6 @@ version_tag="$image:$connector_version"
 echo version tag: $version_tag
 
 docker manifest inspect $version_tag > /dev/null
-
 if [ "$?" == 1 ]
 then
   docker build . \

--- a/scripts/publish-connector.sh
+++ b/scripts/publish-connector.sh
@@ -11,10 +11,17 @@ latest_tag="$image:latest"
 connector_version=$(jq -r '.version' < ${connector_path}package.json)
 version_tag="$image:$connector_version"
 echo version tag: $version_tag
+
 docker manifest inspect $version_tag > /dev/null
+
 if [ "$?" == 1 ]
 then
-  docker build . --build-arg path=$connector_path -t $latest_tag -t $version_tag
+  docker build . \
+    --build-arg path=$connector_path \
+    --label "io.airbyte.version=$connector_version" \
+    --label "io.airbyte.name=$image" \
+    -t $latest_tag \
+    -t $version_tag \
   docker push $latest_tag
   docker push $version_tag
 fi

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Example Airbyte source",
   "keywords": [
     "faros"
@@ -29,7 +29,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "commander": "^8.0.0",
-    "faros-airbyte-cdk": "^0.1.2",
+    "faros-airbyte-cdk": "^0.1.3",
     "verror": "^1.10.0"
   },
   "jest": {


### PR DESCRIPTION
## Description

1. Write stats by model in Faros destination
2. Airbyte container labels (required by Airbyte spec) https://docs.airbyte.io/connector-development#publishing-a-connector. Example - https://hub.docker.com/layers/airbyte/source-postgres/latest/images/sha256-ede6fe4d7e1a4b3f3c4d4f91089766be2caa9178830ef3e92a25f442f57ec691?context=explore

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
