### PR TITLE
Skip failing on undefined converter + add skipped records counter in Faros Destination

### DIFF
--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Faros Destination for Airbyte",
   "keywords": [
     "airbyte",

--- a/destinations/faros-destination/src/common/write-stats.ts
+++ b/destinations/faros-destination/src/common/write-stats.ts
@@ -34,18 +34,17 @@ export class WriteStats {
       .orderBy(0, 'asc')
       .fromPairs()
       .value();
-
     logger.info(`Processed records by stream: ${JSON.stringify(processed)}`);
-    logger.info(`${writeMsg} ${this.recordsWritten} records`);
 
+    logger.info(`${writeMsg} ${this.recordsWritten} records`);
     const written = _(this.writtenByModel)
       .toPairs()
       .orderBy(0, 'asc')
       .fromPairs()
       .value();
-
     logger.info(`${writeMsg} records by model: ${JSON.stringify(written)}`);
-    logger.info(`Errored ${this.recordsErrored} records`);
+
     logger.info(`Skipped ${this.recordsSkipped} records`);
+    logger.info(`Errored ${this.recordsErrored} records`);
   }
 }

--- a/destinations/faros-destination/src/common/write-stats.ts
+++ b/destinations/faros-destination/src/common/write-stats.ts
@@ -9,6 +9,7 @@ export class WriteStats {
     public recordsProcessed: number = 0,
     public recordsWritten: number = 0,
     public recordsErrored: number = 0,
+    public recordsSkipped: number = 0,
     public processedByStream: Dictionary<number> = {},
     public writtenByModel: Dictionary<number> = {}
   ) {}
@@ -45,5 +46,6 @@ export class WriteStats {
 
     logger.info(`${writeMsg} records by model: ${JSON.stringify(written)}`);
     logger.info(`Errored ${this.recordsErrored} records`);
+    logger.info(`Skipped ${this.recordsSkipped} records`);
   }
 }

