### PR TITLE
Fix use of memoize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -198,11 +198,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/abort-controller": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
-			"integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.54.0.tgz",
+			"integrity": "sha512-6N7numECrGwal2NEbJwYXOGjwWsFafz8VuUvCBK5G9SgSL5XAbq1S3lL/4gbme5jhgh9CWh7s+bAY7EpOEH2Xg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -215,40 +215,40 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/client-kms": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.53.0.tgz",
-			"integrity": "sha512-ttYpPrZDsOnBCoj6ODKL48psMdeHlaeEhuWohzWVmljCtedQcXe0VLF+BWsRwkNZ06UDawCS/c5AJ7XefwryUA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.54.0.tgz",
+			"integrity": "sha512-xcq1lQpMmtirCAnyEeKYU+kjT9Rad60ETYGK6a/6uQuvCdwmMEBSw3MSk4Z59iP/uW+bimq/GQPks0r8WFDxyA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.53.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-node": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/client-sts": "3.54.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-node": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"tslib": "^2.3.0"
@@ -263,42 +263,42 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/client-sqs": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.53.0.tgz",
-			"integrity": "sha512-8vUCq/96lmdTnH+MoL30iNgrvpMTj7lIuKBU1hF2Mc7OH4WJ0ijbKjtZt+b9HRTtwJn909jSxv9Nt18HmtEfrQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.54.0.tgz",
+			"integrity": "sha512-0YEaEmvUTgucVh5r+EEvr43g4EoinxhMIkNpMQ3yPHRmopT4Keo8XceAtVkm8VnCjfwyHFgYJeISqOFcQOEKug==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.53.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-node": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/md5-js": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-sdk-sqs": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/client-sts": "3.54.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-node": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/md5-js": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-sdk-sqs": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"entities": "2.2.0",
@@ -315,37 +315,37 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
-			"integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.54.0.tgz",
+			"integrity": "sha512-5ZYYhoMqeaYhOU4kOEM7daKb8D5QhJ+IpwhHHMPhoHqQEwbbhBTFDXRs3ObUP/QYdBUMWS71+pnDoUdyHqPQ0Q==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"tslib": "^2.3.0"
@@ -360,40 +360,40 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
-			"integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.54.0.tgz",
+			"integrity": "sha512-UY8fyi1zaWBJm+ZtDZRvSOv1rjHlvJjtJF3MfGQWDwUM10Amwzfh4Hc2JEzyeMJPkoSSvm6CVjSDyqXo8yLGZA==",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-node": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-sdk-sts": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-node": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-sdk-sts": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"entities": "2.2.0",
@@ -410,12 +410,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/config-resolver": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
-			"integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.54.0.tgz",
+			"integrity": "sha512-VaNuvJLMaz3znmBD9BNkoEqNUs5teILU66SnFqBwVqabmOVeOh7M6/f43CcDarkwGklzZB/bn/rx9NOWUtdunA==",
 			"dependencies": {
-				"@aws-sdk/signature-v4": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/signature-v4": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-config-provider": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -429,12 +429,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
-			"integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.54.0.tgz",
+			"integrity": "sha512-XWfzoUyFVsT4J7iTnXO38FKNdGFyE6ZNBtW9+Yx9EiiLtUlzH09PRv+54KIRQ4uqU+fEdtRh0gOdFajTrnRi3g==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -447,14 +447,14 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-imds": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
-			"integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.54.0.tgz",
+			"integrity": "sha512-Chygp8jswdjtCPmNxEMXigX4clgqh5GDaFGopR/gFaaG960hjF88Fx1/CPYD7exvM1FRO67nyfBOS0QKjSqTXg==",
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -467,17 +467,17 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
-			"integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.54.0.tgz",
+			"integrity": "sha512-EobK9bJwsUdMKx7vB+tL5eaNaj/NoOPaFJlv0JRL3+5px7d2vF0i9yklj4uT7F3vDlOup6R3b1Gg9GtqxfYt9w==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.53.0",
-				"@aws-sdk/credential-provider-imds": "3.53.0",
-				"@aws-sdk/credential-provider-sso": "3.53.0",
-				"@aws-sdk/credential-provider-web-identity": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/credential-provider-env": "3.54.0",
+				"@aws-sdk/credential-provider-imds": "3.54.0",
+				"@aws-sdk/credential-provider-sso": "3.54.0",
+				"@aws-sdk/credential-provider-web-identity": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -491,19 +491,19 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
-			"integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.54.0.tgz",
+			"integrity": "sha512-KsXJG0K7yJg2MCzNW52fSDbCIR5mRobbNnXTMpDRkghlQyHP1gdHsyRedVciMkJhdDILop2lScLw70iQBayP/Q==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.53.0",
-				"@aws-sdk/credential-provider-imds": "3.53.0",
-				"@aws-sdk/credential-provider-ini": "3.53.0",
-				"@aws-sdk/credential-provider-process": "3.53.0",
-				"@aws-sdk/credential-provider-sso": "3.53.0",
-				"@aws-sdk/credential-provider-web-identity": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/credential-provider-env": "3.54.0",
+				"@aws-sdk/credential-provider-imds": "3.54.0",
+				"@aws-sdk/credential-provider-ini": "3.54.0",
+				"@aws-sdk/credential-provider-process": "3.54.0",
+				"@aws-sdk/credential-provider-sso": "3.54.0",
+				"@aws-sdk/credential-provider-web-identity": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -517,13 +517,13 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
-			"integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.54.0.tgz",
+			"integrity": "sha512-hjUQ6FRG3Ihsm77Rgrf1dSfRUVZAFEyAHCuwURePXpYjzMpFYjl12wL6Pwa7MLCqVMyLKQ8HYamznkgBlLQqxw==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -537,14 +537,14 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
-			"integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.54.0.tgz",
+			"integrity": "sha512-8HfBTdOw+9gbWsXRTr5y+QYq8gK+YYDx7tKbNv7ZWjMfw49SDef0j0W4ZBZH+FYEPepOEAKjBgtjvlUeFxrOaA==",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/client-sso": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -558,12 +558,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
-			"integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.54.0.tgz",
+			"integrity": "sha512-Mi87IzpgIi6P3WntumgMJ6rNY8Ay/HtsLFYm4bZ1ZGJH/3QVT4YLm1n8A4xoC+ouhL0i24jmN3X1aNu6amBfEg==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -576,13 +576,13 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
-			"integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.54.0.tgz",
+			"integrity": "sha512-TIn2ocem/gpMQ12KoiOu3uTHO86OOrmFITulV9D8xTzvFqHe34JKjHQPqII6lDbTCnU9N5CMv3N1CXxolIhiOQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/querystring-builder": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/querystring-builder": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"tslib": "^2.3.0"
 			}
