### PR TITLE
Remove node user + Faros destination fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ ENV CONNECTOR_PATH $path
 
 RUN ln -s "/home/node/airbyte/$CONNECTOR_PATH/bin/main" "/home/node/airbyte/main"
 
-USER node
 ENV AIRBYTE_ENTRYPOINT "/home/node/airbyte/main"
 ENTRYPOINT ["/home/node/airbyte/main"]

--- a/README.md
+++ b/README.md
@@ -33,10 +33,7 @@ In order to build a Docker image for a connector run the `docker build` command 
 For example for Faros Destination connector run:
 
 ```shell
-docker build . \
-  --build-arg path=destinations/faros-destination -t faros-destination \
-  --label "io.airbyte.version=0.1.0" \
-  --label "io.airbyte.name=faros-ai/faros-destination"
+docker build . --build-arg path=destinations/faros-destination -t faros-destination
 ```
 
 And then run it:

--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Faros Destination for Airbyte",
   "keywords": [
@@ -30,7 +30,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "faros-airbyte-cdk": "^0.1.3",
+    "faros-airbyte-cdk": "^0.1.4",
     "faros-feeds-sdk": "^0.8.28",
     "jsonata": "^1.8.4",
     "verror": "^1.10.0"

--- a/destinations/faros-destination/src/converters/github/index.ts
+++ b/destinations/faros-destination/src/converters/github/index.ts
@@ -1,0 +1,1 @@
+import {GithubUsers} from './users';

--- a/destinations/faros-destination/test/converters/github.test.ts
+++ b/destinations/faros-destination/test/converters/github.test.ts
@@ -81,6 +81,7 @@ describe('github', () => {
 
     const stdout = await read(cli.stdout);
     logger.debug(stdout);
+    expect(stdout).toMatch('\\"api_key\\":\\"REDACTED\\"');
     expect(stdout).toMatch('Processed 96 records');
     expect(stdout).toMatch('Wrote 58 records');
     expect(stdout).toMatch('Errored 0 records');

--- a/destinations/faros-destination/test/converters/github.test.ts
+++ b/destinations/faros-destination/test/converters/github.test.ts
@@ -23,6 +23,7 @@ describe('github', () => {
   });
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/github-catalog.json';
+  const catalogRawPath = 'test/resources/github-catalog-raw.json';
   let configPath: string;
   const graphSchema = JSON.parse(readTestResourceFile('graph-schema.json'));
   const revisionId = 'test-revision-id';
@@ -116,7 +117,7 @@ describe('github', () => {
       '--config',
       configPath,
       '--catalog',
-      catalogPath,
+      catalogRawPath,
       '--dry-run',
     ]);
     cli.stdin.end(githubPGRawLog, 'utf8');

--- a/destinations/faros-destination/test/resources/github-catalog-raw.json
+++ b/destinations/faros-destination/test/resources/github-catalog-raw.json
@@ -1,0 +1,148 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__assignees"
+      },
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__collaborators"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__commits"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__pull_requests"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__something_else"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__branches"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__reviews"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__events"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__comments"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__commit_comments"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__issue_milestones"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__stargazers"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__tags"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__teams"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__projects"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__issue_labels"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__issues"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__issue_events"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__releases"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__organizations"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__repositories"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__review_comments"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__users"
+      },
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "_airbyte_raw_mytestsource__github__pull_request_stats"
+      },
+      "destination_sync_mode": "append"
+    }
+  ]
+}

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "commander": "^8.0.0",
+    "fast-redact": "^3.0.2",
     "lodash": "^4.17.21",
     "pino": "^6.13.0",
     "verror": "^1.10.0"

--- a/faros-airbyte-cdk/src/destinations/destination-runner.ts
+++ b/faros-airbyte-cdk/src/destinations/destination-runner.ts
@@ -2,7 +2,7 @@ import {Command} from 'commander';
 import path from 'path';
 
 import {AirbyteLogger} from '../logger';
