### PR TITLE
changes for fetch max user and groups in single call and also remove …

### DIFF
--- a/sources/azureactivedirectory-source/src/azureactivedirectory.ts
+++ b/sources/azureactivedirectory-source/src/azureactivedirectory.ts
@@ -105,7 +105,7 @@ export class AzureActiveDirectory {
 
   async *getUsers(): AsyncGenerator<User> {
     const res = await this.httpClient.get<UserResponse>(
-      'users/?$select=Department,postalCode,createdDateTime,identities,streetAddress&$top=999'
+      'users/?$select=department,postalCode,createdDateTime,identities,streetAddress&$top=999'
     );
     for (const item of res.data.value) {
       try {

--- a/sources/azureactivedirectory-source/src/azureactivedirectory.ts
+++ b/sources/azureactivedirectory-source/src/azureactivedirectory.ts
@@ -104,9 +104,19 @@ export class AzureActiveDirectory {
   }
 
   async *getUsers(): AsyncGenerator<User> {
-    const res = await this.httpClient.get<UserResponse>(
-      'users/?$select=department,postalCode,createdDateTime,identities,streetAddress&$top=999'
-    );
+    const maxResults = 999;
+    const res = await this.httpClient.get<UserResponse>('users', {
+      params: {
+        $select: [
+          'department',
+          'postalCode',
+          'createdDateTime',
+          'identities',
+          'streetAddress',
+        ],
+        $top: maxResults,
+      },
+    });
     for (const item of res.data.value) {
       try {
         const managerItem = await this.httpClient.get<User>(
@@ -123,7 +133,12 @@ export class AzureActiveDirectory {
   }
 
   async *getGroups(): AsyncGenerator<Group> {
-    const res = await this.httpClient.get<GroupResponse>('groups/?$top=999');
+    const maxResults = 999;
+    const res = await this.httpClient.get<GroupResponse>('groups', {
+      params: {
+        $top: maxResults,
+      },
+    });
     for (const item of res.data.value) {
       const memberItems = await this.httpClient.get<UserResponse>(
         `groups/${item.id}/members`

--- a/sources/azureactivedirectory-source/src/azureactivedirectory.ts
+++ b/sources/azureactivedirectory-source/src/azureactivedirectory.ts
@@ -118,7 +118,6 @@ export class AzureActiveDirectory {
       } catch (error) {
         this.logger.error(error.toString());
       }
-      console.log(item);
       yield item;
     }
   }

--- a/sources/azureactivedirectory-source/src/azureactivedirectory.ts
+++ b/sources/azureactivedirectory-source/src/azureactivedirectory.ts
@@ -1,5 +1,6 @@
 import axios, {AxiosInstance} from 'axios';
 import {AirbyteLogger, wrapApiError} from 'faros-airbyte-cdk/lib';
+import formatLinkHeader from 'format-link-header';
 import {VError} from 'verror';
 
 import {
@@ -110,7 +111,7 @@ export class AzureActiveDirectory {
         const res = await this.httpClient.get<T[]>(path, param);
         const linkHeader = res.data['@odata.nextLink'];
         if (linkHeader) {
-          after = linkHeader.split('$skiptoken=').pop();
+          after = new URL(linkHeader).searchParams.get('$skiptoken');
           param['params']['$skiptoken'] = after;
         } else {
           after = null;

--- a/sources/azureactivedirectory-source/src/azureactivedirectory.ts
+++ b/sources/azureactivedirectory-source/src/azureactivedirectory.ts
@@ -131,8 +131,7 @@ export class AzureActiveDirectory {
     } while (after);
   }
 
-  async *getUsers(): AsyncGenerator<User> {
-    const maxResults = 999;
+  async *getUsers(maxResults = 999): AsyncGenerator<User> {
     for await (const user of this.paginate<User>('users', {
       params: {
         $select: [
@@ -159,8 +158,7 @@ export class AzureActiveDirectory {
     }
   }
 
-  async *getGroups(): AsyncGenerator<Group> {
-    const maxResults = 999;
+  async *getGroups(maxResults = 999): AsyncGenerator<Group> {
     for await (const group of this.paginate<Group>('groups', {
       params: {
         $top: maxResults,

--- a/sources/azureactivedirectory-source/test/index.test.ts
+++ b/sources/azureactivedirectory-source/test/index.test.ts
@@ -79,7 +79,7 @@ describe('index', () => {
       users.push(user);
     }
 
-    expect(fnUsersFunc).toHaveBeenCalledTimes(5);
+    expect(fnUsersFunc).toHaveBeenCalledTimes(1);
     expect(users).toStrictEqual(readTestResourceFile('users.json'));
   });
 

--- a/sources/azureactivedirectory-source/test/index.test.ts
+++ b/sources/azureactivedirectory-source/test/index.test.ts
@@ -79,7 +79,7 @@ describe('index', () => {
       users.push(user);
     }
 
-    expect(fnUsersFunc).toHaveBeenCalledTimes(1);
+    expect(fnUsersFunc).toHaveBeenCalledTimes(3);
     expect(users).toStrictEqual(readTestResourceFile('users.json'));
   });
 


### PR DESCRIPTION
## Description
> changes for fetching max users and groups in a single call and also removing the user-id API call to improve performance.

## Type of change
Bug Fix- Performance Issue

## Related issues
> Fix [#365]() 

Below are the fixes -
1.) Currently, API is not using its full potential and only fetching 100 users and groups which is the default. this is 9 times in comparison with current
2.) inside the getUser function it is making multiple calls to fetch the same user data which I have combined and now getting in a single call. This will make this function from log (2n) to log(n). 


## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