@@ -593,11 +593,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/hash-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
-			"integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.54.0.tgz",
+			"integrity": "sha512-o2XRftfj3Tj2jsZsdvnEY4OtmkT/9OADCWkINQCTcfy+nMuvs1IAS/qruunfaMJ58GntOoI4CVIbRa2lhhJr5w==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-buffer-from": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -611,11 +611,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/invalid-dependency": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
-			"integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.54.0.tgz",
+			"integrity": "sha512-eeefTPtkb0FQFMBKmwhvmdPqCgGvTcWEiNH8pznAH0hqxLvOLNdNRoKnX5a1WlYoq3eTm0YN9Zh+N1Sj4mbkcg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			}
 		},
@@ -641,11 +641,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/md5-js": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
-			"integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.54.0.tgz",
+			"integrity": "sha512-pMprZD8JBw9WU4Risfd0Clm9SrUpsUS3QriSDeuFnGfRcKHkpw1sDj6HsNsIQ1OCeWuhYqW55Wtzc0pH8U80Mg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"tslib": "^2.3.0"
@@ -657,12 +657,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-content-length": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
-			"integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.54.0.tgz",
+			"integrity": "sha512-DTlZo00stFwFHyR+GTXxhYePzNbXm+aX5yYQUsrsY2J2HuSbADVgDDekJXbtOH36QBa0OJf7JKbWP8PZDxk1zg==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -675,12 +675,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
-			"integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.54.0.tgz",
+			"integrity": "sha512-X+lvYc2ij1+9tfpvdGGb+/APvH7g/M9RYzIEkI/LvNjVCOA3f3rgzFftZZhD/zccRtrygsvXfeZhoDrHxFKl9g==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -693,11 +693,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
-			"integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.54.0.tgz",
+			"integrity": "sha512-bDCQj8IBq1vrXRRrpqD+suJ8hKc4oxUXpRkWdsAD+HnWWRqHjsy0hdq5F8Rj1Abq7CsFtZ+rUXddl+KlmgZ3+A==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -710,13 +710,13 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-retry": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
-			"integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.54.0.tgz",
+			"integrity": "sha512-8kVzwxe0HQajeZWXzAp2XCkbiK8E8AZESfXvLyM34Xy2e8L8gdi1j90QLzpFk6WX6rz7hXBQG7utrCJkwXQxLA==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/service-error-classification": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/service-error-classification": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0",
 				"uuid": "^8.3.2"
 			},
