### PR TITLE
Fix converter-by-name lookup

### DIFF
--- a/destinations/faros-destination/package.json
+++ b/destinations/faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-destination",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Faros Destination for Airbyte",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "analytics-node": "^6.0.0",
     "axios": "^0.26.0",
     "date-format": "^4.0.3",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "faros-feeds-sdk": "^0.9.7",
     "fs-extra": "^10.0.0",
     "git-url-parse": "^11.6.0",

--- a/destinations/faros-destination/src/converters/agileaccelerator/common.ts
+++ b/destinations/faros-destination/src/converters/agileaccelerator/common.ts
@@ -179,6 +179,8 @@ export class AgileAcceleratorCommon {
 
 /** AgileAccelerator converter base */
 export abstract class AgileacceleratorConverter extends Converter {
+  source = 'AgileAccelerator';
+
   /** Almost every AgileAccelerator record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.Id;

--- a/destinations/faros-destination/src/converters/agileaccelerator/works.ts
+++ b/destinations/faros-destination/src/converters/agileaccelerator/works.ts
@@ -8,7 +8,7 @@ import {
   TaskField,
 } from './common';
 
-export class AgileacceleratorWorks extends AgileacceleratorConverter {
+export class Works extends AgileacceleratorConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Epic',
     'tms_Project',

--- a/destinations/faros-destination/src/converters/asana/common.ts
+++ b/destinations/faros-destination/src/converters/asana/common.ts
@@ -78,6 +78,8 @@ export class AsanaCommon {
 
 /** Asana converter base */
 export abstract class AsanaConverter extends Converter {
+  source = 'Asana';
+
   /** All Asana records should have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.gid;

--- a/destinations/faros-destination/src/converters/asana/projects.ts
+++ b/destinations/faros-destination/src/converters/asana/projects.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AsanaCommon, AsanaConverter} from './common';
 
-export class AsanaProjects extends AsanaConverter {
+export class Projects extends AsanaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Project'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/asana/sections.ts
+++ b/destinations/faros-destination/src/converters/asana/sections.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AsanaCommon, AsanaConverter, AsanaSection} from './common';
 
-export class AsanaSections extends AsanaConverter {
+export class Sections extends AsanaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_TaskBoard',
     'tms_TaskBoardProjectRelationship',

--- a/destinations/faros-destination/src/converters/asana/stories.ts
+++ b/destinations/faros-destination/src/converters/asana/stories.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AsanaCommon, AsanaConverter} from './common';
 
-export class AsanaStories extends AsanaConverter {
+export class Stories extends AsanaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Task'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/asana/tags.ts
+++ b/destinations/faros-destination/src/converters/asana/tags.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AsanaConverter} from './common';
 
-export class AsanaTags extends AsanaConverter {
+export class Tags extends AsanaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Label'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/asana/tasks.ts
+++ b/destinations/faros-destination/src/converters/asana/tasks.ts
@@ -30,7 +30,7 @@ enum Tms_TaskStatusCategory {
   Todo = 'Todo',
 }
 
-export class AsanaTasks extends AsanaConverter {
+export class Tasks extends AsanaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Task',
     'tms_Project',

--- a/destinations/faros-destination/src/converters/asana/users.ts
+++ b/destinations/faros-destination/src/converters/asana/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AsanaCommon, AsanaConverter, AsanaUser} from './common';
 
-export class AsanaUsers extends AsanaConverter {
+export class Users extends AsanaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/backlog/common.ts
+++ b/destinations/faros-destination/src/converters/backlog/common.ts
@@ -53,6 +53,8 @@ export class BacklogCommon {
 
 /** Backlog converter base */
 export abstract class BacklogConverter extends Converter {
+  source = 'Backlog';
+
   /** Almost every Backlog record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/backlog/issues.ts
+++ b/destinations/faros-destination/src/converters/backlog/issues.ts
@@ -5,7 +5,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {BacklogCommon, BacklogConverter} from './common';
 import {Issue, TaskField, TaskStatusChange} from './models';
 
-export class BacklogIssues extends BacklogConverter {
+export class Issues extends BacklogConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Label',
     'tms_Task',

--- a/destinations/faros-destination/src/converters/backlog/projects.ts
+++ b/destinations/faros-destination/src/converters/backlog/projects.ts
@@ -5,7 +5,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {BacklogCommon, BacklogConverter} from './common';
 import {Project} from './models';
 
-export class BacklogProjects extends BacklogConverter {
+export class Projects extends BacklogConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Project',
     'tms_Release',

--- a/destinations/faros-destination/src/converters/backlog/users.ts
+++ b/destinations/faros-destination/src/converters/backlog/users.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {BacklogConverter} from './common';
 import {User} from './models';
 
-export class BacklogUsers extends BacklogConverter {
+export class Users extends BacklogConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/bitbucket/branches.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/branches.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {BitbucketConverter} from './common';
 import {Branch} from './types';
 
-export class BitbucketBranches extends BitbucketConverter {
+export class Branches extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Branch'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/bitbucket/commits.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/commits.ts
@@ -5,7 +5,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {BitbucketCommon, BitbucketConverter} from './common';
 import {Commit} from './types';
 
-export class BitbucketCommits extends BitbucketConverter {
+export class Commits extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Commit',
     'vcs_User',

--- a/destinations/faros-destination/src/converters/bitbucket/common.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/common.ts
@@ -54,6 +54,8 @@ export class BitbucketCommon {
 
 /** Bitbucket converter base */
 export abstract class BitbucketConverter extends Converter {
+  source = 'Bitbucket';
+
   /** Almost all Bitbucket records should have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/bitbucket/deployments.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/deployments.ts
@@ -29,7 +29,7 @@ enum DeploymentStatusCategory {
   SUCCESS = 'Success',
 }
 
-export class BitbucketDeployments extends BitbucketConverter {
+export class Deployments extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Deployment',
   ];

--- a/destinations/faros-destination/src/converters/bitbucket/issues.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/issues.ts
@@ -24,7 +24,7 @@ enum TaskStatusCategory {
   TODO = 'Todo',
 }
 
-export class BitbucketIssues extends BitbucketConverter {
+export class Issues extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Task',
     'tms_TaskAssignment',

--- a/destinations/faros-destination/src/converters/bitbucket/pipeline_steps.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/pipeline_steps.ts
@@ -20,7 +20,7 @@ enum BuildStatusCategory {
   CUSTOM = 'Custom',
 }
 
-export class BitbucketPipelineSteps extends BitbucketConverter {
+export class PipelineSteps extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_BuildStep',
   ];

--- a/destinations/faros-destination/src/converters/bitbucket/pipelines.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/pipelines.ts
@@ -15,7 +15,7 @@ enum BuildStatusCategory {
   CUSTOM = 'Custom',
 }
 
-export class BitbucketPipelines extends BitbucketConverter {
+export class Pipelines extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Build',
     'cicd_BuildCommitAssociation',

--- a/destinations/faros-destination/src/converters/bitbucket/pull_request_activities.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/pull_request_activities.ts
@@ -13,7 +13,7 @@ enum PullRequestReviewStateCategory {
   CUSTOM = 'Custom',
 }
 
-export class BitbucketPullRequestActivities extends BitbucketConverter {
+export class PullRequestActivities extends BitbucketConverter {
   readonly logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/bitbucket/pull_requests.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/pull_requests.ts
@@ -17,7 +17,7 @@ enum PullRequestStateCategory {
   CUSTOM = 'Custom',
 }
 
-export class BitbucketPullRequests extends BitbucketConverter {
+export class PullRequests extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_User',
     'vcs_PullRequest',

--- a/destinations/faros-destination/src/converters/bitbucket/repositories.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/repositories.ts
@@ -9,7 +9,7 @@ import {
 import {BitbucketCommon, BitbucketConverter} from './common';
 import {Repository, Workspace} from './types';
 
-export class BitbucketRepositories extends BitbucketConverter {
+export class Repositories extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Repository',
   ];

--- a/destinations/faros-destination/src/converters/bitbucket/workspace_users.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/workspace_users.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {BitbucketCommon, BitbucketConverter} from './common';
 import {WorkspaceUser} from './types';
 
-export class BitbucketWorkspaceUsers extends BitbucketConverter {
+export class WorkspaceUsers extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_User',
     'vcs_Membership',

--- a/destinations/faros-destination/src/converters/bitbucket/workspaces.ts
+++ b/destinations/faros-destination/src/converters/bitbucket/workspaces.ts
@@ -12,7 +12,7 @@ enum OrgTypeCategory {
   CUSTOM = 'Custom',
 }
 
-export class BitbucketWorkspaces extends BitbucketConverter {
+export class Workspaces extends BitbucketConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Organization',
     'vcs_Organization',

--- a/destinations/faros-destination/src/converters/converter-registry.ts
+++ b/destinations/faros-destination/src/converters/converter-registry.ts
@@ -1,4 +1,4 @@
-import {camelCase, upperFirst} from 'lodash';
+import {camelCase, find, findKey} from 'lodash';
 import {Dictionary} from 'ts-essentials';
 import {VError} from 'verror';
 
@@ -39,7 +39,17 @@ export class ConverterRegistry {
       const mod = require(`./${streamName.source}/${streamName.name}`);
 
       // Create converter instance by name
-      const className = upperFirst(camelCase(name));
+      const className =
+        find(
+          Object.keys(mod),
+          (c: string) =>
+            c.toLowerCase() === camelCase(streamName.name).toLowerCase()
+        ) ?? findKey(mod, (f: any) => typeof f === 'function');
+      if (!className) {
+        throw new VError(
+          `Could not find converter from module for stream ${name}`
+        );
+      }
       const converter = new mod[className]();
 
       // Keep the converter instance in the registry

--- a/destinations/faros-destination/src/converters/converter.ts
+++ b/destinations/faros-destination/src/converters/converter.ts
@@ -9,6 +9,7 @@ import {VError} from 'verror';
 export abstract class Converter {
   private stream: StreamName;
 
+  /** Name of the source system that records were fetched from (e.g. GitHub) **/
   abstract readonly source: string;
 
   /** Input stream supported by converter */

--- a/destinations/faros-destination/src/converters/converter.ts
+++ b/destinations/faros-destination/src/converters/converter.ts
@@ -7,13 +7,15 @@ import {VError} from 'verror';
 
 /** Airbyte -> Faros record converter */
 export abstract class Converter {
-  protected stream: StreamName;
+  private stream: StreamName;
+
+  abstract readonly source: string;
 
   /** Input stream supported by converter */
   get streamName(): StreamName {
     if (this.stream) return this.stream;
     this.stream = StreamName.fromString(
-      snakeCase(this.constructor.name).replace('_', StreamNameSeparator)
+      `${this.source}${StreamNameSeparator}${snakeCase(this.constructor.name)}`
     );
     return this.stream;
   }

--- a/destinations/faros-destination/src/converters/datadog/common.ts
+++ b/destinations/faros-destination/src/converters/datadog/common.ts
@@ -20,6 +20,8 @@ type ApplicationMapping = Record<string, {name: string; platform?: string}>;
 
 /** Datadog converter base */
 export abstract class DatadogConverter extends Converter {
+  source = 'Datadog';
+
   /** Almost every Datadog record has an id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/datadog/incidents.ts
+++ b/destinations/faros-destination/src/converters/datadog/incidents.ts
@@ -1,6 +1,5 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-feeds-sdk';
-import VError from 'verror';
 
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {DatadogConverter, IncidentSeverityCategory} from './common';
@@ -13,7 +12,7 @@ enum IncidentStatusCategory {
   Custom = 'Custom',
 }
 
-export class DatadogIncidents extends DatadogConverter {
+export class Incidents extends DatadogConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'ims_Incident',
     'ims_IncidentAssignment',

--- a/destinations/faros-destination/src/converters/datadog/users.ts
+++ b/destinations/faros-destination/src/converters/datadog/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {DatadogConverter} from './common';
 
-export class DatadogUsers extends DatadogConverter {
+export class Users extends DatadogConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['ims_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/docker/common.ts
+++ b/destinations/faros-destination/src/converters/docker/common.ts
@@ -138,6 +138,8 @@ export class DockerCommon {
 
 /** Docker converter base */
 export abstract class DockerConverter extends Converter {
+  source = 'Docker';
+
   /** Every Docker record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/docker/tags.ts
+++ b/destinations/faros-destination/src/converters/docker/tags.ts
@@ -12,7 +12,7 @@ import {
   Tag,
 } from './common';
 
-export class DockerTags extends DockerConverter {
+export class Tags extends DockerConverter {
   readonly logger = new AirbyteLogger();
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Artifact',

--- a/destinations/faros-destination/src/converters/github/assignees.ts
+++ b/destinations/faros-destination/src/converters/github/assignees.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubAssignees extends GithubConverter {
+export class Assignees extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/github/branches.ts
+++ b/destinations/faros-destination/src/converters/github/branches.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubBranches extends GithubConverter {
+export class Branches extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Branch'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/github/collaborators.ts
+++ b/destinations/faros-destination/src/converters/github/collaborators.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubCollaborators extends GithubConverter {
+export class Collaborators extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Membership',
     'vcs_User',

--- a/destinations/faros-destination/src/converters/github/commits.ts
+++ b/destinations/faros-destination/src/converters/github/commits.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubCommits extends GithubConverter {
+export class Commits extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_BranchCommitAssociation',
     'vcs_Commit',

--- a/destinations/faros-destination/src/converters/github/common.ts
+++ b/destinations/faros-destination/src/converters/github/common.ts
@@ -3,7 +3,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {toLower} from 'lodash';
 import {Dictionary} from 'ts-essentials';
 
-import {Converter, DestinationRecord, StreamName} from '../converter';
+import {Converter, DestinationRecord} from '../converter';
 
 /** Common functions shares across GitHub converters */
 export class GithubCommon {
@@ -153,15 +153,11 @@ export class GithubCommon {
 
 /** Github converter base */
 export abstract class GithubConverter extends Converter {
+  source = 'GitHub';
+
   /** All Github records should have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;
-  }
-
-  get streamName(): StreamName {
-    if (this.stream) return this.stream;
-    this.stream = new StreamName('GitHub', super.streamName.name);
-    return this.stream;
   }
 }
 

--- a/destinations/faros-destination/src/converters/github/issue_labels.ts
+++ b/destinations/faros-destination/src/converters/github/issue_labels.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubConverter} from './common';
 
-export class GithubIssueLabels extends GithubConverter {
+export class IssueLabels extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Label'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/github/issue_milestones.ts
+++ b/destinations/faros-destination/src/converters/github/issue_milestones.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubIssueMilestones extends GithubConverter {
+export class IssueMilestones extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Epic'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/github/issues.ts
+++ b/destinations/faros-destination/src/converters/github/issues.ts
@@ -9,7 +9,7 @@ import {
 } from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubIssues extends GithubConverter {
+export class Issues extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Label',
     'tms_Task',

--- a/destinations/faros-destination/src/converters/github/organizations.ts
+++ b/destinations/faros-destination/src/converters/github/organizations.ts
@@ -8,7 +8,7 @@ import {GithubConverter} from './common';
 // Github org types
 const orgTypes = ['organization', 'workspace', 'group'];
 
-export class GithubOrganizations extends GithubConverter {
+export class Organizations extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Organization',
   ];

--- a/destinations/faros-destination/src/converters/github/projects.ts
+++ b/destinations/faros-destination/src/converters/github/projects.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubProjects extends GithubConverter {
+export class Projects extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Project',
     'tms_TaskBoard',

--- a/destinations/faros-destination/src/converters/github/pull_request_stats.ts
+++ b/destinations/faros-destination/src/converters/github/pull_request_stats.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubPullRequestStats extends GithubConverter {
+export class PullRequestStats extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequest',
   ];

--- a/destinations/faros-destination/src/converters/github/pull_requests.ts
+++ b/destinations/faros-destination/src/converters/github/pull_requests.ts
@@ -9,7 +9,7 @@ import {GithubConverter} from './common';
 // Github PR states
 const prStates = ['closed', 'merged', 'open'];
 
-export class GithubPullRequests extends GithubConverter {
+export class PullRequests extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequest',
     'vcs_User',

--- a/destinations/faros-destination/src/converters/github/releases.ts
+++ b/destinations/faros-destination/src/converters/github/releases.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubReleases extends GithubConverter {
+export class Releases extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Release',
     'cicd_ReleaseTagAssociation',

--- a/destinations/faros-destination/src/converters/github/repositories.ts
+++ b/destinations/faros-destination/src/converters/github/repositories.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubRepositories extends GithubConverter {
+export class Repositories extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Project',
     'tms_TaskBoard',

--- a/destinations/faros-destination/src/converters/github/review_comments.ts
+++ b/destinations/faros-destination/src/converters/github/review_comments.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubReviewComments extends GithubConverter {
+export class ReviewComments extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequestComment',
   ];

--- a/destinations/faros-destination/src/converters/github/reviews.ts
+++ b/destinations/faros-destination/src/converters/github/reviews.ts
@@ -13,7 +13,7 @@ const ReviewStates = [
   'dismissed',
 ];
 
-export class GithubReviews extends GithubConverter {
+export class Reviews extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequestReview',
     'vcs_User',

--- a/destinations/faros-destination/src/converters/github/tags.ts
+++ b/destinations/faros-destination/src/converters/github/tags.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubTags extends GithubConverter {
+export class Tags extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Tag'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/github/users.ts
+++ b/destinations/faros-destination/src/converters/github/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GithubCommon, GithubConverter} from './common';
 
-export class GithubUsers extends GithubConverter {
+export class Users extends GithubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Membership',
     'vcs_User',

--- a/destinations/faros-destination/src/converters/gitlab/branches.ts
+++ b/destinations/faros-destination/src/converters/gitlab/branches.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabBranches extends GitlabConverter {
+export class Branches extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Branch',
     'vcs_BranchCommitAssociation',

--- a/destinations/faros-destination/src/converters/gitlab/commits.ts
+++ b/destinations/faros-destination/src/converters/gitlab/commits.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabCommits extends GitlabConverter {
+export class Commits extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Commit'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/common.ts
+++ b/destinations/faros-destination/src/converters/gitlab/common.ts
@@ -77,6 +77,8 @@ export class GitlabCommon {
 
 /** GitLab converter base */
 export abstract class GitlabConverter extends Converter {
+  source = 'GitLab';
+
   /** Almost every GitLab record have id property. Function will be
    * override if record doesn't have id property.
    */

--- a/destinations/faros-destination/src/converters/gitlab/group_labels.ts
+++ b/destinations/faros-destination/src/converters/gitlab/group_labels.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabConverter} from './common';
 
-export class GitlabGroupLabels extends GitlabConverter {
+export class GroupLabels extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Label'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/group_milestones.ts
+++ b/destinations/faros-destination/src/converters/gitlab/group_milestones.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabGroupMilestones extends GitlabConverter {
+export class GroupMilestones extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Epic'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/groups.ts
+++ b/destinations/faros-destination/src/converters/gitlab/groups.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabGroups extends GitlabConverter {
+export class Groups extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Organization',
     'vcs_Organization',

--- a/destinations/faros-destination/src/converters/gitlab/issues.ts
+++ b/destinations/faros-destination/src/converters/gitlab/issues.ts
@@ -9,7 +9,7 @@ import {
 } from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabIssues extends GitlabConverter {
+export class Issues extends GitlabConverter {
   private readonly logger: AirbyteLogger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/gitlab/jobs.ts
+++ b/destinations/faros-destination/src/converters/gitlab/jobs.ts
@@ -9,7 +9,7 @@ import {
 } from '../converter';
 import {CategoryRef, GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabJobs extends GitlabConverter {
+export class Jobs extends GitlabConverter {
   private readonly logger: AirbyteLogger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/gitlab/merge_request_commits.ts
+++ b/destinations/faros-destination/src/converters/gitlab/merge_request_commits.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabMergeRequestCommits extends GitlabConverter {
+export class MergeRequestCommits extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Commit'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/merge_requests.ts
+++ b/destinations/faros-destination/src/converters/gitlab/merge_requests.ts
@@ -9,7 +9,7 @@ import {
 } from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabMergeRequests extends GitlabConverter {
+export class MergeRequests extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequest',
   ];

--- a/destinations/faros-destination/src/converters/gitlab/pipelines.ts
+++ b/destinations/faros-destination/src/converters/gitlab/pipelines.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabPipelines extends GitlabConverter {
+export class Pipelines extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['cicd_Build'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/project_labels.ts
+++ b/destinations/faros-destination/src/converters/gitlab/project_labels.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabConverter} from './common';
 
-export class GitlabProjectLabels extends GitlabConverter {
+export class ProjectLabels extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Label'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/project_milestones.ts
+++ b/destinations/faros-destination/src/converters/gitlab/project_milestones.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabProjectMilestones extends GitlabConverter {
+export class ProjectMilestones extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Epic'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/gitlab/projects.ts
+++ b/destinations/faros-destination/src/converters/gitlab/projects.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabProjects extends GitlabConverter {
+export class Projects extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Pipeline',
     'vcs_Repository',

--- a/destinations/faros-destination/src/converters/gitlab/releases.ts
+++ b/destinations/faros-destination/src/converters/gitlab/releases.ts
@@ -9,7 +9,7 @@ import {
 } from '../converter';
 import {GitlabConverter} from './common';
 
-export class GitlabReleases extends GitlabConverter {
+export class Releases extends GitlabConverter {
   private readonly logger: AirbyteLogger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/gitlab/tags.ts
+++ b/destinations/faros-destination/src/converters/gitlab/tags.ts
@@ -8,7 +8,7 @@ import {
 } from '../converter';
 import {GitlabCommon, GitlabConverter} from './common';
 
-export class GitlabTags extends GitlabConverter {
+export class Tags extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Tag'];
 
   private readonly projectsStream = new StreamName('gitlab', 'projects');

--- a/destinations/faros-destination/src/converters/gitlab/users.ts
+++ b/destinations/faros-destination/src/converters/gitlab/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabConverter} from './common';
 
-export class GitlabUsers extends GitlabConverter {
+export class Users extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/googlecalendar/calendars.ts
+++ b/destinations/faros-destination/src/converters/googlecalendar/calendars.ts
@@ -7,7 +7,7 @@ import {
   GooglecalendarConverter,
 } from './common';
 
-export class GooglecalendarCalendars extends GooglecalendarConverter {
+export class Calendars extends GooglecalendarConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cal_Calendar',
   ];

--- a/destinations/faros-destination/src/converters/googlecalendar/common.ts
+++ b/destinations/faros-destination/src/converters/googlecalendar/common.ts
@@ -131,6 +131,8 @@ export class GooglecalendarCommon {
 
 /** GoogleCalendar converter base */
 export abstract class GooglecalendarConverter extends Converter {
+  source = 'GoogleCalendar';
+
   /** Every GoogleCalendar record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/googlecalendar/events.ts
+++ b/destinations/faros-destination/src/converters/googlecalendar/events.ts
@@ -4,7 +4,7 @@ import {Location, Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {Event, GooglecalendarCommon, GooglecalendarConverter} from './common';
 
-export class GooglecalendarEvents extends GooglecalendarConverter {
+export class Events extends GooglecalendarConverter {
   // Locations cache to avoid querying the API for the same location
   private locationsCache = new Map<string, Location>();
 

--- a/destinations/faros-destination/src/converters/harness/common.ts
+++ b/destinations/faros-destination/src/converters/harness/common.ts
@@ -114,6 +114,8 @@ export interface ExecutionPipeline {
 
 /** Harness converter base */
 export abstract class HarnessConverter extends Converter {
+  source = 'Harness';
+
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;
   }

--- a/destinations/faros-destination/src/converters/harness/executions.ts
+++ b/destinations/faros-destination/src/converters/harness/executions.ts
@@ -20,7 +20,7 @@ const DEFAULT_EXECUTION_TAG_ARTIFACT_ORG = 'faros_artifact_org';
 const DEFAULT_EXECUTION_TAG_ARTIFACT_SOURCE = 'faros_artifact_source';
 const DEFAULT_EXECUTION_TAG_ARTIFACT_REPO = 'faros_artifact_repo';
 
-export class HarnessExecutions extends HarnessConverter {
+export class Executions extends HarnessConverter {
   private readonly logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/jenkins/builds.ts
+++ b/destinations/faros-destination/src/converters/jenkins/builds.ts
@@ -1,15 +1,10 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-feeds-sdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
-import {JenkinsCommon} from './common';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {JenkinsCommon, JenkinsConverter} from './common';
 
-export class JenkinsBuilds extends Converter {
+export class Builds extends JenkinsConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Organization',
     'cicd_Pipeline',

--- a/destinations/faros-destination/src/converters/jenkins/common.ts
+++ b/destinations/faros-destination/src/converters/jenkins/common.ts
@@ -1,6 +1,6 @@
 import {URL} from 'url';
 
-import {DestinationRecord} from '../converter';
+import {Converter, DestinationRecord} from '../converter';
 
 interface JenkinsUrl {
   hostname: string;
@@ -65,4 +65,8 @@ export class JenkinsCommon {
       return undefined;
     }
   }
+}
+
+export abstract class JenkinsConverter extends Converter {
+  source = 'Jenkins';
 }

--- a/destinations/faros-destination/src/converters/jenkins/jobs.ts
+++ b/destinations/faros-destination/src/converters/jenkins/jobs.ts
@@ -1,14 +1,9 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
-import {JenkinsCommon, Job} from './common';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {JenkinsCommon, JenkinsConverter, Job} from './common';
 
-export class JenkinsJobs extends Converter {
+export class Jobs extends JenkinsConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Organization',
     'cicd_Pipeline',

--- a/destinations/faros-destination/src/converters/jira/board_issues.ts
+++ b/destinations/faros-destination/src/converters/jira/board_issues.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
-export class JiraBoardIssues extends JiraConverter {
+export class BoardIssues extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_TaskBoardRelationship',
   ];

--- a/destinations/faros-destination/src/converters/jira/boards.ts
+++ b/destinations/faros-destination/src/converters/jira/boards.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
-export class JiraBoards extends JiraConverter {
+export class Boards extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_TaskBoard',
     'tms_TaskBoardProjectRelationship',

--- a/destinations/faros-destination/src/converters/jira/common.ts
+++ b/destinations/faros-destination/src/converters/jira/common.ts
@@ -66,6 +66,8 @@ export interface JiraConfig {
 }
 
 export abstract class JiraConverter extends Converter {
+  source = 'Jira';
+
   /** All Jira records should have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/jira/epics.ts
+++ b/destinations/faros-destination/src/converters/jira/epics.ts
@@ -4,7 +4,7 @@ import TurndownService from 'turndown';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraCommon, JiraConverter, JiraStatusCategories} from './common';
 
-export class JiraEpics extends JiraConverter {
+export class Epics extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Epic'];
 
   private turndown = new TurndownService();

--- a/destinations/faros-destination/src/converters/jira/issue_fields.ts
+++ b/destinations/faros-destination/src/converters/jira/issue_fields.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
 // Required as dependency by Issues and Sprints stream
-export class JiraIssueFields extends JiraConverter {
+export class IssueFields extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [];
 
   async convert(

--- a/destinations/faros-destination/src/converters/jira/project_versions.ts
+++ b/destinations/faros-destination/src/converters/jira/project_versions.ts
@@ -9,7 +9,7 @@ import {
 } from '../converter';
 import {JiraConverter} from './common';
 
-export class JiraProjectVersions extends JiraConverter {
+export class ProjectVersions extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Release',
     'tms_ProjectReleaseRelationship',
@@ -18,7 +18,7 @@ export class JiraProjectVersions extends JiraConverter {
   private static readonly projectsStream = new StreamName('jira', 'projects');
 
   override get dependencies(): ReadonlyArray<StreamName> {
-    return [JiraProjectVersions.projectsStream];
+    return [ProjectVersions.projectsStream];
   }
 
   async convert(
@@ -41,7 +41,7 @@ export class JiraProjectVersions extends JiraConverter {
       },
     ];
     const project = ctx.get(
-      JiraProjectVersions.projectsStream.asString,
+      ProjectVersions.projectsStream.asString,
       String(projectVersion.projectId)
     );
     if (project) {

--- a/destinations/faros-destination/src/converters/jira/projects.ts
+++ b/destinations/faros-destination/src/converters/jira/projects.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
-export class JiraProjects extends JiraConverter {
+export class Projects extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Project',
     'tms_TaskBoard',

--- a/destinations/faros-destination/src/converters/jira/pull_requests.ts
+++ b/destinations/faros-destination/src/converters/jira/pull_requests.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
 // Required as dependency by Issues converter
-export class JiraPullRequests extends JiraConverter {
+export class PullRequests extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [];
 
   async convert(

--- a/destinations/faros-destination/src/converters/jira/sprint_issues.ts
+++ b/destinations/faros-destination/src/converters/jira/sprint_issues.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
 // Required as dependency Sprints converter
-export class JiraSprintIssues extends JiraConverter {
+export class SprintIssues extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [];
 
   async convert(

--- a/destinations/faros-destination/src/converters/jira/sprints.ts
+++ b/destinations/faros-destination/src/converters/jira/sprints.ts
@@ -18,7 +18,7 @@ import {
 } from '../converter';
 import {JiraCommon, JiraConverter, SprintIssue} from './common';
 
-export class JiraSprints extends JiraConverter {
+export class Sprints extends JiraConverter {
   private logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Sprint'];
@@ -36,11 +36,11 @@ export class JiraSprints extends JiraConverter {
   private sprintIssueRecords?: Dictionary<SprintIssue[], number>;
 
   override get dependencies(): ReadonlyArray<StreamName> {
-    return [JiraSprints.issueFieldsStream, JiraSprints.sprintIssuesStream];
+    return [Sprints.issueFieldsStream, Sprints.sprintIssuesStream];
   }
 
   private static getFieldIdsByName(ctx: StreamContext): Dictionary<string[]> {
-    const records = ctx.getAll(JiraSprints.issueFieldsStream.asString);
+    const records = ctx.getAll(Sprints.issueFieldsStream.asString);
     return invertBy(
       pickBy(
         mapValues(records, (r) => r.record.data.name as string),
@@ -52,7 +52,7 @@ export class JiraSprints extends JiraConverter {
   private static getSprintIssueRecords(
     ctx: StreamContext
   ): Dictionary<SprintIssue[], number> {
-    const records = ctx.getAll(JiraSprints.sprintIssuesStream.asString);
+    const records = ctx.getAll(Sprints.sprintIssuesStream.asString);
     return groupBy(
       Object.values(records).map((r) => r.record.data as SprintIssue),
       (si) => si.sprintId
@@ -85,10 +85,10 @@ export class JiraSprints extends JiraConverter {
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const sprint = record.record.data;
     if (!this.pointsFieldIdsByName) {
-      this.pointsFieldIdsByName = JiraSprints.getFieldIdsByName(ctx);
+      this.pointsFieldIdsByName = Sprints.getFieldIdsByName(ctx);
     }
     if (!this.sprintIssueRecords) {
-      this.sprintIssueRecords = JiraSprints.getSprintIssueRecords(ctx);
+      this.sprintIssueRecords = Sprints.getSprintIssueRecords(ctx);
     }
 
     let completedPoints = 0;

--- a/destinations/faros-destination/src/converters/jira/users.ts
+++ b/destinations/faros-destination/src/converters/jira/users.ts
@@ -3,7 +3,7 @@ import {AirbyteLogger, AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
-export class JiraUsers extends JiraConverter {
+export class Users extends JiraConverter {
   private logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_User'];

--- a/destinations/faros-destination/src/converters/jira/workflow_statuses.ts
+++ b/destinations/faros-destination/src/converters/jira/workflow_statuses.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {JiraConverter} from './common';
 
 // Required as dependency by Issues converter
-export class JiraWorkflowStatuses extends JiraConverter {
+export class WorkflowStatuses extends JiraConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [];
 
   async convert(

--- a/destinations/faros-destination/src/converters/jsonata.ts
+++ b/destinations/faros-destination/src/converters/jsonata.ts
@@ -11,6 +11,8 @@ import {
 
 /** Record converter to convert records using provided JSONata expression */
 export class JSONataConverter extends Converter {
+  source = 'JSONata';
+
   constructor(
     private readonly jsonataExpr: jsonata.Expression,
     readonly destinationModels: ReadonlyArray<DestinationModel>

--- a/destinations/faros-destination/src/converters/okta/common.ts
+++ b/destinations/faros-destination/src/converters/okta/common.ts
@@ -4,6 +4,8 @@ import {Converter} from '../converter';
 
 /** Okta converter base */
 export abstract class OktaConverter extends Converter {
+  source = 'Okta';
+
   /** Almost every Okta record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/okta/groups.ts
+++ b/destinations/faros-destination/src/converters/okta/groups.ts
@@ -4,7 +4,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {OktaConverter} from './common';
 import {Group} from './models';
 
-export class OktaGroups extends OktaConverter {
+export class Groups extends OktaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'org_Team',
     'org_TeamMembership',

--- a/destinations/faros-destination/src/converters/okta/users.ts
+++ b/destinations/faros-destination/src/converters/okta/users.ts
@@ -6,7 +6,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {OktaConverter} from './common';
 import {User} from './models';
 
-export class OktaUsers extends OktaConverter {
+export class Users extends OktaConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'identity_Identity',
     'org_Department',

--- a/destinations/faros-destination/src/converters/okta_faros/common.ts
+++ b/destinations/faros-destination/src/converters/okta_faros/common.ts
@@ -1,0 +1,5 @@
+import {Converter} from '../converter';
+
+export abstract class OktaFarosConverter extends Converter {
+  source = 'Okta_Faros';
+}

--- a/destinations/faros-destination/src/converters/okta_faros/groups.ts
+++ b/destinations/faros-destination/src/converters/okta_faros/groups.ts
@@ -1,18 +1,14 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
-import {OktaGroups} from '../okta/groups';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {Groups as OktaGroups} from '../okta/groups';
+import {OktaFarosConverter} from './common';
 
 /**
  * This converter is identical to OktaGroups for Okta community source.
  * It is here to support the Okta source we developed at Faros.
  */
-export class OktaFarosGroups extends Converter {
+export class Groups extends OktaFarosConverter {
   private alias = new OktaGroups();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> =

--- a/destinations/faros-destination/src/converters/okta_faros/users.ts
+++ b/destinations/faros-destination/src/converters/okta_faros/users.ts
@@ -1,18 +1,14 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
-import {OktaUsers} from '../okta/users';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {Users as OktaUsers} from '../okta/users';
+import {OktaFarosConverter} from './common';
 
 /**
  * This converter is identical to OktaUsers for Okta community source.
  * It is here to support the Okta source we developed at Faros.
  */
-export class OktaFarosUsers extends Converter {
+export class Users extends OktaFarosConverter {
   private alias = new OktaUsers();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> =

--- a/destinations/faros-destination/src/converters/pagerduty/common.ts
+++ b/destinations/faros-destination/src/converters/pagerduty/common.ts
@@ -28,6 +28,8 @@ interface PagerdutyConfig {
 
 /** PagerDuty converter base */
 export abstract class PagerdutyConverter extends Converter {
+  source = 'PagerDuty';
+
   /** Almost every Pagerduty record have id property. Function will be
    * override if record doesn't have id property.
    */

--- a/destinations/faros-destination/src/converters/pagerduty/incident_log_entries.ts
+++ b/destinations/faros-destination/src/converters/pagerduty/incident_log_entries.ts
@@ -16,7 +16,7 @@ enum IncidentEventTypeCategory {
   Custom = 'Custom',
 }
 
-export class PagerdutyIncidentLogEntries extends PagerdutyConverter {
+export class IncidentLogEntries extends PagerdutyConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'ims_IncidentEvent',
   ];

--- a/destinations/faros-destination/src/converters/pagerduty/incidents.ts
+++ b/destinations/faros-destination/src/converters/pagerduty/incidents.ts
@@ -20,7 +20,7 @@ interface Acknowledgement {
   acknowledger: PagerdutyObject;
 }
 
-export class PagerdutyIncidents extends PagerdutyConverter {
+export class Incidents extends PagerdutyConverter {
   private readonly logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/pagerduty/priorities_resource.ts
+++ b/destinations/faros-destination/src/converters/pagerduty/priorities_resource.ts
@@ -25,7 +25,7 @@ interface Priority extends PagerdutyObject {
   readonly updated_at: string; // date-time
 }
 
-export class PagerdutyPrioritiesResource extends PagerdutyConverter {
+export class PrioritiesResource extends PagerdutyConverter {
   private readonly logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/pagerduty/users.ts
+++ b/destinations/faros-destination/src/converters/pagerduty/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {PagerdutyConverter} from './common';
 
-export class PagerdutyUsers extends PagerdutyConverter {
+export class Users extends PagerdutyConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['ims_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/phabricator/commits.ts
+++ b/destinations/faros-destination/src/converters/phabricator/commits.ts
@@ -1,15 +1,10 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-feeds-sdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
-import {PhabricatorCommon} from './common';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {PhabricatorCommon, PhabricatorConverter} from './common';
 
-export class PhabricatorCommits extends Converter {
+export class Commits extends PhabricatorConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_BranchCommitAssociation',
     'vcs_Commit',

--- a/destinations/faros-destination/src/converters/phabricator/common.ts
+++ b/destinations/faros-destination/src/converters/phabricator/common.ts
@@ -113,6 +113,8 @@ export class PhabricatorCommon {
 
 /** Phabricator converter base */
 export abstract class PhabricatorConverter extends Converter {
+  source = 'Phabricator';
+
   /** Most of Phabricator records should have phid property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.phid;

--- a/destinations/faros-destination/src/converters/phabricator/repositories.ts
+++ b/destinations/faros-destination/src/converters/phabricator/repositories.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {PhabricatorCommon, PhabricatorConverter} from './common';
 
-export class PhabricatorRepositories extends PhabricatorConverter {
+export class Repositories extends PhabricatorConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Repository',
     'vcs_Organization',

--- a/destinations/faros-destination/src/converters/phabricator/revisions.ts
+++ b/destinations/faros-destination/src/converters/phabricator/revisions.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {PhabricatorCommon, PhabricatorConverter} from './common';
 
-export class PhabricatorRevisions extends PhabricatorConverter {
+export class Revisions extends PhabricatorConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequest',
     'vcs_PullRequestReview',

--- a/destinations/faros-destination/src/converters/phabricator/users.ts
+++ b/destinations/faros-destination/src/converters/phabricator/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {PhabricatorCommon, PhabricatorConverter} from './common';
 
-export class PhabricatorUsers extends PhabricatorConverter {
+export class Users extends PhabricatorConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Membership',
     'vcs_User',

--- a/destinations/faros-destination/src/converters/shortcut/common.ts
+++ b/destinations/faros-destination/src/converters/shortcut/common.ts
@@ -65,6 +65,8 @@ export class ShortcutCommon {
 
 /** Shortcut converter base */
 export abstract class ShortcutConverter extends Converter {
+  source = 'Shortcut';
+
   /** Almost every Shortcut record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/shortcut/epics.ts
+++ b/destinations/faros-destination/src/converters/shortcut/epics.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {ShortcutCommon, ShortcutConverter} from './common';
 import {Epic} from './models';
-export class ShortcutEpics extends ShortcutConverter {
+export class Epics extends ShortcutConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Epic'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/shortcut/iterations.ts
+++ b/destinations/faros-destination/src/converters/shortcut/iterations.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {ShortcutCommon, ShortcutConverter} from './common';
 import {Iteration} from './models';
-export class ShortcutIterations extends ShortcutConverter {
+export class Iterations extends ShortcutConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Sprint'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/shortcut/members.ts
+++ b/destinations/faros-destination/src/converters/shortcut/members.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {ShortcutConverter} from './common';
 import {Member} from './models';
-export class ShortcutMembers extends ShortcutConverter {
+export class Members extends ShortcutConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/shortcut/projects.ts
+++ b/destinations/faros-destination/src/converters/shortcut/projects.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {ShortcutConverter} from './common';
 import {Project} from './models';
-export class ShortcutProjects extends ShortcutConverter {
+export class Projects extends ShortcutConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_Project',
     'tms_TaskBoard',

--- a/destinations/faros-destination/src/converters/shortcut/stories.ts
+++ b/destinations/faros-destination/src/converters/shortcut/stories.ts
@@ -5,7 +5,7 @@ import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {ShortcutCommon, ShortcutConverter} from './common';
 import {Story} from './models';
 
-export class ShortcutStories extends ShortcutConverter {
+export class Stories extends ShortcutConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'tms_TaskTag',
     'tms_Label',

--- a/destinations/faros-destination/src/converters/squadcast/common.ts
+++ b/destinations/faros-destination/src/converters/squadcast/common.ts
@@ -179,6 +179,8 @@ export class SquadcastCommon {
 
 /** SquadCast converter base */
 export abstract class SquadcastConverter extends Converter {
+  source = 'SquadCast';
+
   /** Almost every SquadCast record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/squadcast/events.ts
+++ b/destinations/faros-destination/src/converters/squadcast/events.ts
@@ -4,7 +4,7 @@ import {Utils} from 'faros-feeds-sdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {Event, IncidentEventTypeCategory, SquadcastConverter} from './common';
 
-export class SquadcastEvents extends SquadcastConverter {
+export class Events extends SquadcastConverter {
   id(record: AirbyteRecord): string {
     return record?.record?.data?.alert_source_id;
   }

--- a/destinations/faros-destination/src/converters/squadcast/incidents.ts
+++ b/destinations/faros-destination/src/converters/squadcast/incidents.ts
@@ -13,7 +13,7 @@ import {
   SquadcastConverter,
 } from './common';
 
-export class SquadcastIncidents extends SquadcastConverter {
+export class Incidents extends SquadcastConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'compute_Application',
     'ims_Incident',

--- a/destinations/faros-destination/src/converters/squadcast/services.ts
+++ b/destinations/faros-destination/src/converters/squadcast/services.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {Service, SquadcastConverter} from './common';
 
-export class SquadcastServices extends SquadcastConverter {
+export class Services extends SquadcastConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'compute_Application',
   ];

--- a/destinations/faros-destination/src/converters/squadcast/users.ts
+++ b/destinations/faros-destination/src/converters/squadcast/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {SquadcastConverter, User} from './common';
 
-export class SquadcastUsers extends SquadcastConverter {
+export class Users extends SquadcastConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['ims_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/statuspage/common.ts
+++ b/destinations/faros-destination/src/converters/statuspage/common.ts
@@ -96,6 +96,8 @@ export interface IncidentSeverity {
 
 /** StatusPage converter base */
 export abstract class StatuspageConverter extends Converter {
+  source = 'StatusPage';
+
   /** Every StatusPage record have id property */
   id(record: AirbyteRecord): any {
     return record?.record?.data?.id;

--- a/destinations/faros-destination/src/converters/statuspage/incident_updates.ts
+++ b/destinations/faros-destination/src/converters/statuspage/incident_updates.ts
@@ -9,7 +9,7 @@ import {
   StatuspageIncidentStatus,
 } from './common';
 
-export class StatuspageIncidentUpdates extends StatuspageConverter {
+export class IncidentUpdates extends StatuspageConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'ims_IncidentEvent',
   ];

--- a/destinations/faros-destination/src/converters/statuspage/incidents.ts
+++ b/destinations/faros-destination/src/converters/statuspage/incidents.ts
@@ -14,7 +14,7 @@ import {
   StatuspageIncidentStatus,
 } from './common';
 
-export class StatuspageIncidents extends StatuspageConverter {
+export class Incidents extends StatuspageConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'compute_Application',
     'ims_Incident',

--- a/destinations/faros-destination/src/converters/statuspage/users.ts
+++ b/destinations/faros-destination/src/converters/statuspage/users.ts
@@ -3,7 +3,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {StatuspageConverter} from './common';
 
-export class StatuspageUsers extends StatuspageConverter {
+export class Users extends StatuspageConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['ims_User'];
 
   async convert(

--- a/destinations/faros-destination/src/converters/victorops/common.ts
+++ b/destinations/faros-destination/src/converters/victorops/common.ts
@@ -10,6 +10,8 @@ interface VictoropsConfig {
 }
 
 export abstract class VictoropsConverter extends Converter {
+  source = 'VictorOps';
+
   protected victoropsConfig(ctx: StreamContext): VictoropsConfig {
     return ctx.config.source_specific_configs?.victorops ?? {};
   }

--- a/destinations/faros-destination/src/converters/victorops/incidents.ts
+++ b/destinations/faros-destination/src/converters/victorops/incidents.ts
@@ -41,7 +41,7 @@ type IncidentPhase =
   | 'acknowledged'
   | 'resolved';
 
-export class VictoropsIncidents extends VictoropsConverter {
+export class Incidents extends VictoropsConverter {
   private readonly logger = new AirbyteLogger();
 
   readonly destinationModels: ReadonlyArray<DestinationModel> = [

--- a/destinations/faros-destination/src/converters/victorops/teams.ts
+++ b/destinations/faros-destination/src/converters/victorops/teams.ts
@@ -1,13 +1,9 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {VictoropsConverter} from './common';
 
-export class VictoropsTeams extends Converter {
+export class Teams extends VictoropsConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['ims_Team'];
 
   id(record: AirbyteRecord): any {

--- a/destinations/faros-destination/src/converters/victorops/users.ts
+++ b/destinations/faros-destination/src/converters/victorops/users.ts
@@ -1,13 +1,9 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 
-import {
-  Converter,
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-} from '../converter';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {VictoropsConverter} from './common';
 
-export class VictoropsUsers extends Converter {
+export class Users extends VictoropsConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['ims_User'];
 
   id(record: AirbyteRecord): any {

--- a/destinations/faros-destination/test/converter-registry.test.ts
+++ b/destinations/faros-destination/test/converter-registry.test.ts
@@ -40,9 +40,6 @@ describe('converter registry', () => {
       if (converter && converter.convert) {
         const streamName = converter.streamName.asString.toLowerCase();
 
-        // Skip Okta Faros converter aliases
-        if (streamName.startsWith('okta__faros')) continue;
-
         expect(streamName).toBe(stream.asString.toLowerCase());
         expect(converter.dependencies.length).toBeGreaterThanOrEqual(0);
         expect(converter.destinationModels.length).toBeGreaterThanOrEqual(0);

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.51",
+  "version": "0.1.52",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/sources/agileaccelerator-source/package.json
+++ b/sources/agileaccelerator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agileaccelerator-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "AgileAccelerator Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/backlog-source/package.json
+++ b/sources/backlog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Backlog Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/bitbucket-source/package.json
+++ b/sources/bitbucket-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucket-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Bitbucket Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "axios": "^0.26.0",
     "bitbucket": "^2.7.0",
     "bottleneck": "^2.19.5",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "faros-feeds-sdk": "^0.9.7",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/customer-io-source/package.json
+++ b/sources/customer-io-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customer-io-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Customer.io Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/datadog-source/package.json
+++ b/sources/datadog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "DataDog Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@datadog/datadog-api-client": "^1.0.0-beta.8",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/docker-source/package.json
+++ b/sources/docker-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Docker Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Example Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/googlecalendar-source/package.json
+++ b/sources/googlecalendar-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlecalendar-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "GoogleCalendar Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "faros-feeds-sdk": "^0.9.7",
     "googleapis": "^95.0.0",
     "verror": "^1.10.1"

--- a/sources/harness-source/package.json
+++ b/sources/harness-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Harness Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "graphql-request": "^4.0.0",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"

--- a/sources/jenkins-source/package.json
+++ b/sources/jenkins-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Jenkins Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "jenkins": "^0.28.1",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/okta-source/package.json
+++ b/sources/okta-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Okta Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "parse-link-header": "2.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/pagerduty-source/package.json
+++ b/sources/pagerduty-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "PagerDuty Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@pagerduty/pdjs": "^2.2.3",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "faros-feeds-sdk": "^0.9.7",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"

--- a/sources/phabricator-source/package.json
+++ b/sources/phabricator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phabricator-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Phabricator Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "commander": "^9.0.0",
     "condoit": "^2.1.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "moment": "^2.29.1",
     "verror": "^1.10.1"
   },

--- a/sources/shortcut-source/package.json
+++ b/sources/shortcut-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Shortcut Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "axios": "^0.26.0",
     "clubhouse-lib": "^0.13.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/squadcast-source/package.json
+++ b/sources/squadcast-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squadcast-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "SquadCast Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/statuspage-source/package.json
+++ b/sources/statuspage-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statuspage-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "StatusPage Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "statuspage.io": "^3.1.0",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/victorops-source/package.json
+++ b/sources/victorops-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victorops-source",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "VictorOps Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios-retry": "^3.2.4",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.51",
+    "faros-airbyte-cdk": "^0.1.52",
     "luxon": "^2.0.2",
     "verror": "^1.10.1",
     "victorops-api-client": "^1.0.2"


### PR DESCRIPTION
## Description

- Converter class names should only be the name of the stream itself, without the strictly capitalized "source prefix", e.g. `Issues` instead of `GithubIssues`
- Base Converter class has an additional required property: `source`, that takes the place of the strictly capitalized prefix that is now removed. This string should follow the casing of the actual source system, e.g. "GitHub" not "Github".

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
