### PR TITLE
FAI-2297: Impacted service information

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -396,6 +396,16 @@
                     "type": "object",
                     "title": "Configuration",
                     "properties": {
+                      "application_mapping": {
+                        "type": "string",
+                        "title": "Application Mapping",
+                        "description": "JSON map of ServiceNow service(s) name, to compute platform specific app name and platform name. Used to reference compute_Application object, from an ims_Incident object.",
+                        "multiline": true,
+                        "default": "{}",
+                        "examples": [
+                          "{ \"Aion\": { \"name\": \"aion\", \"platform\": \"ECS\" } }"
+                        ]
+                      },
                       "default_severity": {
                         "type": "string",
                         "title": "Default Severity",

--- a/destinations/airbyte-faros-destination/src/converters/asana/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/common.ts
@@ -1,4 +1,4 @@
-import {AirbyteRecord} from 'faros-airbyte-cdk/src/protocol';
+import {AirbyteRecord} from 'faros-airbyte-cdk';
 
 import {Converter, DestinationRecord} from '../converter';
 

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/common.ts
@@ -1,6 +1,6 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 
-import {Converter, StreamContext} from '../converter';
+import {Converter, parseObjectConfig, StreamContext} from '../converter';
 
 export enum IncidentSeverityCategory {
   Sev1 = 'Sev1',
@@ -19,7 +19,10 @@ export enum IncidentPriorityCategory {
   Custom = 'Custom',
 }
 
+type ApplicationMapping = Record<string, {name: string; platform?: string}>;
+
 interface ServiceNowConfig {
+  application_mapping?: ApplicationMapping;
   default_severity?: IncidentSeverityCategory;
   default_priority?: IncidentPriorityCategory;
 }
@@ -35,5 +38,14 @@ export abstract class ServiceNowConverter extends Converter {
 
   protected config(ctx: StreamContext): ServiceNowConfig {
     return ctx.config.source_specific_configs?.servicenow ?? {};
+  }
+
+  protected applicationMapping(ctx: StreamContext): ApplicationMapping {
+    return (
+      parseObjectConfig(
+        this.config(ctx)?.application_mapping,
+        'Application Mapping'
+      ) ?? {}
+    );
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
@@ -81,6 +81,33 @@ export class Incidents extends ServiceNowConverter {
       });
     }
 
+    const applicationName = incident.cmdb_ci?.displayValue;
+    if (applicationName) {
+      const applicationMapping = this.applicationMapping(ctx);
+
+      let application = {
+        name: applicationName,
+        platform: '',
+      };
+
+      if (
+        applicationName in applicationMapping &&
+        applicationMapping[applicationName].name
+      ) {
+        const mappedApp = applicationMapping[applicationName];
+        application = {
+          name: mappedApp.name,
+          platform: mappedApp.platform ?? application.platform,
+        };
+      }
+
+      res.push({model: 'compute_Application', record: application});
+      res.push({
+        model: 'ims_IncidentApplicationImpact',
+        record: {incident: incidentKey, application},
+      });
+    }
+
     return res;
   }
 

--- a/sources/servicenow-source/resources/graphQL/listIncidentsQuery.gql
+++ b/sources/servicenow-source/resources/graphQL/listIncidentsQuery.gql
@@ -38,6 +38,10 @@ query listIncidents($pageSize: Int! = 100, $offset: Int! = 0, $queryConditions: 
         sys_updated_on {
           value
         }
+        cmdb_ci {
+          value
+          displayValue
+        }
       }
     }
   }

--- a/sources/servicenow-source/resources/schemas/incident.json
+++ b/sources/servicenow-source/resources/schemas/incident.json
@@ -34,9 +34,6 @@
       "properties": {
         "value": {
           "type": "string"
-        },
-        "displayValue": {
-          "type": "string"
         }
       }
     },
@@ -45,18 +42,12 @@
       "properties": {
         "value": {
           "type": "string"
-        },
-        "displayValue": {
-          "type": "string"
         }
       }
     },
     "state": {
       "type": "object",
       "properties": {
-        "value": {
-          "type": "string"
-        },
         "displayValue": {
           "type": "string"
         }
@@ -98,6 +89,14 @@
       "type": "object",
       "properties": {
         "value": {
+          "type": "string"
+        }
+      }
+    },
+    "cmdb_ci": {
+      "type": "object",
+      "properties": {
+        "displayValue": {
           "type": "string"
         }
       }

--- a/sources/servicenow-source/src/servicenow/models.ts
+++ b/sources/servicenow-source/src/servicenow/models.ts
@@ -32,6 +32,9 @@ export interface Incident {
   readonly sys_updated_on: {
     readonly value: Date;
   };
+  readonly cmdb_ci: {
+    readonly displayValue: string;
+  };
 }
 
 export interface User {

--- a/sources/servicenow-source/src/servicenow/servicenow.ts
+++ b/sources/servicenow-source/src/servicenow/servicenow.ts
@@ -111,7 +111,7 @@ export class ServiceNow {
 
   // Retrieve users that have been modified since last sys_updated_on
   async *getUsers(
-    sys_updated_on = this.cutOff,
+    sys_updated_on?: string,
     pageSize = this.config.page_size ?? DEFAULT_PAGE_SIZE
   ): AsyncGenerator<User, any, any> {
     let offset = 0;

--- a/sources/servicenow-source/test_files/incidents.json
+++ b/sources/servicenow-source/test_files/incidents.json
@@ -35,6 +35,9 @@
     },
     "sys_updated_on": {
       "value": "2022-03-17 19:44:35"
+    },
+    "cmdb_ci": {
+      "displayValue": "Storage Area Network 001"
     }
   },
   {
@@ -73,6 +76,9 @@
     },
     "sys_updated_on": {
       "value": "2022-03-17 20:15:35"
+    },
+    "cmdb_ci": {
+      "displayValue": "Service 1"
     }
   },
   {


### PR DESCRIPTION
## Description

Retrieve service information from ServiceNow incidents. Also pull all users when sys_updated_on not provided rather than falling back to cutoff.

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