-import {PACKAGE_VERSION} from '../utils';
+import {PACKAGE_VERSION, redactConfig} from '../utils';
 import {AirbyteDestination} from './destination';
 
 export class AirbyteDestinationRunner {
@@ -64,7 +64,8 @@ export class AirbyteDestinationRunner {
         async (opts: {config: string; catalog: string; dryRun: boolean}) => {
           const config = require(path.resolve(opts.config));
           const catalog = require(path.resolve(opts.catalog));
-          this.logger.info('config: ' + JSON.stringify(config));
+          const spec = await this.destination.spec();
+          this.logger.info('config: ' + redactConfig(config, spec));
           this.logger.info('catalog: ' + JSON.stringify(catalog));
           this.logger.info('dryRun: ' + opts.dryRun);
 

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -134,16 +134,20 @@ export class AirbyteRecord implements AirbyteMessage {
     }
   ) {}
 
-  unpackRaw(): AirbyteRecord {
+  isRaw(): boolean {
     const stream = this.record.stream;
-    if (!stream || !stream.startsWith(AirbyteRawStreamPrefix)) {
-      return this;
+    return stream && stream.startsWith(AirbyteRawStreamPrefix);
+  }
+
+  unpackRaw(): AirbyteRecord {
+    if (this.isRaw()) {
+      return new AirbyteRecord({
+        stream: this.record.stream.slice(AirbyteRawStreamPrefix.length),
+        emitted_at: new Date(this.record.data[AirbyteRawEmittedAt]).getTime(),
+        data: JSON.parse(this.record.data[AirbyteRawData]),
+      });
     }
-    return new AirbyteRecord({
-      stream: stream.slice(AirbyteRawStreamPrefix.length),
-      emitted_at: new Date(this.record.data[AirbyteRawEmittedAt]).getTime(),
-      data: JSON.parse(this.record.data[AirbyteRawData]),
-    });
+    return this;
   }
 
   static make(

--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import {AirbyteLogger} from '../logger';
 import {AirbyteState} from '../protocol';
-import {PACKAGE_VERSION} from '../utils';
+import {PACKAGE_VERSION, redactConfig} from '../utils';
 import {AirbyteSource} from './source';
 
 export class AirbyteSourceRunner {
@@ -77,7 +77,8 @@ export class AirbyteSourceRunner {
         async (opts: {config: string; catalog: string; state?: string}) => {
           const config = require(path.resolve(opts.config));
           const catalog = require(path.resolve(opts.catalog));
-          this.logger.info('config: ' + JSON.stringify(config));
+          const spec = await this.source.spec();
+          this.logger.info('config: ' + redactConfig(config, spec));
           this.logger.info('catalog: ' + JSON.stringify(catalog));
 
           let state: AirbyteState | undefined = undefined;

--- a/faros-airbyte-cdk/src/utils.ts
+++ b/faros-airbyte-cdk/src/utils.ts
@@ -1,10 +1,26 @@
+import fastRedact from 'fast-redact';
 import fs from 'fs';
 import path from 'path';
+
+import {AirbyteConfig, AirbyteSpec} from './protocol';
 
 export const PACKAGE_ROOT = path.join(__dirname, '..');
 
 const packageInfo = JSON.parse(
   fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8')
 );
+
+/** Redact config of all secret values based on the provided specification */
+export function redactConfig(config: AirbyteConfig, spec: AirbyteSpec): string {
+  const props = spec.spec.connectionSpecification?.properties ?? {};
+  const paths = [];
+  for (const prop of Object.keys(props)) {
+    if (props[prop]?.airbyte_secret === true) {
+      paths.push(prop);
+    }
+  }
+  const redact = fastRedact({paths, censor: 'REDACTED'});
+  return `${redact(config)}`;
+}
 
 export const PACKAGE_VERSION = packageInfo.version;

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.4",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 				"axios": "^0.21.1",
 				"commander": "^8.0.0",
 				"faros-feeds-sdk": "^0.8.28",
+				"fast-redact": "^3.0.2",
 				"jsonata": "^1.8.4",
 				"lodash": "^4.17.21",
 				"pino": "^6.13.0",
@@ -16,6 +17,7 @@
 			},
 			"devDependencies": {
 				"@types/eslint": "^7.2.13",
+				"@types/fast-redact": "^3.0.1",
 				"@types/jest": "^26.0.23",
 				"@types/lodash": "^4.14.168",
 				"@types/node": "^14.14.31",
@@ -3615,6 +3617,12 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
+		"node_modules/@types/fast-redact": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-c00XG5vDAsAb7+BlT/1yd5AUAAg787E9HEKJ9w6fpbdoG4VSeQke0c78rEYK18rOJhAef73N8TIxvNUC4fxDGw==",
+			"dev": true
+		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -7188,9 +7196,9 @@
 			"dev": true
 		},
 		"node_modules/fast-redact": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
-			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
+			"integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -19567,6 +19575,12 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
+		"@types/fast-redact": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-c00XG5vDAsAb7+BlT/1yd5AUAAg787E9HEKJ9w6fpbdoG4VSeQke0c78rEYK18rOJhAef73N8TIxvNUC4fxDGw==",
+			"dev": true
+		},
 		"@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -22425,9 +22439,9 @@
 			"dev": true
 		},
 		"fast-redact": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
-			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw=="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
+			"integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg=="
 		},
 		"fast-safe-stringify": {
 			"version": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/eslint": "^7.2.13",
+    "@types/fast-redact": "^3.0.1",
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.168",
     "@types/node": "^14.14.31",

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Example Airbyte source",
   "keywords": [
     "faros"
@@ -29,7 +29,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "commander": "^8.0.0",
-    "faros-airbyte-cdk": "^0.1.3",
+    "faros-airbyte-cdk": "^0.1.4",
     "verror": "^1.10.0"
   },
   "jest": {


### PR DESCRIPTION
## Description

Remove node user + Faros destination fixes
1. Remove `USER node` to avoid permission denied errors on EKS
```
❯ kubectl logs pods/destination-worker-.... main                       
sh: can't create /pipes/stderr: Permission denied
Using existing AIRBYTE_ENTRYPOINT: /home/node/airbyte/main
```
2. Avoid logging secrets when running source & destinations
3. Fix stream lookup for raw inputs

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
