### PR TITLE
Test api errors thrown up

### DIFF
--- a/sources/servicenow-source/test/index.test.ts
+++ b/sources/servicenow-source/test/index.test.ts
@@ -118,6 +118,22 @@ describe('index', () => {
     expect(items).toStrictEqual(incidents);
   });
 
+  test('streams - incidents, throws up API error', async () => {
+    const expectedMessage = 'API Error';
+    listIncidents.mockRejectedValue(new VError(expectedMessage));
+    const source = new sut.ServiceNowSource(logger);
+    const streams = source.streams({});
+    const stream = streams[0];
+    try {
+      const iter = stream.readRecords(SyncMode.FULL_REFRESH);
+      await iter.next();
+    } catch (err: any) {
+      expect(err.message).toBe(expectedMessage);
+      return;
+    }
+    expect(0).toBe(1);
+  });
+
   test('streams - users, use incremental sync mode', async () => {
     const source = new sut.ServiceNowSource(logger);
     const streams = source.streams({
@@ -152,5 +168,21 @@ describe('index', () => {
       items.push(item);
     }
     expect(items).toStrictEqual(users);
+  });
+
+  test('streams - users, throws up API error', async () => {
+    const expectedMessage = 'API Error';
+    listUsers.mockRejectedValue(new VError(expectedMessage));
+    const source = new sut.ServiceNowSource(logger);
+    const streams = source.streams({});
+    const stream = streams[1];
+    try {
+      const iter = stream.readRecords(SyncMode.FULL_REFRESH);
+      await iter.next();
+    } catch (err: any) {
+      expect(err.message).toBe(expectedMessage);
+      return;
+    }
+    expect(0).toBe(1);
   });
 });

--- a/sources/servicenow-source/test/index.test.ts
+++ b/sources/servicenow-source/test/index.test.ts
@@ -130,7 +130,6 @@ describe('index', () => {
       fail('Error should have been thrown.');
     } catch (err: any) {
       expect(err.message).toBe(expectedMessage);
-      return;
     }
   });
 
@@ -182,7 +181,6 @@ describe('index', () => {
       fail('Error should have been thrown.');
     } catch (err: any) {
       expect(err.message).toBe(expectedMessage);
-      return;
     }
   });
 });

--- a/sources/servicenow-source/test/index.test.ts
+++ b/sources/servicenow-source/test/index.test.ts
@@ -127,11 +127,11 @@ describe('index', () => {
     try {
       const iter = stream.readRecords(SyncMode.FULL_REFRESH);
       await iter.next();
+      fail('Error should have been thrown.');
     } catch (err: any) {
       expect(err.message).toBe(expectedMessage);
       return;
     }
-    expect(0).toBe(1);
   });
 
   test('streams - users, use incremental sync mode', async () => {
@@ -179,10 +179,10 @@ describe('index', () => {
     try {
       const iter = stream.readRecords(SyncMode.FULL_REFRESH);
       await iter.next();
+      fail('Error should have been thrown.');
     } catch (err: any) {
       expect(err.message).toBe(expectedMessage);
       return;
     }
-    expect(0).toBe(1);
   });
 });


### PR DESCRIPTION
## Description

Add explicit tests to confirm that errors are being thrown out of readRecords.

Probably not worth bumping the version for this.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
