### PR TITLE
Fix PagerDuty spec

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-faros-destination",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Faros Destination for Airbyte",
   "keywords": [
     "airbyte",
@@ -36,7 +36,7 @@
     "analytics-node": "^6.0.0",
     "axios": "^0.26.0",
     "date-format": "^4.0.6",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "faros-feeds-sdk": "^0.10.0",
     "fs-extra": "^10.0.0",
     "git-url-parse": "^11.6.0",

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.93",
+  "version": "0.1.94",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/sources/agileaccelerator-source/package.json
+++ b/sources/agileaccelerator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agileaccelerator-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "AgileAccelerator Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/azure-repos-source/package.json
+++ b/sources/azure-repos-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-repos-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Azure Repos Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/azureactivedirectory-source/package.json
+++ b/sources/azureactivedirectory-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azureactivedirectory-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Azure Active Directory Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/azurepipeline-source/package.json
+++ b/sources/azurepipeline-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azurepipeline-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Azure Pipeline Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/backlog-source/package.json
+++ b/sources/backlog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Backlog Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/bitbucket-source/package.json
+++ b/sources/bitbucket-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucket-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Bitbucket Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "bitbucket": "^2.7.0",
     "bottleneck": "^2.19.5",
     "date-format": "^4.0.6",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/buildkite-source/package.json
+++ b/sources/buildkite-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buildkite-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "BuildKite Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "graphql-request": "^4.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/circleci-source/package.json
+++ b/sources/circleci-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "CircleCI Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/customer-io-source/package.json
+++ b/sources/customer-io-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customer-io-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Customer.io Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/datadog-source/package.json
+++ b/sources/datadog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "DataDog Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@datadog/datadog-api-client": "1.0.0-beta.8",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/docker-source/package.json
+++ b/sources/docker-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Docker Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Example Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/firehydrant-source/package.json
+++ b/sources/firehydrant-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firehydrant-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "BuildKite Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "graphql-request": "^4.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/gitlab-ci-source/package.json
+++ b/sources/gitlab-ci-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-ci-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Gitlab CI Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "@gitbeaker/node": "^35.6.0",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/googlecalendar-source/package.json
+++ b/sources/googlecalendar-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlecalendar-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "GoogleCalendar Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "googleapis": "^100.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/harness-source/package.json
+++ b/sources/harness-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Harness Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "graphql-request": "^4.0.0",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"

--- a/sources/jenkins-source/package.json
+++ b/sources/jenkins-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Jenkins Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "jenkins": "^0.28.1",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/okta-source/package.json
+++ b/sources/okta-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Okta Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "parse-link-header": "2.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/opsgenie-source/package.json
+++ b/sources/opsgenie-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opsgenie-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "OpsGenie Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "graphql-request": "^4.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/pagerduty-source/package.json
+++ b/sources/pagerduty-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "PagerDuty Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@pagerduty/pdjs": "^2.2.4",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"
   },

--- a/sources/pagerduty-source/resources/spec.json
+++ b/sources/pagerduty-source/resources/spec.json
@@ -16,18 +16,18 @@
         "airbyte_secret": true
       },
       "cutoff_days": {
-        "type": "integer",
+        "type": "string",
         "title": "Cutoff Days",
-        "default": 90,
-        "description": "Fetch pipelines updated in the last number of days"
+        "default": "90",
+        "description": "Fetch pipelines updated in the last number of days",
+        "pattern": "^[0-9]+$"
       },
       "page_size": {
-        "type": "integer",
-        "minimum": 1,
-        "maximum": 25,
-        "default": 25,
+        "type": "string",
         "title": "Page Size",
-        "description": "page size to use when querying PagerDuty API"
+        "default": "25",
+        "description": "page size to use when querying PagerDuty API",
+        "pattern": "^([1-9]|[12][0-5])$"
       },
       "incident_log_entries_overview": {
         "type": "boolean",

--- a/sources/pagerduty-source/src/pagerduty.ts
+++ b/sources/pagerduty-source/src/pagerduty.ts
@@ -29,8 +29,8 @@ interface Assignment {
 
 export interface PagerdutyConfig {
   readonly token: string;
-  readonly cutoff_days?: number;
-  readonly page_size?: number;
+  readonly cutoff_days?: string;
+  readonly page_size?: string;
   readonly default_severity?: IncidentSeverityCategory;
   readonly incident_log_entries_overview?: boolean;
 }

--- a/sources/pagerduty-source/src/streams/incidentLogEntries.ts
+++ b/sources/pagerduty-source/src/streams/incidentLogEntries.ts
@@ -47,7 +47,7 @@ export class IncidentLogEntries extends AirbyteStreamBase {
     if (syncMode === SyncMode.INCREMENTAL) {
       const lastSynced = streamState?.lastSynced;
       const cutoffTimestamp = now
-        .minus({days: this.config.cutoff_days || DEFAULT_CUTOFF_DAYS})
+        .minus({days: Number(this.config.cutoff_days) || DEFAULT_CUTOFF_DAYS})
         .toJSDate()
         .toISOString();
       since = lastSynced ? new Date(lastSynced).toISOString() : cutoffTimestamp;
@@ -56,7 +56,7 @@ export class IncidentLogEntries extends AirbyteStreamBase {
     yield* pagerduty.getIncidentLogEntries(
       since,
       until,
-      this.config.page_size,
+      Number(this.config.page_size),
       this.config.incident_log_entries_overview
     );
   }

--- a/sources/pagerduty-source/src/streams/incidents.ts
+++ b/sources/pagerduty-source/src/streams/incidents.ts
@@ -43,14 +43,14 @@ export class Incidents extends AirbyteStreamBase {
 
     const now = DateTime.now();
     const cutoffTimestamp = now
-      .minus({days: this.config.cutoff_days || DEFAULT_CUTOFF_DAYS})
+      .minus({days: Number(this.config.cutoff_days) || DEFAULT_CUTOFF_DAYS})
       .toJSDate();
     const since =
       syncMode === SyncMode.INCREMENTAL
         ? streamState?.lastSynced ?? cutoffTimestamp.toISOString()
         : undefined;
 
-    yield* pagerduty.getIncidents(since, this.config.page_size);
+    yield* pagerduty.getIncidents(since, Number(this.config.page_size));
   }
 
   getUpdatedState(

--- a/sources/phabricator-source/package.json
+++ b/sources/phabricator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phabricator-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Phabricator Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "commander": "^9.0.0",
     "condoit": "^2.1.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "moment": "^2.29.1",
     "verror": "^1.10.1"
   },

--- a/sources/servicenow-source/package.json
+++ b/sources/servicenow-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servicenow-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "ServiceNow Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/shortcut-source/package.json
+++ b/sources/shortcut-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Shortcut Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "axios": "^0.26.0",
     "clubhouse-lib": "^0.13.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/squadcast-source/package.json
+++ b/sources/squadcast-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squadcast-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "SquadCast Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/statuspage-source/package.json
+++ b/sources/statuspage-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statuspage-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Statuspage Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "statuspage.io": "^3.1.0",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/victorops-source/package.json
+++ b/sources/victorops-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victorops-source",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "VictorOps Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios-retry": "^3.2.4",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.93",
+    "faros-airbyte-cdk": "^0.1.94",
     "luxon": "^2.0.2",
     "verror": "^1.10.1",
     "victorops-api-client": "^1.0.2"


### PR DESCRIPTION
## Description

Cutoff days and page_size fields in spec currently require `integer`, however when you change these default values in the airbyte source spec, it fails the schema check as airbyte receives `string` from the UI.

Changing the spec to expect string values and converting where applicable in the `incident` and `logentry` classes.


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