@@ -730,11 +730,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sqs": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.53.0.tgz",
-			"integrity": "sha512-Bq0SfsrYd7amMFPDw9DSj0OoUXJcCgb9PjRM4XqLEk15vwHKwgV668nlNZUdt2kxe+wZ2SA39BGLvtYLeIaqKw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.54.0.tgz",
+			"integrity": "sha512-Q/l82uUecLa63SBhNa0YIdkXXbRonJePCDmfaHPpwbCEwMSUDFutSy/MtrMzsXVx3HYisSbwscrmm5hZkT1UPg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-hex-encoding": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -748,15 +748,15 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sts": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
-			"integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.54.0.tgz",
+			"integrity": "sha512-4vOlG96fKgqmLMsguoKFdBkk2Fq8JttpgPts9d5Ox73+yQsa0VKrpLiD5OUPqgjGZcX2bilMKCAOBc2v3ESAHw==",
 			"dependencies": {
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/signature-v4": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/signature-v4": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -769,11 +769,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-serde": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
-			"integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.54.0.tgz",
+			"integrity": "sha512-O89/5aOiNegBP6Mv+gPr22Zawz2zF2v1o8kwFv2s4PWDzpmvrdF2by6e2Uh9sKzfpcwEW7Wr8kDTwajampVjgA==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -786,14 +786,14 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-signing": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
-			"integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.54.0.tgz",
+			"integrity": "sha512-KYxmRDh7D6ysAezlsDf3cN2h6OjH66x3NUdgUmW+78nkN9tRvvJEjhmu6IOkPd4E1V9P3JOLbq6zVjDVU12WDQ==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/signature-v4": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/signature-v4": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -806,9 +806,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-stack": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
-			"integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.54.0.tgz",
+			"integrity": "sha512-38iit8VJ7jhFlMdwdDESEJOwbi8wIjF7Q1FOFIoCvURLGkTDQdabGXKwcFVfRuceLO+LJxWP3l0z0c10uZa6gQ==",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -822,12 +822,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
-			"integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.54.0.tgz",
+			"integrity": "sha512-831GP5EBJdDxyq93dpgBZUwBWnZAID2aFvE/VN8c5X8U00ZT7GRt9cy5EL2b6AQN3Z4uWL1ZVDVkYmRAHs33Lg==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -840,13 +840,13 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/node-config-provider": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
-			"integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.54.0.tgz",
+			"integrity": "sha512-Q2a1vyoZa2UX/dItP3cqNdLUoTGdIY4hD5nA+mTg5mKlOWci35v8Rypr40tQz4ZwiDF6QQmK0tvD3bBUULm0wA==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -859,14 +859,14 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/node-http-handler": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
-			"integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.54.0.tgz",
+			"integrity": "sha512-g6+IXe4FCMrx4vrY73yvFNAUsBJ1vhjDshUCihBv5tEXsd45/MqmON/VWYoaQZts0m2wx2fKsdoDKSIZZY7AiQ==",
 			"dependencies": {
-				"@aws-sdk/abort-controller": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/querystring-builder": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/abort-controller": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/querystring-builder": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -879,11 +879,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/property-provider": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
-			"integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.0.tgz",
+			"integrity": "sha512-8e+KXskwOhXF0MIdIcZLFsOTfMVGp41Y6kywgewQaHkZoMzZ6euRziyWNgnshUE794tjxxol9resudSUehPjIw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -896,11 +896,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/protocol-http": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
-			"integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.54.0.tgz",
+			"integrity": "sha512-v4CgQ2mBzEwNubM1duWP3Unu98EPNF2BuKWe4wT1HNG2MTkODS56fsgVT6sGGXS9nB/reEzB+3bXO5FS8+3SUg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -913,11 +913,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
-			"integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.54.0.tgz",
+			"integrity": "sha512-7rs2gGPpiIHntbYGPFkxkXQkSK7uVBqlWRl0m6fNngUEz2n8jRxytB6LlALMHbXeXh28+zzq0VxbAwqAAUQ4oQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-uri-escape": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -931,11 +931,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/querystring-parser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
-			"integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.54.0.tgz",
+			"integrity": "sha512-OZ4mRJ9rXgBskPBSoXBw8tV4kfNK0f/pP55qE1eZIcQ1z7EvVz4NjldgqMfscT20Cx5VzUbus3q9EPcV+HbR1w==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -948,9 +948,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/service-error-classification": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
-			"integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.54.0.tgz",
+			"integrity": "sha512-XWANvjJJZNqsYhGmccSSuhsvINIUX1KckfDmvYtUR6cKM6nM6QWOg/QJeTFageTEpruJ5TqzW9vY414bIE883w==",
 			"engines": {
 				"node": ">= 12.0.0"
 			}
@@ -972,12 +972,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/signature-v4": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
-			"integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.54.0.tgz",
+			"integrity": "sha512-22Bf8uQ0Q/I7WpLFU88G7WVpRw6tWUX9Ggr0Z++81uZF5YCPbWDNtFDHitoERaRc/M4vUMxNuTsX/JWOR3fFPg==",
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-hex-encoding": "3.52.0",
 				"@aws-sdk/util-uri-escape": "3.52.0",
 				"tslib": "^2.3.0"
@@ -992,12 +992,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/smithy-client": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
-			"integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.54.0.tgz",
+			"integrity": "sha512-zdYN5pwhJU7x8qZKWTZPsFD5YQkDt6kyCNRsNjSWJ0ON4R3wUlFIwT3YzeQ5nMOTD86cVIm1n2RaSTYHwelFXg==",
 			"dependencies": {
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -1010,20 +1010,20 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
-			"integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.0.tgz",
+			"integrity": "sha512-Jp2MHXnrM0pk0RIoSl5AHFm7TBk+7b8HTIcQ2X/6kGwwwnWw9qlg9ZFziegJTNTLJ4iVgZjz/yMlEvgrp7z9CA==",
 			"engines": {
 				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/url-parser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
-			"integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.54.0.tgz",
+			"integrity": "sha512-DJWdlkXq3rsOydxwR9htPUW4QXhmo75Hybg96D3F2uPUvPCm8gJFngXp/9hW1OYcgfNu13HXqUy+t6V23cC7Iw==",
 			"dependencies": {
-				"@aws-sdk/querystring-parser": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/querystring-parser": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			}
 		},
@@ -1063,9 +1063,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/util-body-length-browser": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
-			"integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.54.0.tgz",
+			"integrity": "sha512-hnY9cXbKWJ2Fjb4bK35sFdD4vK+sFe59JtxxI336yYzANulc462LU/J1RgONXYBW60d9iwJ7U+S+9oTJrEH6WQ==",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			}
@@ -1076,9 +1076,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/util-body-length-node": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
-			"integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.54.0.tgz",
+			"integrity": "sha512-BBQB3kqHqHQp2GAINJGuse9JBM7hfU0tMp9rfw0nym4C/VRooiJVrIb28tKseLtd7nihXvsZXPvEc2jQBe1Thg==",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -1142,12 +1142,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
-			"integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.54.0.tgz",
+			"integrity": "sha512-9QnRbTsD2MuEr59vaPAbC95ba7druMFRSZjpwc3L7U9zpsJruNDaL5aAmV0gCAIPZg7eSaJmipyWr0AvwwgroQ==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.0"
 			},
@@ -1161,15 +1161,15 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/util-defaults-mode-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
-			"integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.54.0.tgz",
+			"integrity": "sha512-kHFgEyAWCaR5uSmRwyVbWQnjiNib3EJSAG9y7bwMIHSOK/6TVOXGlb1KIoO6ZtLE1FZFlS55FIRFeOPmIFFZbA==",
 			"dependencies": {
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-imds": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-imds": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -1230,11 +1230,11 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
-			"integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.54.0.tgz",
+			"integrity": "sha512-pU5KL1Nnlc1igeED2R44k9GEIxlLBhwmUGIw8/Emfm8xAlGOX4NsVSfHK9EpJQth0z5ZJ4Lni6S5+nW4V16yLw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.0"
 			}
@@ -1245,12 +1245,12 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
-			"integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.54.0.tgz",
+			"integrity": "sha512-euKoYk1TfyV9XlJyAlGWdYqhQ5B4COwBxsV9OpwiAINUFm91NSv6uavFC/ZZQBXRks6j9pHDAXeXu7bHVolvlA==",
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"engines": {
@@ -7448,9 +7448,9 @@
 			]
 		},
 		"node_modules/faros-feeds-sdk": {
-			"version": "0.9.10",
-			"resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.9.10.tgz",
-			"integrity": "sha512-r18JMqLehpsa2x3dWO4Op+O+34Z/gTxQr1Sgxvga0bC9vgQOPsHD6t/qACa7SyPqAlS2y7g9VgmbPxTA+TeeHg==",
+			"version": "0.9.11",
+			"resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.9.11.tgz",
+			"integrity": "sha512-6ZX2HIAn63gR8CmmeRqESuf14kv7v0wu8XJlC6faaY8vuUIgyNHU1F368JVwaqZFelFP557Gjqc0QN049OYx1Q==",
 			"dependencies": {
 				"@avro/common-types": "^0.2.0",
 				"@avro/streams": "^1.0.10",
@@ -15799,11 +15799,11 @@
 			}
 		},
 		"@aws-sdk/abort-controller": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
-			"integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.54.0.tgz",
+			"integrity": "sha512-6N7numECrGwal2NEbJwYXOGjwWsFafz8VuUvCBK5G9SgSL5XAbq1S3lL/4gbme5jhgh9CWh7s+bAY7EpOEH2Xg==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -15815,40 +15815,40 @@
 			}
 		},
 		"@aws-sdk/client-kms": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.53.0.tgz",
-			"integrity": "sha512-ttYpPrZDsOnBCoj6ODKL48psMdeHlaeEhuWohzWVmljCtedQcXe0VLF+BWsRwkNZ06UDawCS/c5AJ7XefwryUA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.54.0.tgz",
+			"integrity": "sha512-xcq1lQpMmtirCAnyEeKYU+kjT9Rad60ETYGK6a/6uQuvCdwmMEBSw3MSk4Z59iP/uW+bimq/GQPks0r8WFDxyA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.53.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-node": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/client-sts": "3.54.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-node": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"tslib": "^2.3.0"
@@ -15862,42 +15862,42 @@
 			}
 		},
 		"@aws-sdk/client-sqs": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.53.0.tgz",
