### PR TITLE
DataDog source fix

### DIFF
--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Faros Destination for Airbyte",
   "keywords": [
     "airbyte",

--- a/destinations/faros-destination/src/converters/datadog/incidents.ts
+++ b/destinations/faros-destination/src/converters/datadog/incidents.ts
@@ -46,7 +46,8 @@ export class DatadogIncidents extends DatadogConverter {
         description: incident.attributes?.fields?.summary?.value,
         url: null,
         severity:
-          this.getSeverity(incident.attributes?.severity) ?? defaultSeverity,
+          this.getSeverity(incident.attributes?.fields?.severity?.value) ??
+          defaultSeverity,
         priority: null,
         status: this.getStatus(incident.attributes?.state) ?? null,
         createdAt: Utils.toDate(incident.attributes?.created) ?? null,

--- a/destinations/faros-destination/src/converters/datadog/incidents.ts
+++ b/destinations/faros-destination/src/converters/datadog/incidents.ts
@@ -49,7 +49,8 @@ export class DatadogIncidents extends DatadogConverter {
           this.getSeverity(incident.attributes?.fields?.severity?.value) ??
           defaultSeverity,
         priority: null,
-        status: this.getStatus(incident.attributes?.state) ?? null,
+        status:
+          this.getStatus(incident.attributes?.fields?.state?.value) ?? null,
         createdAt: Utils.toDate(incident.attributes?.created) ?? null,
         updatedAt: Utils.toDate(incident.attributes?.modified) ?? null,
         acknowledgedAt: Utils.toDate(incident.attributes?.detected) ?? null,


### PR DESCRIPTION
## Description

The API that I was testing against did return the `status` and `state` in the previous locations, but I suspect that the DataDog v2 api client does not expose them there. I tested and they are exposed here.

```json
{
    "record": {
        "stream": "incidents",
        "emitted_at": 1646193807077,
        "data": {
            "attributes": {
                ...
                "fields": {
                    "severity": {
                        "type": "dropdown",
                        "value": "SEV-5"
                    },
                    ...
                    "state": {
                        "type": "dropdown",
                        "value": "resolved"
                    }
                    ...
                }
                ...
            },
            ...
        }
    },
    "type": "RECORD"
}
```

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
