### PR TITLE
FAI-383 - Use user login instead of id in Github converters

### DIFF
--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "description": "Faros Destination for Airbyte",
   "keywords": [
@@ -30,7 +30,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "faros-airbyte-cdk": "^0.1.16",
+    "faros-airbyte-cdk": "^0.1.17",
     "faros-feeds-sdk": "^0.8.28",
     "jsonata": "^1.8.4",
     "object-sizeof": "^1.6.1",

--- a/destinations/faros-destination/src/converters/github/commits.ts
+++ b/destinations/faros-destination/src/converters/github/commits.ts
@@ -25,10 +25,7 @@ export class GithubCommits extends GithubConverter {
 
     if (!repository) return res;
 
-    // TODO: change user uid to login once it's available
-    const author = commit.author_id
-      ? {uid: `${commit.author_id}`, source}
-      : null;
+    const author = commit.author ? {uid: commit.author.login, source} : null;
 
     res.push({
       model: 'vcs_Commit',

--- a/destinations/faros-destination/src/converters/github/common.ts
+++ b/destinations/faros-destination/src/converters/github/common.ts
@@ -55,8 +55,8 @@ export class GithubCommon {
     return {
       model: 'vcs_User',
       record: {
-        uid: `${user.id}`, // TODO: change user uid to login once it's available
-        name: user.login ?? user.name ?? null,
+        uid: user.login,
+        name: user.name ?? user.login ?? null,
         htmlUrl: user.html_url ?? null,
         type,
         source,
@@ -82,8 +82,8 @@ export class GithubCommon {
     return {
       model: 'tms_User',
       record: {
-        uid: `${user.id}`, // TODO: change user uid to login once it's available
-        name: user.login ?? user.name ?? null,
+        uid: user.login,
+        name: user.name ?? user.login ?? null,
         source,
       },
     };

--- a/destinations/faros-destination/src/converters/github/pull_requests.ts
+++ b/destinations/faros-destination/src/converters/github/pull_requests.ts
@@ -33,8 +33,8 @@ export class GithubPullRequests extends GithubConverter {
       : null;
 
     let author: DestinationRecord | undefined = undefined;
-    if (pr.author ?? pr.user) {
-      author = GithubCommon.vcs_User(pr.author ?? pr.user, source);
+    if (pr.user) {
+      author = GithubCommon.vcs_User(pr.user, source);
       res.push(author);
     }
 

--- a/destinations/faros-destination/src/converters/github/releases.ts
+++ b/destinations/faros-destination/src/converters/github/releases.ts
@@ -25,10 +25,7 @@ export class GithubReleases extends GithubConverter {
 
     if (!repository) return res;
 
-    // TODO: change user uid to login once it's available
-    const author = release.author_id
-      ? {uid: `${release.author_id}`, source}
-      : null;
+    const author = release.author ? {uid: release.author.login, source} : null;
 
     res.push({
       model: 'cicd_Release',

--- a/destinations/faros-destination/src/converters/github/review_comments.ts
+++ b/destinations/faros-destination/src/converters/github/review_comments.ts
@@ -27,8 +27,7 @@ export class GithubReviewComments extends GithubConverter {
     const prNum = GithubCommon.parsePRnumber(comment.pull_request_url);
     const pullRequest = {repository, number: prNum};
 
-    // TODO: change user uid to login once it's available
-    const author = comment.user ? {uid: `${comment.user.id}`, source} : null;
+    const author = comment.user ? {uid: comment.user.login, source} : null;
 
     return [
       {

--- a/destinations/faros-destination/src/converters/github/reviews.ts
+++ b/destinations/faros-destination/src/converters/github/reviews.ts
@@ -34,8 +34,8 @@ export class GithubReviews extends GithubConverter {
     if (!repository) return [];
 
     let author: DestinationRecord | undefined = undefined;
-    if (review.author ?? review.user) {
-      author = GithubCommon.vcs_User(review.author ?? review.user, source);
+    if (review.user) {
+      author = GithubCommon.vcs_User(review.user, source);
       res.push(author);
     }
 

--- a/destinations/faros-destination/test/converters/github.test.ts
+++ b/destinations/faros-destination/test/converters/github.test.ts
@@ -251,7 +251,7 @@ describe('github', () => {
       tms_TaskBoardProjectRelationship: 50,
       tms_TaskBoardRelationship: 1,
       tms_TaskTag: 2,
-      tms_User: 13,
+      tms_User: 14,
       vcs_Branch: 4,
       vcs_Commit: 77,
       vcs_Membership: 12,

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Example Airbyte source",
   "keywords": [
     "faros"
@@ -29,7 +29,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "commander": "^8.0.0",
-    "faros-airbyte-cdk": "^0.1.16",
+    "faros-airbyte-cdk": "^0.1.17",
     "verror": "^1.10.0"
   },
   "jest": {


### PR DESCRIPTION
## Description

Use user login instead of id in Github converters. Thanks @cjwooo for adding support for it in Airbyte sources!

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

Requires Airbyte Github source >= 0.2.x