-			"integrity": "sha512-8vUCq/96lmdTnH+MoL30iNgrvpMTj7lIuKBU1hF2Mc7OH4WJ0ijbKjtZt+b9HRTtwJn909jSxv9Nt18HmtEfrQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.54.0.tgz",
+			"integrity": "sha512-0YEaEmvUTgucVh5r+EEvr43g4EoinxhMIkNpMQ3yPHRmopT4Keo8XceAtVkm8VnCjfwyHFgYJeISqOFcQOEKug==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.53.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-node": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/md5-js": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-sdk-sqs": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/client-sts": "3.54.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-node": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/md5-js": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-sdk-sqs": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"entities": "2.2.0",
@@ -15913,37 +15913,37 @@
 			}
 		},
 		"@aws-sdk/client-sso": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
-			"integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.54.0.tgz",
+			"integrity": "sha512-5ZYYhoMqeaYhOU4kOEM7daKb8D5QhJ+IpwhHHMPhoHqQEwbbhBTFDXRs3ObUP/QYdBUMWS71+pnDoUdyHqPQ0Q==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"tslib": "^2.3.0"
@@ -15957,40 +15957,40 @@
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
-			"integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.54.0.tgz",
+			"integrity": "sha512-UY8fyi1zaWBJm+ZtDZRvSOv1rjHlvJjtJF3MfGQWDwUM10Amwzfh4Hc2JEzyeMJPkoSSvm6CVjSDyqXo8yLGZA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "2.0.0",
 				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-node": "3.53.0",
-				"@aws-sdk/fetch-http-handler": "3.53.0",
-				"@aws-sdk/hash-node": "3.53.0",
-				"@aws-sdk/invalid-dependency": "3.53.0",
-				"@aws-sdk/middleware-content-length": "3.53.0",
-				"@aws-sdk/middleware-host-header": "3.53.0",
-				"@aws-sdk/middleware-logger": "3.53.0",
-				"@aws-sdk/middleware-retry": "3.53.0",
-				"@aws-sdk/middleware-sdk-sts": "3.53.0",
-				"@aws-sdk/middleware-serde": "3.53.0",
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/middleware-user-agent": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/node-http-handler": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/smithy-client": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-node": "3.54.0",
+				"@aws-sdk/fetch-http-handler": "3.54.0",
+				"@aws-sdk/hash-node": "3.54.0",
+				"@aws-sdk/invalid-dependency": "3.54.0",
+				"@aws-sdk/middleware-content-length": "3.54.0",
+				"@aws-sdk/middleware-host-header": "3.54.0",
+				"@aws-sdk/middleware-logger": "3.54.0",
+				"@aws-sdk/middleware-retry": "3.54.0",
+				"@aws-sdk/middleware-sdk-sts": "3.54.0",
+				"@aws-sdk/middleware-serde": "3.54.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/middleware-user-agent": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/node-http-handler": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/smithy-client": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"@aws-sdk/util-base64-node": "3.52.0",
-				"@aws-sdk/util-body-length-browser": "3.52.0",
-				"@aws-sdk/util-body-length-node": "3.52.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.53.0",
-				"@aws-sdk/util-defaults-mode-node": "3.53.0",
-				"@aws-sdk/util-user-agent-browser": "3.53.0",
-				"@aws-sdk/util-user-agent-node": "3.53.0",
+				"@aws-sdk/util-body-length-browser": "3.54.0",
+				"@aws-sdk/util-body-length-node": "3.54.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.54.0",
+				"@aws-sdk/util-defaults-mode-node": "3.54.0",
+				"@aws-sdk/util-user-agent-browser": "3.54.0",
+				"@aws-sdk/util-user-agent-node": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"entities": "2.2.0",
@@ -16006,12 +16006,12 @@
 			}
 		},
 		"@aws-sdk/config-resolver": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
-			"integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.54.0.tgz",
+			"integrity": "sha512-VaNuvJLMaz3znmBD9BNkoEqNUs5teILU66SnFqBwVqabmOVeOh7M6/f43CcDarkwGklzZB/bn/rx9NOWUtdunA==",
 			"requires": {
-				"@aws-sdk/signature-v4": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/signature-v4": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-config-provider": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -16024,12 +16024,12 @@
 			}
 		},
 		"@aws-sdk/credential-provider-env": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
-			"integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.54.0.tgz",
+			"integrity": "sha512-XWfzoUyFVsT4J7iTnXO38FKNdGFyE6ZNBtW9+Yx9EiiLtUlzH09PRv+54KIRQ4uqU+fEdtRh0gOdFajTrnRi3g==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16041,14 +16041,14 @@
 			}
 		},
 		"@aws-sdk/credential-provider-imds": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
-			"integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.54.0.tgz",
+			"integrity": "sha512-Chygp8jswdjtCPmNxEMXigX4clgqh5GDaFGopR/gFaaG960hjF88Fx1/CPYD7exvM1FRO67nyfBOS0QKjSqTXg==",
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
-				"@aws-sdk/url-parser": "3.53.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
+				"@aws-sdk/url-parser": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16060,17 +16060,17 @@
 			}
 		},
 		"@aws-sdk/credential-provider-ini": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
-			"integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.54.0.tgz",
+			"integrity": "sha512-EobK9bJwsUdMKx7vB+tL5eaNaj/NoOPaFJlv0JRL3+5px7d2vF0i9yklj4uT7F3vDlOup6R3b1Gg9GtqxfYt9w==",
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.53.0",
-				"@aws-sdk/credential-provider-imds": "3.53.0",
-				"@aws-sdk/credential-provider-sso": "3.53.0",
-				"@aws-sdk/credential-provider-web-identity": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/credential-provider-env": "3.54.0",
+				"@aws-sdk/credential-provider-imds": "3.54.0",
+				"@aws-sdk/credential-provider-sso": "3.54.0",
+				"@aws-sdk/credential-provider-web-identity": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -16083,19 +16083,19 @@
 			}
 		},
 		"@aws-sdk/credential-provider-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
-			"integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.54.0.tgz",
+			"integrity": "sha512-KsXJG0K7yJg2MCzNW52fSDbCIR5mRobbNnXTMpDRkghlQyHP1gdHsyRedVciMkJhdDILop2lScLw70iQBayP/Q==",
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.53.0",
-				"@aws-sdk/credential-provider-imds": "3.53.0",
-				"@aws-sdk/credential-provider-ini": "3.53.0",
-				"@aws-sdk/credential-provider-process": "3.53.0",
-				"@aws-sdk/credential-provider-sso": "3.53.0",
-				"@aws-sdk/credential-provider-web-identity": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/credential-provider-env": "3.54.0",
+				"@aws-sdk/credential-provider-imds": "3.54.0",
+				"@aws-sdk/credential-provider-ini": "3.54.0",
+				"@aws-sdk/credential-provider-process": "3.54.0",
+				"@aws-sdk/credential-provider-sso": "3.54.0",
+				"@aws-sdk/credential-provider-web-identity": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -16108,13 +16108,13 @@
 			}
 		},
 		"@aws-sdk/credential-provider-process": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
