### PR TITLE
Switch logging to info in Faros destination

### DIFF
--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "description": "Faros Destination for Airbyte",
   "keywords": [
@@ -30,7 +30,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "faros-airbyte-cdk": "^0.1.15",
+    "faros-airbyte-cdk": "^0.1.16",
     "faros-feeds-sdk": "^0.8.28",
     "jsonata": "^1.8.4",
     "object-sizeof": "^1.6.1",

--- a/destinations/faros-destination/src/index.ts
+++ b/destinations/faros-destination/src/index.ts
@@ -337,7 +337,7 @@ class FarosDestination extends AirbyteDestination {
               ctx.set(streamName, String(recordId), unpacked);
               // Print stream context stats every so often
               if (stats.recordsProcessed % 1000 == 0) {
-                this.logger.debug(`Stream context stats: ${ctx.stats(false)}`);
+                this.logger.info(`Stream context stats: ${ctx.stats(false)}`);
               }
             }
             // Process the record immidiately if converter has no dependencies,
@@ -352,10 +352,10 @@ class FarosDestination extends AirbyteDestination {
       }
       // Process all the remaining records
       if (recordsToBeProcessedLast.length > 0) {
-        this.logger.debug(
+        this.logger.info(
           `Stdin processing completed, but still have ${recordsToBeProcessedLast.length} records to process`
         );
-        this.logger.debug(`Stream context stats: ${ctx.stats(true)}`);
+        this.logger.info(`Stream context stats: ${ctx.stats(true)}`);
         recordsToBeProcessedLast.forEach((process) => {
           this.handleRecordProcessingError(stats, () => process(ctx));
         });
@@ -427,7 +427,7 @@ class FarosDestination extends AirbyteDestination {
       const converter = this.getConverter(stream, (err: Error) =>
         this.logger.error(err.message)
       );
-      this.logger.debug(
+      this.logger.info(
         `Using ${converter.constructor.name} converter to convert ${stream} stream records`
       );
 
@@ -450,7 +450,7 @@ class FarosDestination extends AirbyteDestination {
     const deps = Object.keys(dependenciesByStream);
     for (const d of deps) {
       const dd = [...dependenciesByStream[d].values()];
-      this.logger.debug(
+      this.logger.info(
         `Records of stream ${d} will be accumulated and processed last, ` +
           `since their converter has dependencies on streams: ${dd.join(',')}`
       );

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Example Airbyte source",
   "keywords": [
     "faros"
@@ -29,7 +29,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "commander": "^8.0.0",
-    "faros-airbyte-cdk": "^0.1.15",
+    "faros-airbyte-cdk": "^0.1.16",
     "verror": "^1.10.0"
   },
   "jest": {


### PR DESCRIPTION
## Description

Since Airbyte does not propagate `LOG_LEVEL` to the connector containers yet, we have to work with info level for now.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
