### PR TITLE
Phabricator streams use dateModified for state

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-faros-destination",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Faros Destination for Airbyte",
   "keywords": [
     "airbyte",
@@ -36,7 +36,7 @@
     "analytics-node": "^6.0.0",
     "axios": "^0.26.0",
     "date-format": "^4.0.6",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "faros-feeds-sdk": "^0.10.0",
     "fs-extra": "^10.0.0",
     "git-url-parse": "^11.6.0",

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faros-airbyte-cdk",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Airbyte Connector Development Kit (CDK) for JavaScript/TypeScript",
   "keywords": [
     "airbyte",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.95",
+  "version": "0.1.96",
   "packages": [
     "faros-airbyte-cdk",
     "destinations/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11615,9 +11615,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
-			"integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+			"integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -15224,7 +15224,7 @@
 		"node_modules/traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+			"integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
 		},
 		"node_modules/treeverse": {
 			"version": "2.0.0",
@@ -15649,7 +15649,7 @@
 		"node_modules/url-template": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
@@ -16128,7 +16128,7 @@
 		"node_modules/xcase": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xcase/-/xcase-2.0.1.tgz",
-			"integrity": "sha1-x/pyyqD0QNt4/VZzQyA4rJhEULk="
+			"integrity": "sha512-UmFXIPU+9Eg3E9m/728Bii0lAIuoc+6nbrNUKaRPJOFp91ih44qqGlWtxMB6kXFrRD6po+86ksHM5XHCfk6iPw=="
 		},
 		"node_modules/xml-name-validator": {
 			"version": "3.0.0",
@@ -25616,9 +25616,9 @@
 			"dev": true
 		},
 		"marked": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
-			"integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA=="
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+			"integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA=="
 		},
 		"md5": {
 			"version": "2.3.0",
@@ -28424,7 +28424,7 @@
 		"traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+			"integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
 		},
 		"treeverse": {
 			"version": "2.0.0",
@@ -28728,7 +28728,7 @@
 		"url-template": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -29113,7 +29113,7 @@
 		"xcase": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xcase/-/xcase-2.0.1.tgz",
-			"integrity": "sha1-x/pyyqD0QNt4/VZzQyA4rJhEULk="
+			"integrity": "sha512-UmFXIPU+9Eg3E9m/728Bii0lAIuoc+6nbrNUKaRPJOFp91ih44qqGlWtxMB6kXFrRD6po+86ksHM5XHCfk6iPw=="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/sources/agileaccelerator-source/package.json
+++ b/sources/agileaccelerator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agileaccelerator-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "AgileAccelerator Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/azure-repos-source/package.json
+++ b/sources/azure-repos-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-repos-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Azure Repos Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/azureactivedirectory-source/package.json
+++ b/sources/azureactivedirectory-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azureactivedirectory-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Azure Active Directory Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/azurepipeline-source/package.json
+++ b/sources/azurepipeline-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azurepipeline-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Azure Pipeline Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/backlog-source/package.json
+++ b/sources/backlog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backlog-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Backlog Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/bitbucket-source/package.json
+++ b/sources/bitbucket-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucket-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Bitbucket Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "bitbucket": "^2.7.0",
     "bottleneck": "^2.19.5",
     "date-format": "^4.0.6",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/buildkite-source/package.json
+++ b/sources/buildkite-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buildkite-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "BuildKite Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "graphql-request": "^4.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/circleci-source/package.json
+++ b/sources/circleci-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "CircleCI Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/customer-io-source/package.json
+++ b/sources/customer-io-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customer-io-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Customer.io Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/datadog-source/package.json
+++ b/sources/datadog-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "DataDog Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@datadog/datadog-api-client": "1.0.0-beta.8",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/docker-source/package.json
+++ b/sources/docker-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Docker Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/example-source/package.json
+++ b/sources/example-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Example Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/firehydrant-source/package.json
+++ b/sources/firehydrant-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firehydrant-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "BuildKite Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "graphql-request": "^4.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/gitlab-ci-source/package.json
+++ b/sources/gitlab-ci-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-ci-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Gitlab CI Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "@gitbeaker/node": "^35.6.0",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/googlecalendar-source/package.json
+++ b/sources/googlecalendar-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlecalendar-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "GoogleCalendar Airbyte source",
   "keywords": [
     "airbyte",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "googleapis": "^100.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/harness-source/package.json
+++ b/sources/harness-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Harness Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "graphql-request": "^4.0.0",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"

--- a/sources/jenkins-source/package.json
+++ b/sources/jenkins-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Jenkins Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "jenkins": "^0.28.1",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/okta-source/package.json
+++ b/sources/okta-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Okta Airbyte source",
   "keywords": [
     "airbyte",
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "parse-link-header": "2.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/opsgenie-source/package.json
+++ b/sources/opsgenie-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opsgenie-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "OpsGenie Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "graphql-request": "^4.0.0",
     "verror": "^1.10.1"
   },

--- a/sources/pagerduty-source/package.json
+++ b/sources/pagerduty-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "PagerDuty Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "@pagerduty/pdjs": "^2.2.4",
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "luxon": "^2.0.2",
     "verror": "^1.10.1"
   },

--- a/sources/phabricator-source/package.json
+++ b/sources/phabricator-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phabricator-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Phabricator Airbyte source",
   "keywords": [
     "airbyte",
@@ -33,7 +33,7 @@
     "axios": "^0.26.0",
     "commander": "^9.0.0",
     "condoit": "^2.1.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "moment": "^2.29.1",
     "verror": "^1.10.1"
   },

--- a/sources/phabricator-source/src/phabricator.ts
+++ b/sources/phabricator-source/src/phabricator.ts
@@ -207,11 +207,11 @@ export class Phabricator {
       repoIds?: phid[];
       repoNames?: string[];
     },
-    createdAt?: number,
+    modifiedAt?: number,
     limit = this.limit
   ): AsyncGenerator<Repository, any, any> {
-    const created = Math.max(createdAt ?? 0, this.startDate.unix());
-    this.logger.debug(`Fetching repositories created since ${created}`);
+    const modified = modifiedAt ?? 0;
+    this.logger.debug(`Fetching repositories modified since ${modified}`);
 
     const attachments = {projects: true, uris: true, metrics: true};
     let constraints = {};
@@ -257,7 +257,7 @@ export class Phabricator {
       },
       async (repos) => {
         const newRepos = repos.filter(
-          (repo) => repo.fields.dateCreated > created
+          (repo) => repo.fields.dateModified > modified
         );
         // Cache repositories for other queries
         for (const repo of newRepos) {
@@ -379,13 +379,13 @@ export class Phabricator {
     filter: {
       userIds?: phid[];
     },
-    createdAt?: number,
+    modifiedAt?: number,
     limit = this.limit
   ): AsyncGenerator<User, any, any> {
-    const created = Math.max(createdAt ?? 0, this.startDate.unix());
-    this.logger.debug(`Fetching users created since ${created}`);
+    const modified = modifiedAt ?? 0;
+    this.logger.debug(`Fetching users modified since ${modified}`);
 
-    const constraints = {phids: filter.userIds ?? [], createdStart: created};
+    const constraints = {phids: filter.userIds ?? []};
 
     yield* this.paginate(
       limit,
@@ -400,7 +400,7 @@ export class Phabricator {
       },
       async (users) => {
         const newUsers = users.filter(
-          (user) => user.fields.dateCreated > created
+          (user) => user.fields.dateModified > modified
         );
         return newUsers;
       }
@@ -411,11 +411,11 @@ export class Phabricator {
     filter: {
       slugs?: string[];
     },
-    createdAt?: number,
+    modifiedAt?: number,
     limit = this.limit
   ): AsyncGenerator<Project, any, any> {
-    const created = Math.max(createdAt ?? 0, this.startDate.unix());
-    this.logger.debug(`Fetching projects created since ${created}`);
+    const modified = modifiedAt ?? 0;
+    this.logger.debug(`Fetching projects modified since ${modified}`);
 
     const constraints = {slugs: filter.slugs ?? []};
     const attachments = {members: true, ancestors: true, watchers: true};
@@ -434,7 +434,7 @@ export class Phabricator {
       },
       async (projects) => {
         const newProjects = projects.filter(
-          (project) => project.fields.dateCreated > created
+          (project) => project.fields.dateModified > modified
         );
         return newProjects;
       }

--- a/sources/phabricator-source/src/streams/projects.ts
+++ b/sources/phabricator-source/src/streams/projects.ts
@@ -9,7 +9,7 @@ import {Dictionary} from 'ts-essentials';
 import {Phabricator, PhabricatorConfig, Project} from '../phabricator';
 
 export interface ProjectsState {
-  latestCreatedAt: number;
+  latestModifiedAt: number;
 }
 
 export class Projects extends AirbyteStreamBase {
@@ -26,15 +26,18 @@ export class Projects extends AirbyteStreamBase {
     throw 'phid';
   }
   get cursorField(): string[] {
-    return ['fields', 'dateCreated'];
+    return ['fields', 'dateModified'];
   }
   getUpdatedState(
     currentStreamState: ProjectsState,
     latestRecord: Project
   ): ProjectsState {
-    const latestCreated = currentStreamState?.latestCreatedAt ?? 0;
-    const recordCreated = latestRecord.fields?.dateCreated ?? 0;
-    currentStreamState.latestCreatedAt = Math.max(latestCreated, recordCreated);
+    const latestModified = currentStreamState?.latestModifiedAt ?? 0;
+    const recordModified = latestRecord.fields?.dateModified ?? 0;
+    currentStreamState.latestModifiedAt = Math.max(
+      latestModified,
+      recordModified
+    );
     return currentStreamState;
   }
   async *readRecords(
@@ -45,8 +48,8 @@ export class Projects extends AirbyteStreamBase {
   ): AsyncGenerator<Project, any, any> {
     const phabricator = Phabricator.instance(this.config, this.logger);
     const state = syncMode === SyncMode.INCREMENTAL ? streamState : undefined;
-    const createdAt = state?.latestCreatedAt ?? 0;
+    const modifiedAt = state?.latestModifiedAt ?? 0;
 
-    yield* phabricator.getProjects({slugs: phabricator.projects}, createdAt);
+    yield* phabricator.getProjects({slugs: phabricator.projects}, modifiedAt);
   }
 }

--- a/sources/phabricator-source/src/streams/users.ts
+++ b/sources/phabricator-source/src/streams/users.ts
@@ -9,7 +9,7 @@ import {Dictionary} from 'ts-essentials';
 import {Phabricator, PhabricatorConfig, User} from '../phabricator';
 
 export interface UsersState {
-  latestCreatedAt: number;
+  latestModifiedAt: number;
 }
 
 export class Users extends AirbyteStreamBase {
@@ -26,15 +26,18 @@ export class Users extends AirbyteStreamBase {
     throw 'phid';
   }
   get cursorField(): string[] {
-    return ['fields', 'dateCreated'];
+    return ['fields', 'dateModified'];
   }
   getUpdatedState(
     currentStreamState: UsersState,
     latestRecord: User
   ): UsersState {
-    const latestCreated = currentStreamState?.latestCreatedAt ?? 0;
-    const recordCreated = latestRecord.fields?.dateCreated ?? 0;
-    currentStreamState.latestCreatedAt = Math.max(latestCreated, recordCreated);
+    const latestModified = currentStreamState?.latestModifiedAt ?? 0;
+    const recordModified = latestRecord.fields?.dateModified ?? 0;
+    currentStreamState.latestModifiedAt = Math.max(
+      latestModified,
+      recordModified
+    );
     return currentStreamState;
   }
   async *readRecords(
@@ -45,8 +48,8 @@ export class Users extends AirbyteStreamBase {
   ): AsyncGenerator<User, any, any> {
     const phabricator = Phabricator.instance(this.config, this.logger);
     const state = syncMode === SyncMode.INCREMENTAL ? streamState : undefined;
-    const createdAt = state?.latestCreatedAt ?? 0;
+    const modifiedAt = state?.latestModifiedAt ?? 0;
 
-    yield* phabricator.getUsers({}, createdAt);
+    yield* phabricator.getUsers({}, modifiedAt);
   }
 }

--- a/sources/servicenow-source/package.json
+++ b/sources/servicenow-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servicenow-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "ServiceNow Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/shortcut-source/package.json
+++ b/sources/shortcut-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Shortcut Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
     "axios": "^0.26.0",
     "clubhouse-lib": "^0.13.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/squadcast-source/package.json
+++ b/sources/squadcast-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squadcast-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "SquadCast Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"
   },

--- a/sources/statuspage-source/package.json
+++ b/sources/statuspage-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statuspage-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Statuspage Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "statuspage.io": "^3.1.0",
     "typescript-memoize": "^1.1.0",
     "verror": "^1.10.1"

--- a/sources/victorops-source/package.json
+++ b/sources/victorops-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victorops-source",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "VictorOps Airbyte source",
   "keywords": [
     "airbyte",
@@ -32,7 +32,7 @@
   "dependencies": {
     "axios-retry": "^3.2.4",
     "commander": "^9.0.0",
-    "faros-airbyte-cdk": "^0.1.95",
+    "faros-airbyte-cdk": "^0.1.96",
     "luxon": "^2.0.2",
     "verror": "^1.10.1",
     "victorops-api-client": "^1.0.2"


### PR DESCRIPTION
## Description

Change streams to use `dateModified` to track state, so that updated information will get fetched by incremental syncs.
Change projects, users, and repo streams to fetch all records regardless of `cutoff_days` for the first incremental sync. Reasoning for this is that these data types may not be updated often, so restricting to `cutoff_days` will likely not pull all the relevant data. Now, only the commits stream will fetch data starting from `cutoff_days` for the first sync.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