-			"integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.54.0.tgz",
+			"integrity": "sha512-hjUQ6FRG3Ihsm77Rgrf1dSfRUVZAFEyAHCuwURePXpYjzMpFYjl12wL6Pwa7MLCqVMyLKQ8HYamznkgBlLQqxw==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -16127,14 +16127,14 @@
 			}
 		},
 		"@aws-sdk/credential-provider-sso": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
-			"integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.54.0.tgz",
+			"integrity": "sha512-8HfBTdOw+9gbWsXRTr5y+QYq8gK+YYDx7tKbNv7ZWjMfw49SDef0j0W4ZBZH+FYEPepOEAKjBgtjvlUeFxrOaA==",
 			"requires": {
-				"@aws-sdk/client-sso": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/client-sso": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-credentials": "3.53.0",
 				"tslib": "^2.3.0"
 			},
@@ -16147,12 +16147,12 @@
 			}
 		},
 		"@aws-sdk/credential-provider-web-identity": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
-			"integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.54.0.tgz",
+			"integrity": "sha512-Mi87IzpgIi6P3WntumgMJ6rNY8Ay/HtsLFYm4bZ1ZGJH/3QVT4YLm1n8A4xoC+ouhL0i24jmN3X1aNu6amBfEg==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16164,13 +16164,13 @@
 			}
 		},
 		"@aws-sdk/fetch-http-handler": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
-			"integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.54.0.tgz",
+			"integrity": "sha512-TIn2ocem/gpMQ12KoiOu3uTHO86OOrmFITulV9D8xTzvFqHe34JKjHQPqII6lDbTCnU9N5CMv3N1CXxolIhiOQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/querystring-builder": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/querystring-builder": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-base64-browser": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -16183,11 +16183,11 @@
 			}
 		},
 		"@aws-sdk/hash-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
-			"integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.54.0.tgz",
+			"integrity": "sha512-o2XRftfj3Tj2jsZsdvnEY4OtmkT/9OADCWkINQCTcfy+nMuvs1IAS/qruunfaMJ58GntOoI4CVIbRa2lhhJr5w==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-buffer-from": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -16200,11 +16200,11 @@
 			}
 		},
 		"@aws-sdk/invalid-dependency": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
-			"integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.54.0.tgz",
+			"integrity": "sha512-eeefTPtkb0FQFMBKmwhvmdPqCgGvTcWEiNH8pznAH0hqxLvOLNdNRoKnX5a1WlYoq3eTm0YN9Zh+N1Sj4mbkcg==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16231,11 +16231,11 @@
 			}
 		},
 		"@aws-sdk/md5-js": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
-			"integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.54.0.tgz",
+			"integrity": "sha512-pMprZD8JBw9WU4Risfd0Clm9SrUpsUS3QriSDeuFnGfRcKHkpw1sDj6HsNsIQ1OCeWuhYqW55Wtzc0pH8U80Mg==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-utf8-browser": "3.52.0",
 				"@aws-sdk/util-utf8-node": "3.52.0",
 				"tslib": "^2.3.0"
@@ -16249,12 +16249,12 @@
 			}
 		},
 		"@aws-sdk/middleware-content-length": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
-			"integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.54.0.tgz",
+			"integrity": "sha512-DTlZo00stFwFHyR+GTXxhYePzNbXm+aX5yYQUsrsY2J2HuSbADVgDDekJXbtOH36QBa0OJf7JKbWP8PZDxk1zg==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16266,12 +16266,12 @@
 			}
 		},
 		"@aws-sdk/middleware-host-header": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
-			"integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.54.0.tgz",
+			"integrity": "sha512-X+lvYc2ij1+9tfpvdGGb+/APvH7g/M9RYzIEkI/LvNjVCOA3f3rgzFftZZhD/zccRtrygsvXfeZhoDrHxFKl9g==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16283,11 +16283,11 @@
 			}
 		},
 		"@aws-sdk/middleware-logger": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
-			"integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.54.0.tgz",
+			"integrity": "sha512-bDCQj8IBq1vrXRRrpqD+suJ8hKc4oxUXpRkWdsAD+HnWWRqHjsy0hdq5F8Rj1Abq7CsFtZ+rUXddl+KlmgZ3+A==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16299,13 +16299,13 @@
 			}
 		},
 		"@aws-sdk/middleware-retry": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
-			"integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.54.0.tgz",
+			"integrity": "sha512-8kVzwxe0HQajeZWXzAp2XCkbiK8E8AZESfXvLyM34Xy2e8L8gdi1j90QLzpFk6WX6rz7hXBQG7utrCJkwXQxLA==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/service-error-classification": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/service-error-classification": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0",
 				"uuid": "^8.3.2"
 			},
@@ -16318,11 +16318,11 @@
 			}
 		},
 		"@aws-sdk/middleware-sdk-sqs": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.53.0.tgz",
-			"integrity": "sha512-Bq0SfsrYd7amMFPDw9DSj0OoUXJcCgb9PjRM4XqLEk15vwHKwgV668nlNZUdt2kxe+wZ2SA39BGLvtYLeIaqKw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.54.0.tgz",
+			"integrity": "sha512-Q/l82uUecLa63SBhNa0YIdkXXbRonJePCDmfaHPpwbCEwMSUDFutSy/MtrMzsXVx3HYisSbwscrmm5hZkT1UPg==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-hex-encoding": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -16335,15 +16335,15 @@
 			}
 		},
 		"@aws-sdk/middleware-sdk-sts": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
-			"integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.54.0.tgz",
+			"integrity": "sha512-4vOlG96fKgqmLMsguoKFdBkk2Fq8JttpgPts9d5Ox73+yQsa0VKrpLiD5OUPqgjGZcX2bilMKCAOBc2v3ESAHw==",
 			"requires": {
-				"@aws-sdk/middleware-signing": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/signature-v4": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/middleware-signing": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/signature-v4": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16355,11 +16355,11 @@
 			}
 		},
 		"@aws-sdk/middleware-serde": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
-			"integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.54.0.tgz",
+			"integrity": "sha512-O89/5aOiNegBP6Mv+gPr22Zawz2zF2v1o8kwFv2s4PWDzpmvrdF2by6e2Uh9sKzfpcwEW7Wr8kDTwajampVjgA==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16371,14 +16371,14 @@
 			}
 		},
 		"@aws-sdk/middleware-signing": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
