### PR TITLE
Remove repoSourceFallback

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/jenkins/builds.ts
+++ b/destinations/airbyte-faros-destination/src/converters/jenkins/builds.ts
@@ -4,12 +4,7 @@ import parseGitUrl from 'git-url-parse';
 import {toLower} from 'lodash';
 
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
-import {
-  DEFAULT_REPO_SOURCE_FALL_BACK,
-  JenkinsCommon,
-  JenkinsConverter,
-  RepoSource,
-} from './common';
+import {JenkinsCommon, JenkinsConverter, RepoSource} from './common';
 
 export class Builds extends JenkinsConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
@@ -108,7 +103,7 @@ export class Builds extends JenkinsConverter {
       if (sourceToLower?.includes('bitbucket')) source = RepoSource.BITBUCKET;
       else if (sourceToLower?.includes('gitlab')) source = RepoSource.GITLAB;
       else if (sourceToLower?.includes('github')) source = RepoSource.GITHUB;
-      else source = DEFAULT_REPO_SOURCE_FALL_BACK;
+      else source = RepoSource.VCS;
       repos.push({
         source: source,
         org: realGitUrl.organization,

--- a/destinations/airbyte-faros-destination/src/converters/jenkins/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/jenkins/common.ts
@@ -24,7 +24,6 @@ export enum RepoSource {
   GITLAB = 'GitLab',
   VCS = 'VCS',
 }
-export const DEFAULT_REPO_SOURCE_FALL_BACK = 'repoSourceFallback';
 
 /** Common functions shares across Jenkins converters */
 export class JenkinsCommon {


### PR DESCRIPTION
## Description

If we are not going to allow for a configurable repo source fallback, it should just default to `VCS`.
