### PR TITLE
Add trailing slash to connector_path if missing

### DIFF
--- a/scripts/publish-connector.sh
+++ b/scripts/publish-connector.sh
@@ -5,6 +5,8 @@ if [ -z "$1" ]; then
 fi
 connector_path=$1
 
+[[ "${connector_path}" != */ ]] && connector_path="${connector_path}/"
+
 org="farosai"
 connector_name="$(echo $connector_path | cut -f2 -d'/')"
 prefix="airbyte-"


### PR DESCRIPTION
## Description

Add trailing slash to connector_path if missing 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

https://github.com/faros-ai/airbyte-connectors/issues/449