-			"integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.54.0.tgz",
+			"integrity": "sha512-KYxmRDh7D6ysAezlsDf3cN2h6OjH66x3NUdgUmW+78nkN9tRvvJEjhmu6IOkPd4E1V9P3JOLbq6zVjDVU12WDQ==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/signature-v4": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/signature-v4": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16390,9 +16390,9 @@
 			}
 		},
 		"@aws-sdk/middleware-stack": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
-			"integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.54.0.tgz",
+			"integrity": "sha512-38iit8VJ7jhFlMdwdDESEJOwbi8wIjF7Q1FOFIoCvURLGkTDQdabGXKwcFVfRuceLO+LJxWP3l0z0c10uZa6gQ==",
 			"requires": {
 				"tslib": "^2.3.0"
 			},
@@ -16405,12 +16405,12 @@
 			}
 		},
 		"@aws-sdk/middleware-user-agent": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
-			"integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.54.0.tgz",
+			"integrity": "sha512-831GP5EBJdDxyq93dpgBZUwBWnZAID2aFvE/VN8c5X8U00ZT7GRt9cy5EL2b6AQN3Z4uWL1ZVDVkYmRAHs33Lg==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16422,13 +16422,13 @@
 			}
 		},
 		"@aws-sdk/node-config-provider": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
-			"integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.54.0.tgz",
+			"integrity": "sha512-Q2a1vyoZa2UX/dItP3cqNdLUoTGdIY4hD5nA+mTg5mKlOWci35v8Rypr40tQz4ZwiDF6QQmK0tvD3bBUULm0wA==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
 				"@aws-sdk/shared-ini-file-loader": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16440,14 +16440,14 @@
 			}
 		},
 		"@aws-sdk/node-http-handler": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
-			"integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.54.0.tgz",
+			"integrity": "sha512-g6+IXe4FCMrx4vrY73yvFNAUsBJ1vhjDshUCihBv5tEXsd45/MqmON/VWYoaQZts0m2wx2fKsdoDKSIZZY7AiQ==",
 			"requires": {
-				"@aws-sdk/abort-controller": "3.53.0",
-				"@aws-sdk/protocol-http": "3.53.0",
-				"@aws-sdk/querystring-builder": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/abort-controller": "3.54.0",
+				"@aws-sdk/protocol-http": "3.54.0",
+				"@aws-sdk/querystring-builder": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16459,11 +16459,11 @@
 			}
 		},
 		"@aws-sdk/property-provider": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
-			"integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.0.tgz",
+			"integrity": "sha512-8e+KXskwOhXF0MIdIcZLFsOTfMVGp41Y6kywgewQaHkZoMzZ6euRziyWNgnshUE794tjxxol9resudSUehPjIw==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16475,11 +16475,11 @@
 			}
 		},
 		"@aws-sdk/protocol-http": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
-			"integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.54.0.tgz",
+			"integrity": "sha512-v4CgQ2mBzEwNubM1duWP3Unu98EPNF2BuKWe4wT1HNG2MTkODS56fsgVT6sGGXS9nB/reEzB+3bXO5FS8+3SUg==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16491,11 +16491,11 @@
 			}
 		},
 		"@aws-sdk/querystring-builder": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
-			"integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.54.0.tgz",
+			"integrity": "sha512-7rs2gGPpiIHntbYGPFkxkXQkSK7uVBqlWRl0m6fNngUEz2n8jRxytB6LlALMHbXeXh28+zzq0VxbAwqAAUQ4oQ==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-uri-escape": "3.52.0",
 				"tslib": "^2.3.0"
 			},
@@ -16508,11 +16508,11 @@
 			}
 		},
 		"@aws-sdk/querystring-parser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
-			"integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.54.0.tgz",
+			"integrity": "sha512-OZ4mRJ9rXgBskPBSoXBw8tV4kfNK0f/pP55qE1eZIcQ1z7EvVz4NjldgqMfscT20Cx5VzUbus3q9EPcV+HbR1w==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16524,9 +16524,9 @@
 			}
 		},
 		"@aws-sdk/service-error-classification": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
-			"integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ=="
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.54.0.tgz",
+			"integrity": "sha512-XWANvjJJZNqsYhGmccSSuhsvINIUX1KckfDmvYtUR6cKM6nM6QWOg/QJeTFageTEpruJ5TqzW9vY414bIE883w=="
 		},
 		"@aws-sdk/shared-ini-file-loader": {
 			"version": "3.52.0",
@@ -16544,12 +16544,12 @@
 			}
 		},
 		"@aws-sdk/signature-v4": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
-			"integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.54.0.tgz",
+			"integrity": "sha512-22Bf8uQ0Q/I7WpLFU88G7WVpRw6tWUX9Ggr0Z++81uZF5YCPbWDNtFDHitoERaRc/M4vUMxNuTsX/JWOR3fFPg==",
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.52.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"@aws-sdk/util-hex-encoding": "3.52.0",
 				"@aws-sdk/util-uri-escape": "3.52.0",
 				"tslib": "^2.3.0"
@@ -16563,12 +16563,12 @@
 			}
 		},
 		"@aws-sdk/smithy-client": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
-			"integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.54.0.tgz",
+			"integrity": "sha512-zdYN5pwhJU7x8qZKWTZPsFD5YQkDt6kyCNRsNjSWJ0ON4R3wUlFIwT3YzeQ5nMOTD86cVIm1n2RaSTYHwelFXg==",
 			"requires": {
-				"@aws-sdk/middleware-stack": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/middleware-stack": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16580,17 +16580,17 @@
 			}
 		},
 		"@aws-sdk/types": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
-			"integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.0.tgz",
+			"integrity": "sha512-Jp2MHXnrM0pk0RIoSl5AHFm7TBk+7b8HTIcQ2X/6kGwwwnWw9qlg9ZFziegJTNTLJ4iVgZjz/yMlEvgrp7z9CA=="
 		},
 		"@aws-sdk/url-parser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
-			"integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.54.0.tgz",
+			"integrity": "sha512-DJWdlkXq3rsOydxwR9htPUW4QXhmo75Hybg96D3F2uPUvPCm8gJFngXp/9hW1OYcgfNu13HXqUy+t6V23cC7Iw==",
 			"requires": {
-				"@aws-sdk/querystring-parser": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/querystring-parser": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16633,9 +16633,9 @@
 			}
 		},
 		"@aws-sdk/util-body-length-browser": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
-			"integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.54.0.tgz",
+			"integrity": "sha512-hnY9cXbKWJ2Fjb4bK35sFdD4vK+sFe59JtxxI336yYzANulc462LU/J1RgONXYBW60d9iwJ7U+S+9oTJrEH6WQ==",
 			"requires": {
 				"tslib": "^2.3.0"
 			},
