### PR TITLE
Revert "Use major version only (#388)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "CDK_VERSION=$CDK_VERSION" >> $GITHUB_ENV
 
       - name: Check tag exists
-        uses: mukunku/tag-exists-action@v1
+        uses: mukunku/tag-exists-action@v1.0.0
         id: check-tag
         with:
           tag: v${{ env.CDK_VERSION }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create tag
         if: steps.check-tag.outputs.exists == 'false'
-        uses: pkgdeps/git-tag-action@v2
+        uses: pkgdeps/git-tag-action@v2.0.1
         with:
           git_commit_sha: ${{ github.sha }}
           git_tag_prefix: v
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Docker login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.14.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit d9e0b6bbb69340ffa18f5915324d10b03127cb16.

## Description

I believe major version only syntax only works for core GitHub actions.
## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
