### PR TITLE
Fix Docker image path for Faros Destination

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-faros-destination",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Faros Destination for Airbyte",
   "keywords": [
     "airbyte",
@@ -36,7 +36,7 @@
     "analytics-node": "^6.0.0",
     "axios": "^0.26.0",
     "date-format": "^4.0.3",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "faros-feeds-sdk": "^0.9.11",
     "fs-extra": "^10.0.0",
     "git-url-parse": "^11.6.0",

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.55",
+  "version": "0.1.56",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/scripts/publish-connector.sh
+++ b/scripts/publish-connector.sh
@@ -5,22 +5,28 @@ if [ -z "$1" ]; then
 fi
 connector_path=$1
 
-image="farosai/airbyte-$(echo $connector_path | cut -f2 -d'/')"
-echo image name: $image
+org="farosai"
+connector_name="$(echo $connector_path | cut -f2 -d'/')"
+prefix="airbyte-"
+if [[ "$connector_name" = $prefix* ]]; then
+  image="$org/$connector_name"
+else
+  image="$org/$prefix$connector_name"
+fi
+
 latest_tag="$image:latest"
 connector_version=$(jq -r '.version' < ${connector_path}package.json)
 version_tag="$image:$connector_version"
-echo version tag: $version_tag
+echo "Image version tag: $version_tag"
 
 docker manifest inspect $version_tag > /dev/null
-if [ "$?" == 1 ]
-then
+if [ "$?" == 1 ]; then
   docker build . \
     --build-arg path=$connector_path \
     -t $latest_tag \
     -t $version_tag \
     --label "io.airbyte.version=$connector_version" \
     --label "io.airbyte.name=$image"
-  docker push $latest_tag
-  docker push $version_tag
+  # docker push $latest_tag
+  # docker push $version_tag
 fi

--- a/scripts/publish-connector.sh
+++ b/scripts/publish-connector.sh
@@ -27,6 +27,6 @@ if [ "$?" == 1 ]; then
     -t $version_tag \
     --label "io.airbyte.version=$connector_version" \
     --label "io.airbyte.name=$image"
-  # docker push $latest_tag
-  # docker push $version_tag
+  docker push $latest_tag
+  docker push $version_tag
 fi

--- a/sources/agileaccelerator-source/package.json
+++ b/sources/agileaccelerator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agileaccelerator-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "AgileAccelerator Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/backlog-source/package.json
+++ b/sources/backlog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Backlog Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/bitbucket-source/package.json
+++ b/sources/bitbucket-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucket-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Bitbucket Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "axios": "^0.26.0",
     "bitbucket": "^2.7.0",
     "bottleneck": "^2.19.5",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/customer-io-source/package.json
+++ b/sources/customer-io-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customer-io-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Customer.io Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/datadog-source/package.json
+++ b/sources/datadog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "DataDog Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@datadog/datadog-api-client": "^1.0.0-beta.8",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/docker-source/package.json
+++ b/sources/docker-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Docker Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Example Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/googlecalendar-source/package.json
+++ b/sources/googlecalendar-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlecalendar-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "GoogleCalendar Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "googleapis": "^95.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/harness-source/package.json
+++ b/sources/harness-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Harness Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "graphql-request": "^4.0.0",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"

--- a/sources/jenkins-source/package.json
+++ b/sources/jenkins-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Jenkins Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "jenkins": "^0.28.1",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/okta-source/package.json
+++ b/sources/okta-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Okta Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "parse-link-header": "2.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/pagerduty-source/package.json
+++ b/sources/pagerduty-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "PagerDuty Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@pagerduty/pdjs": "^2.2.3",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"
   },

--- a/sources/phabricator-source/package.json
+++ b/sources/phabricator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phabricator-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Phabricator Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "commander": "^9.0.0",
     "condoit": "^2.1.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "moment": "^2.29.1",
     "verror": "^1.10.1"
   },

--- a/sources/shortcut-source/package.json
+++ b/sources/shortcut-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Shortcut Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "axios": "^0.26.0",
     "clubhouse-lib": "^0.13.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/squadcast-source/package.json
+++ b/sources/squadcast-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squadcast-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "SquadCast Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/statuspage-source/package.json
+++ b/sources/statuspage-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statuspage-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "StatusPage Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "statuspage.io": "^3.1.0",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/victorops-source/package.json
+++ b/sources/victorops-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victorops-source",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "VictorOps Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios-retry": "^3.2.4",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.55",
+    "faros-airbyte-cdk": "^0.1.56",
     "luxon": "^2.0.2",
     "verror": "^1.10.1",
     "victorops-api-client": "^1.0.2"


### PR DESCRIPTION
## Description

Instead of `docker.io/farosai/airbyte-airbyte-faros-destination:x.y.z` it should be `docker.io/farosai/airbyte-faros-destination:x.y.z`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