@@ -16648,9 +16648,9 @@
 			}
 		},
 		"@aws-sdk/util-body-length-node": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
-			"integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.54.0.tgz",
+			"integrity": "sha512-BBQB3kqHqHQp2GAINJGuse9JBM7hfU0tMp9rfw0nym4C/VRooiJVrIb28tKseLtd7nihXvsZXPvEc2jQBe1Thg==",
 			"requires": {
 				"tslib": "^2.3.0"
 			},
@@ -16710,12 +16710,12 @@
 			}
 		},
 		"@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
-			"integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.54.0.tgz",
+			"integrity": "sha512-9QnRbTsD2MuEr59vaPAbC95ba7druMFRSZjpwc3L7U9zpsJruNDaL5aAmV0gCAIPZg7eSaJmipyWr0AvwwgroQ==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.0"
 			},
@@ -16728,15 +16728,15 @@
 			}
 		},
 		"@aws-sdk/util-defaults-mode-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
-			"integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.54.0.tgz",
+			"integrity": "sha512-kHFgEyAWCaR5uSmRwyVbWQnjiNib3EJSAG9y7bwMIHSOK/6TVOXGlb1KIoO6ZtLE1FZFlS55FIRFeOPmIFFZbA==",
 			"requires": {
-				"@aws-sdk/config-resolver": "3.53.0",
-				"@aws-sdk/credential-provider-imds": "3.53.0",
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/property-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/config-resolver": "3.54.0",
+				"@aws-sdk/credential-provider-imds": "3.54.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/property-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -16793,11 +16793,11 @@
 			}
 		},
 		"@aws-sdk/util-user-agent-browser": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
-			"integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.54.0.tgz",
+			"integrity": "sha512-pU5KL1Nnlc1igeED2R44k9GEIxlLBhwmUGIw8/Emfm8xAlGOX4NsVSfHK9EpJQth0z5ZJ4Lni6S5+nW4V16yLw==",
 			"requires": {
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/types": "3.54.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.0"
 			},
@@ -16810,12 +16810,12 @@
 			}
 		},
 		"@aws-sdk/util-user-agent-node": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
