### PR TITLE
FAI-1665 - Added ConverterTyped and DestinationRecordTyped

### DIFF
--- a/destinations/airbyte-faros-destination/README.md
+++ b/destinations/airbyte-faros-destination/README.md
@@ -57,8 +57,8 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Converter, DestinationModel, DestinationRecord,FarosDestinationRunner,StreamContext} from 'airbyte-faros-destination'
 
 class Builds extends Converter {
-  source: string = 'CustomSource'
-  destinationModels: ReadonlyArray<DestinationModel> = ['cicd_Build'];
+  source = 'CustomSource'
+  destinationModels = ['cicd_Build'];
 
   id(record: AirbyteRecord): string {
     return record.record.data.id;
@@ -66,7 +66,7 @@ class Builds extends Converter {
 
   async convert(
     record: AirbyteRecord,
-    _ctx: StreamContext
+    ctx: StreamContext
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const build = record.record.data
     return [
@@ -83,21 +83,21 @@ class Builds extends Converter {
     ];
   }
 }
+
 class Pipelines extends Converter {
   // similar to the Builds in the example above
   ...
 }
 
-// main entry point
+// Main entry point
 export function mainCommand(): Command {
   const destinationRunner = new FarosDestinationRunner();
 
-  // Register your custom converter(s)
+// Register your custom converter(s)
   destinationRunner.registerConverters(
     new Builds(),
     new Pipelines()
   );
-
   return destinationRunner.program;
 }
 ```

--- a/destinations/airbyte-faros-destination/README.md
+++ b/destinations/airbyte-faros-destination/README.md
@@ -93,7 +93,7 @@ class Pipelines extends Converter {
 export function mainCommand(): Command {
   const destinationRunner = new FarosDestinationRunner();
 
-// Register your custom converter(s)
+  // Register your custom converter(s)
   destinationRunner.registerConverters(
     new Builds(),
     new Pipelines()

--- a/destinations/airbyte-faros-destination/src/converters/converter-registry.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter-registry.ts
@@ -64,7 +64,7 @@ export class ConverterRegistry {
   }
 
   /**
-   * Add a convertor to the registory.
+   * Add a convertor to the registry.
    */
   static addConverter(converter: Converter): void {
     const name = converter.streamName.asString;

--- a/destinations/airbyte-faros-destination/src/converters/converter.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter.ts
@@ -6,7 +6,7 @@ import {Dictionary} from 'ts-essentials';
 import {VError} from 'verror';
 
 /** Airbyte -> Faros record converter */
-export abstract class Converter {
+export abstract class ConverterTyped<R> {
   private stream: StreamName;
 
   /** Name of the source system that records were fetched from (e.g. GitHub) **/
@@ -38,8 +38,9 @@ export abstract class Converter {
   abstract convert(
     record: AirbyteRecord,
     ctx: StreamContext
-  ): Promise<ReadonlyArray<DestinationRecord>>;
+  ): Promise<ReadonlyArray<DestinationRecordTyped<R>>>;
 }
+export abstract class Converter extends ConverterTyped<Dictionary<any>> {}
 
 // Helper function for reading object type configurations that
 // may be inputted as proper JSON via API or stringified JSON via Airbyte UI
@@ -150,10 +151,11 @@ export class StreamName {
  *   }
  * }
  */
-export type DestinationRecord = {
+export type DestinationRecordTyped<R extends Dictionary<any>> = {
   readonly model: DestinationModel;
-  readonly record: Dictionary<any>;
+  readonly record: R;
 };
+export type DestinationRecord = DestinationRecordTyped<Dictionary<any>>;
 
 /** Faros destination model name, e.g identity_Identity, vcs_Commit */
 export type DestinationModel = string;


### PR DESCRIPTION
## Description

Added ConverterTyped and DestinationRecordTyped to allow creating typed converters.

Below is an example of a customer converter typed with `FooBar`:

```typescript
interface FooBar { foo: string; bar: number; }

class CustomConverter extends ConverterTyped<FooBar> {
  source = 'Custom';
  destinationModels = ['test_Model'];

  id(record: AirbyteRecord): string { return record.record.data.id; }

  async convert(
       record: AirbyteRecord,
       ctx: StreamContext
  ): Promise<ReadonlyArray<DestinationRecordTyped<FooBar>>> {
    const data = record.record.data;
    return [{ model: 'test_Model', record: { foo: String(data.id), bar: 123 }}];
  }
}
```

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Issues
FAI-1665