--- a/destinations/faros-destination/test/converters/agileaccelerator.test.ts
+++ b/destinations/faros-destination/test/converters/agileaccelerator.test.ts
@@ -66,6 +66,7 @@ describe('agileaccelerator', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/asana.test.ts
+++ b/destinations/faros-destination/test/converters/asana.test.ts
@@ -88,6 +88,7 @@ describe('asana', () => {
     expect(stdout).toMatch('Processed 11 records');
     expect(stdout).toMatch('Wrote 14 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
     expect(entriesSize).toBeGreaterThan(0);
@@ -111,6 +112,7 @@ describe('asana', () => {
     expect(stdout).toMatch('Processed 11 records');
     expect(stdout).toMatch('Would write 14 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
@@ -131,11 +133,12 @@ describe('asana', () => {
     expect(stdout).toMatch('Processed 11 records');
     expect(stdout).toMatch('Would write 14 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('skip to process bad records when strategy is skip', async () => {
+  test('skip to process bad records when strategy is SKIP', async () => {
     const cli = await CLI.runWith([
       'write',
       '--config',
@@ -162,11 +165,12 @@ describe('asana', () => {
     expect(stdout).toMatch('Processed 1 records');
     expect(stdout).toMatch('Would write 1 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 1 records');
     expect(await read(cli.stderr)).toMatch('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('fail to process bad records when strategy is fail', async () => {
+  test('fail to process bad records when strategy is FAIL', async () => {
     fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
@@ -188,6 +192,7 @@ describe('asana', () => {
     expect(stdout).toMatch('Processed 0 records');
     expect(stdout).toMatch('Would write 0 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 0 records');
     const stderr = await read(cli.stderr);
     expect(stderr).toMatch('Undefined stream mytestsource__asana__bad');
     expect(await cli.wait()).toBeGreaterThan(0);
@@ -234,6 +239,7 @@ describe('asana', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/bitbucket.test.ts
+++ b/destinations/faros-destination/test/converters/bitbucket.test.ts
@@ -84,6 +84,7 @@ describe('bitbucket', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/github.test.ts
+++ b/destinations/faros-destination/test/converters/github.test.ts
@@ -88,6 +88,7 @@ describe('github', () => {
     expect(stdout).toMatch('Processed 96 records');
     expect(stdout).toMatch('Wrote 58 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
     expect(entriesSize).toBeGreaterThan(0);
@@ -111,6 +112,7 @@ describe('github', () => {
     expect(stdout).toMatch('Processed 96 records');
     expect(stdout).toMatch('Would write 58 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
@@ -131,11 +133,12 @@ describe('github', () => {
     expect(stdout).toMatch('Processed 111 records');
     expect(stdout).toMatch('Would write 146 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('skip to process bad records when strategy is skip', async () => {
+  test('skip to process bad records when strategy is SKIP', async () => {
     const cli = await CLI.runWith([
       'write',
       '--config',
@@ -162,11 +165,12 @@ describe('github', () => {
     expect(stdout).toMatch('Processed 1 records');
     expect(stdout).toMatch('Would write 1 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 1 records');
     expect(await read(cli.stderr)).toMatch('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('fail to process bad records when strategy is fail', async () => {
+  test('fail to process bad records when strategy is FAIL', async () => {
     fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
@@ -188,6 +192,7 @@ describe('github', () => {
     expect(stdout).toMatch('Processed 0 records');
     expect(stdout).toMatch('Would write 0 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 0 records');
     const stderr = await read(cli.stderr);
     expect(stderr).toMatch('Undefined stream mytestsource__github__bad');
     expect(await cli.wait()).toBeGreaterThan(0);
@@ -272,6 +277,7 @@ describe('github', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/gitlab.test.ts
+++ b/destinations/faros-destination/test/converters/gitlab.test.ts
@@ -88,6 +88,7 @@ describe('gitlab', () => {
     expect(stdout).toMatch('Processed 55 records');
     expect(stdout).toMatch('Wrote 68 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
     expect(entriesSize).toBeGreaterThan(0);
@@ -111,6 +112,7 @@ describe('gitlab', () => {
     expect(stdout).toMatch('Processed 55 records');
     expect(stdout).toMatch('Would write 68 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
@@ -131,11 +133,12 @@ describe('gitlab', () => {
     expect(stdout).toMatch('Processed 55 records');
     expect(stdout).toMatch('Would write 68 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('skip to process bad records when strategy is skip', async () => {
+  test('skip to process bad records when strategy is SKIP', async () => {
     const cli = await CLI.runWith([
       'write',
       '--config',
@@ -162,11 +165,12 @@ describe('gitlab', () => {
     expect(stdout).toMatch('Processed 1 records');
     expect(stdout).toMatch('Would write 1 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 1 records');
     expect(await read(cli.stderr)).toMatch('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('fail to process bad records when strategy is fail', async () => {
+  test('fail to process bad records when strategy is FAIL', async () => {
     fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
@@ -188,6 +192,7 @@ describe('gitlab', () => {
     expect(stdout).toMatch('Processed 0 records');
     expect(stdout).toMatch('Would write 0 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 0 records');
     const stderr = await read(cli.stderr);
     expect(stderr).toMatch('Undefined stream mytestsource__gitlab__bad');
     expect(await cli.wait()).toBeGreaterThan(0);
@@ -259,6 +264,7 @@ describe('gitlab', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/googlecalendar.test.ts
+++ b/destinations/faros-destination/test/converters/googlecalendar.test.ts
@@ -91,6 +91,7 @@ describe('googlecalendar', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/harness.test.ts
+++ b/destinations/faros-destination/test/converters/harness.test.ts
@@ -31,7 +31,7 @@ describe('harness', () => {
     fs.unlinkSync(configPath);
   });
 
-  test('skip to process bad records when strategy is skip', async () => {
+  test('skip to process bad records when strategy is SKIP', async () => {
     const cli = await CLI.runWith([
       'write',
       '--config',
@@ -58,11 +58,12 @@ describe('harness', () => {
     expect(stdout).toMatch('Processed 1 records');
     expect(stdout).toMatch('Would write 1 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 1 records');
     expect(await read(cli.stderr)).toMatch('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('fail to process bad records when strategy is fail', async () => {
+  test('fail to process bad records when strategy is FAIL', async () => {
     fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
@@ -84,6 +85,7 @@ describe('harness', () => {
     expect(stdout).toMatch('Processed 0 records');
     expect(stdout).toMatch('Would write 0 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 0 records');
     const stderr = await read(cli.stderr);
     expect(stderr).toMatch('Undefined stream mytestsource__harness__bad');
     expect(await cli.wait()).toBeGreaterThan(0);
@@ -124,6 +126,7 @@ describe('harness', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/jenkins.test.ts
+++ b/destinations/faros-destination/test/converters/jenkins.test.ts
@@ -82,6 +82,7 @@ describe('jenkins', () => {
     expect(stdout).toMatch('Processed 4 records');
     expect(stdout).toMatch('Wrote 11 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
     expect(entriesSize).toBeGreaterThan(0);
@@ -105,11 +106,12 @@ describe('jenkins', () => {
     expect(stdout).toMatch('Processed 4 records');
     expect(stdout).toMatch('Would write 11 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('skip to process bad records when strategy is skip', async () => {
+  test('skip to process bad records when strategy is SKIP', async () => {
     const cli = await CLI.runWith([
       'write',
       '--config',
@@ -137,11 +139,12 @@ describe('jenkins', () => {
     expect(stdout).toMatch('Processed 1 records');
     expect(stdout).toMatch('Would write 1 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 1 records');
     expect(await read(cli.stderr)).toMatch('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('fail to process bad records when strategy is fail', async () => {
+  test('fail to process bad records when strategy is FAIL', async () => {
     fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
@@ -163,6 +166,7 @@ describe('jenkins', () => {
     expect(stdout).toMatch('Processed 0 records');
     expect(stdout).toMatch('Would write 0 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 0 records');
     const stderr = await read(cli.stderr);
     expect(stderr).toMatch('Undefined stream mytestsource__jenkins__bad');
     expect(await cli.wait()).toBeGreaterThan(0);
@@ -204,6 +208,7 @@ describe('jenkins', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/jira.test.ts
+++ b/destinations/faros-destination/test/converters/jira.test.ts
@@ -149,6 +149,7 @@ describe('jira', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/okta.test.ts
+++ b/destinations/faros-destination/test/converters/okta.test.ts
@@ -66,6 +66,7 @@ describe('okta', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/pagerduty.test.ts
+++ b/destinations/faros-destination/test/converters/pagerduty.test.ts
@@ -82,6 +82,7 @@ describe('pagerduty', () => {
     expect(stdout).toMatch('Processed 7 records');
     expect(stdout).toMatch('Wrote 16 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
     expect(entriesSize).toBeGreaterThan(0);
@@ -105,11 +106,12 @@ describe('pagerduty', () => {
     expect(stdout).toMatch('Processed 7 records');
     expect(stdout).toMatch('Would write 16 records');
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(await read(cli.stderr)).toBe('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('skip to process bad records when strategy is skip', async () => {
+  test('skip to process bad records when strategy is SKIP', async () => {
     const cli = await CLI.runWith([
       'write',
       '--config',
@@ -136,11 +138,12 @@ describe('pagerduty', () => {
     expect(stdout).toMatch('Processed 1 records');
     expect(stdout).toMatch('Would write 1 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 1 records');
     expect(await read(cli.stderr)).toMatch('');
     expect(await cli.wait()).toBe(0);
   });
 
-  test('fail to process bad records when strategy is fail', async () => {
+  test('fail to process bad records when strategy is FAIL', async () => {
     fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
@@ -162,6 +165,7 @@ describe('pagerduty', () => {
     expect(stdout).toMatch('Processed 0 records');
     expect(stdout).toMatch('Would write 0 records');
     expect(stdout).toMatch('Errored 1 records');
+    expect(stdout).toMatch('Skipped 0 records');
     const stderr = await read(cli.stderr);
     expect(stderr).toMatch('Undefined stream mytestsource__pagerduty__bad');
     expect(await cli.wait()).toBeGreaterThan(0);
@@ -207,6 +211,7 @@ describe('pagerduty', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/phabricator.test.ts
+++ b/destinations/faros-destination/test/converters/phabricator.test.ts
@@ -75,6 +75,7 @@ describe('phabricator', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/squadcast.test.ts
+++ b/destinations/faros-destination/test/converters/squadcast.test.ts
@@ -71,6 +71,7 @@ describe('squadcast', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/statuspage.test.ts
+++ b/destinations/faros-destination/test/converters/statuspage.test.ts
@@ -68,6 +68,7 @@ describe('statuspage', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/converters/victorops.test.ts
+++ b/destinations/faros-destination/test/converters/victorops.test.ts
@@ -69,6 +69,7 @@ describe('victorops', () => {
     expect(stdout).toMatch(`Processed ${processedTotal} records`);
     expect(stdout).toMatch(`Would write ${writtenTotal} records`);
     expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
     expect(stdout).toMatch(
       JSON.stringify(
         AirbyteLog.make(

--- a/destinations/faros-destination/test/index.test.ts
+++ b/destinations/faros-destination/test/index.test.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import {getLocal} from 'mockttp';
 import os from 'os';
 
-import {Edition, InvalidRecordStrategy} from '../src';
+import {Edition} from '../src';
 import {CLI, read} from './cli';
 import {initMockttp, tempConfig, tempCustomConfig} from './testing-tools';
 


### PR DESCRIPTION
## Description

Skip failing on undefined converter + add skipped records counter in Faros Destination. This change should make Faros Destination more robust when processing records from a stream with an undefined converter, by simply skipping the records.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