-			"integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.54.0.tgz",
+			"integrity": "sha512-euKoYk1TfyV9XlJyAlGWdYqhQ5B4COwBxsV9OpwiAINUFm91NSv6uavFC/ZZQBXRks6j9pHDAXeXu7bHVolvlA==",
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.53.0",
-				"@aws-sdk/types": "3.53.0",
+				"@aws-sdk/node-config-provider": "3.54.0",
+				"@aws-sdk/types": "3.54.0",
 				"tslib": "^2.3.0"
 			},
 			"dependencies": {
@@ -21846,9 +21846,9 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"faros-feeds-sdk": {
-			"version": "0.9.10",
-			"resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.9.10.tgz",
-			"integrity": "sha512-r18JMqLehpsa2x3dWO4Op+O+34Z/gTxQr1Sgxvga0bC9vgQOPsHD6t/qACa7SyPqAlS2y7g9VgmbPxTA+TeeHg==",
+			"version": "0.9.11",
+			"resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.9.11.tgz",
+			"integrity": "sha512-6ZX2HIAn63gR8CmmeRqESuf14kv7v0wu8XJlC6faaY8vuUIgyNHU1F368JVwaqZFelFP557Gjqc0QN049OYx1Q==",
 			"requires": {
 				"@avro/common-types": "^0.2.0",
 				"@avro/streams": "^1.0.10",

--- a/sources/backlog-source/package.json
+++ b/sources/backlog-source/package.json
@@ -32,6 +32,7 @@
     "axios": "^0.26.0",
     "commander": "^9.0.0",
     "faros-airbyte-cdk": "^0.1.50",
+    "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/backlog-source/src/backlog.ts
+++ b/sources/backlog-source/src/backlog.ts
@@ -81,7 +81,8 @@ export class Backlog {
     (lastUpdatedAt?: string) =>
       new Date(lastUpdatedAt ?? DEFAULT_MEMOIZE_START_TIME)
   )
-  async *getIssues(lastUpdatedAt?: string): AsyncGenerator<Issue> {
+  async getIssues(lastUpdatedAt?: string): Promise<ReadonlyArray<Issue>> {
+    const results: Issue[] = [];
     const startTime = new Date(lastUpdatedAt ?? 0);
     const config = this.cfg.project_id
       ? {
@@ -104,9 +105,10 @@ export class Backlog {
 
         if (comment.status === 200) item.comments = comment.data;
 
-        yield item;
+        results.push(item);
       }
     }
+    return results;
   }
 
   formatDate(d: Date): string {

--- a/sources/backlog-source/src/streams/issues.ts
+++ b/sources/backlog-source/src/streams/issues.ts
@@ -44,7 +44,9 @@ export class Issues extends AirbyteStreamBase {
         ? streamState?.lastUpdatedAt
         : undefined;
     const backlog = await Backlog.instance(this.config, this.logger);
-    yield* backlog.getIssues(lastUpdatedAt);
+    for (const issue of await backlog.getIssues(lastUpdatedAt)) {
+      yield issue;
+    }
   }
 
   getUpdatedState(

--- a/sources/bitbucket-source/src/bitbucket/bitbucket.ts
+++ b/sources/bitbucket-source/src/bitbucket/bitbucket.ts
@@ -269,7 +269,7 @@ export class Bitbucket {
   }
 
   @Memoize((repoSlug: string): string => repoSlug)
-  async getPipelines(repoSlug: string): Promise<Pipeline[]> {
+  async getPipelines(repoSlug: string): Promise<ReadonlyArray<Pipeline>> {
     const results: Pipeline[] = [];
     try {
       const func = (): Promise<BitbucketResponse<Pipeline>> =>
@@ -333,7 +333,7 @@ export class Bitbucket {
   async getPullRequests(
     repoSlug: string,
     lastUpdated?: string
-  ): Promise<PullRequest[]> {
+  ): Promise<ReadonlyArray<PullRequest>> {
     try {
       const results: PullRequest[] = [];
       /**

--- a/sources/docker-source/src/docker.ts
+++ b/sources/docker-source/src/docker.ts
@@ -140,7 +140,8 @@ export class Docker {
   }
 
   @Memoize((repo: string): string => repo)
-  async *getTags(repo: string): AsyncGenerator<Tag> {
+  async getTags(repo: string): Promise<ReadonlyArray<Tag>> {
+    const results: Tag[] = [];
     const res = await dockerRegistry.getTags(
       this.registryBase,
       repo,
@@ -157,13 +158,14 @@ export class Docker {
         repo,
         imageManifest.config.digest
       );
-      yield {
+      results.push({
         name: item,
         projectName: repo,
         imageConfig,
         imageManifest,
-      };
+      });
     }
+    return results;
   }
 
   @Memoize((repo: string, digest: string): string => repo.concat(digest))

--- a/sources/docker-source/src/streams/tags.ts
+++ b/sources/docker-source/src/streams/tags.ts
@@ -47,6 +47,8 @@ export class Tags extends AirbyteStreamBase {
       projectName: repo,
     };
     const docker = await Docker.instance(config, this.logger);
-    yield* docker.getTags(repo);
+    for (const tag of await docker.getTags(repo)) {
+      yield tag;
+    }
   }
 }

--- a/sources/docker-source/test/index.test.ts
+++ b/sources/docker-source/test/index.test.ts
@@ -86,12 +86,11 @@ describe('index', () => {
   test('streams - tags, use full_refresh sync mode', async () => {
     const fnTagsFunc = jest.fn();
 
-    let tagIndex = 0;
     Docker.instance = jest.fn().mockImplementation(() => {
       return {
         ...new Docker('registry-base', 100, 5, {headers: {}}, undefined),
-        getTags: fnTagsFunc.mockImplementation(async function* () {
-          yield readTestResourceFile('tags.json')[tagIndex++];
+        getTags: fnTagsFunc.mockImplementation(async function () {
+          return readTestResourceFile('tags.json');
         }),
       };
     });

--- a/sources/jenkins-source/package.json
+++ b/sources/jenkins-source/package.json
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "faros-airbyte-cdk": "^0.1.50",
     "jenkins": "^0.28.1",
-    "typescript-memoize": "^1.0.1",
+    "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/jenkins-source/src/jenkins.ts
+++ b/sources/jenkins-source/src/jenkins.ts
@@ -141,7 +141,7 @@ export class Jenkins {
   async syncJobs(
     jenkinsCfg: JenkinsConfig,
     streamSlice: Job | null
-  ): Promise<Job[]> {
+  ): Promise<ReadonlyArray<Job>> {
     const pageSize = jenkinsCfg.pageSize || DEFAULT_PAGE_SIZE;
     const last100Builds = jenkinsCfg.last100Builds ?? false;
     const depth = jenkinsCfg.depth ?? (await this.calculateMaxJobsDepth());

--- a/sources/jenkins-source/src/streams/jobs.ts
+++ b/sources/jenkins-source/src/streams/jobs.ts
@@ -53,8 +53,7 @@ export class Jobs extends AirbyteStreamBase {
     const state =
       syncMode === SyncMode.INCREMENTAL ? streamSlice || null : null;
 
-    const jobs: Job[] = await jenkins.syncJobs(this.config, state);
-    for (const job of jobs) {
+    for (const job of await jenkins.syncJobs(this.config, state)) {
       yield job;
     }
   }

--- a/sources/shortcut-source/package.json
+++ b/sources/shortcut-source/package.json
@@ -33,6 +33,7 @@
     "clubhouse-lib": "^0.13.0",
     "commander": "^9.0.0",
     "faros-airbyte-cdk": "^0.1.50",
+    "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/shortcut-source/src/shortcut.ts
+++ b/sources/shortcut-source/src/shortcut.ts
@@ -79,19 +79,23 @@ export class Shortcut {
     (lastUpdatedAt?: string) =>
       new Date(lastUpdatedAt ?? DEFAULT_MEMOIZE_START_TIME)
   )
-  async *getIterations(lastUpdatedAt?: string): AsyncGenerator<Iteration> {
+  async getIterations(
+    lastUpdatedAt?: string
+  ): Promise<ReadonlyArray<Iteration>> {
+    const results: Iteration[] = [];
     const startTime = new Date(lastUpdatedAt ?? 0);
     const list = await this.client.listIterations();
     for (const item of list) {
       if (!lastUpdatedAt) {
-        yield item;
+        results.push(item);
       } else {
         const updatedAt = new Date(item.updated_at);
         if (updatedAt >= startTime) {
-          yield item;
+          results.push(item);
         }
       }
     }
+    return results;
   }
 
   async *getEpics(projectId: number): AsyncGenerator<Epic> {

--- a/sources/shortcut-source/src/streams/iterations.ts
+++ b/sources/shortcut-source/src/streams/iterations.ts
@@ -40,7 +40,9 @@ export class Iterations extends AirbyteStreamBase {
         ? streamState?.lastUpdatedAt
         : undefined;
     const shortcut = await Shortcut.instance(this.config);
-    yield* shortcut.getIterations(lastUpdatedAt);
+    for (const iteration of await shortcut.getIterations(lastUpdatedAt)) {
+      yield iteration;
+    }
   }
 
   getUpdatedState(

--- a/sources/squadcast-source/src/streams/incidents.ts
+++ b/sources/squadcast-source/src/streams/incidents.ts
@@ -38,9 +38,13 @@ export class Incidents extends AirbyteStreamBase {
     streamState?: IncidentState
   ): AsyncGenerator<Incident> {
     const lastUpdatedAt =
-      syncMode === SyncMode.INCREMENTAL ? streamState?.lastUpdatedAt : undefined;
+      syncMode === SyncMode.INCREMENTAL
+        ? streamState?.lastUpdatedAt
+        : undefined;
     const squadcast = await Squadcast.instance(this.config, this.logger);
-    yield* squadcast.getIncidents(lastUpdatedAt);
+    for (const incident of await squadcast.getIncidents(lastUpdatedAt)) {
+      yield incident;
+    }
   }
 
   getUpdatedState(

--- a/sources/statuspage-source/package.json
+++ b/sources/statuspage-source/package.json
@@ -34,7 +34,7 @@
     "commander": "^9.0.0",
     "faros-airbyte-cdk": "^0.1.50",
     "statuspage.io": "^3.1.0",
-    "typescript-memoize": "^1.0.1",
+    "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/statuspage-source/src/streams/incidents.ts
+++ b/sources/statuspage-source/src/streams/incidents.ts
@@ -40,7 +40,9 @@ export class Incidents extends AirbyteStreamBase {
     const state = syncMode === SyncMode.INCREMENTAL ? streamState : undefined;
     const cutoff: Date = state?.cutoff ? new Date(state?.cutoff) : undefined;
 
-    yield* statuspage.getIncidents(cutoff);
+    for (const incident of await statuspage.getIncidents(cutoff)) {
+      yield incident;
+    }
   }
 
   getUpdatedState(


### PR DESCRIPTION
## Description

The typescript-memoize library does not work for generators. Only the first call was yielding results. Therefore, I converted all the functions that utilize the `@Memoize` annotation to return normal lists.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
