### PR TITLE
Remove fs.unlink since `temp` deletes files automagically + make tests work with Node 16

### DIFF
--- a/destinations/airbyte-faros-destination/test/converters/agileaccelerator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/agileaccelerator.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('agileaccelerator', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/asana.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/asana.test.ts
@@ -31,7 +31,6 @@ describe('asana', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process and write records', async () => {
@@ -166,7 +165,6 @@ describe('asana', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/azure-repos.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azure-repos.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('azure-repos', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/azureactivedirectory.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azureactivedirectory.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('azureactivedirectory', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('azurepipeline', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/backlog.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/backlog.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('backlog', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('bamboohr', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/bitbucket.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bitbucket.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('bitbucket', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/buildkite.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/buildkite.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('buildkite', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/circleci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/circleci.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('circleci', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/datadog.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/datadog.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 import pino from 'pino';
@@ -46,7 +45,6 @@ describe('datadog', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/docker.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/docker.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -35,7 +34,6 @@ describe('docker', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('faros_feeds', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/firehydrant.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/firehydrant.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 import pino from 'pino';
@@ -39,7 +38,6 @@ describe('firehydrant', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/github.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/github.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel, AirbyteRecord} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import os from 'os';
@@ -31,7 +30,6 @@ describe('github', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process and write records', async () => {
@@ -166,7 +164,6 @@ describe('github', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel, AirbyteRecord} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import os from 'os';
@@ -31,7 +30,6 @@ describe('gitlab-ci', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process and write records', async () => {
@@ -166,7 +164,6 @@ describe('gitlab-ci', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel, AirbyteRecord} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import os from 'os';
@@ -31,7 +30,6 @@ describe('gitlab', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process and write records', async () => {
@@ -166,7 +164,6 @@ describe('gitlab', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/googlecalendar.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/googlecalendar.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -51,7 +50,6 @@ describe('googlecalendar', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/harness.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/harness.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel, AirbyteRecord} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import os from 'os';
@@ -28,7 +27,6 @@ describe('harness', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('skip to process bad records when strategy is SKIP', async () => {
@@ -64,7 +62,6 @@ describe('harness', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/jenkins.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jenkins.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel, AirbyteRecord} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import os from 'os';
@@ -30,7 +29,6 @@ describe('jenkins', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process and write records', async () => {
@@ -145,7 +143,6 @@ describe('jenkins', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/jira.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jira.test.ts
@@ -44,7 +44,6 @@ describe('jira', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('check valid jira source config', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/okta.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/okta.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 import pino from 'pino';
@@ -39,7 +38,6 @@ describe('okta', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/opsgenie.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/opsgenie.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 import pino from 'pino';
@@ -39,7 +38,6 @@ describe('opsgenie', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel, AirbyteRecord} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import os from 'os';
@@ -30,7 +29,6 @@ describe('pagerduty', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process and write records', async () => {
@@ -144,7 +142,6 @@ describe('pagerduty', () => {
   });
 
   test('fail to process bad records when strategy is FAIL', async () => {
-    fs.unlinkSync(configPath);
     configPath = await tempConfig(mockttp.url, InvalidRecordStrategy.FAIL);
     const cli = await CLI.runWith([
       'write',

--- a/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('phabricator', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/servicenow.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/servicenow.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 import pino from 'pino';
@@ -43,7 +42,6 @@ describe('servicenow', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/shortcut.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/shortcut.test.ts
@@ -26,7 +26,6 @@ describe('shortcut', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/squadcast.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/squadcast.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('squadcast', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('statuspage', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
@@ -1,5 +1,4 @@
 import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
-import fs from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import pino from 'pino';
@@ -26,7 +25,6 @@ describe('victorops', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/index.test.ts
+++ b/destinations/airbyte-faros-destination/test/index.test.ts
@@ -3,7 +3,6 @@ import {
   AirbyteConnectionStatusMessage,
   AirbyteSpec,
 } from 'faros-airbyte-cdk';
-import fs from 'fs';
 import {getLocal} from 'mockttp';
 import os from 'os';
 
@@ -22,7 +21,6 @@ describe('index', () => {
 
   afterEach(async () => {
     await mockttp.stop();
-    fs.unlinkSync(configPath);
   });
 
   test('help', async () => {
@@ -58,47 +56,37 @@ describe('index', () => {
   });
 
   test('check community edition config', async () => {
-    let configPath: string;
-    try {
-      configPath = await tempConfig(
-        mockttp.url,
-        InvalidRecordStrategy.SKIP,
-        Edition.COMMUNITY
-      );
-      const cli = await CLI.runWith(['check', '--config', configPath]);
+    const configPath = await tempConfig(
+      mockttp.url,
+      InvalidRecordStrategy.SKIP,
+      Edition.COMMUNITY
+    );
+    const cli = await CLI.runWith(['check', '--config', configPath]);
 
-      expect(await read(cli.stderr)).toBe('');
-      expect(await read(cli.stdout)).toBe(
-        JSON.stringify(
-          new AirbyteConnectionStatusMessage({
-            status: AirbyteConnectionStatus.SUCCEEDED,
-          })
-        ) + os.EOL
-      );
-      expect(await cli.wait()).toBe(0);
-    } finally {
-      fs.unlinkSync(configPath);
-    }
+    expect(await read(cli.stderr)).toBe('');
+    expect(await read(cli.stdout)).toBe(
+      JSON.stringify(
+        new AirbyteConnectionStatusMessage({
+          status: AirbyteConnectionStatus.SUCCEEDED,
+        })
+      ) + os.EOL
+    );
+    expect(await cli.wait()).toBe(0);
   });
 
   test('fail check on invalid segment user id', async () => {
-    let configPath: string;
-    try {
-      configPath = await tempConfig(
-        mockttp.url,
-        InvalidRecordStrategy.SKIP,
-        Edition.COMMUNITY,
-        {segment_user_id: 'badid'}
-      );
-      const cli = await CLI.runWith(['check', '--config', configPath]);
+    const configPath = await tempConfig(
+      mockttp.url,
+      InvalidRecordStrategy.SKIP,
+      Edition.COMMUNITY,
+      {segment_user_id: 'badid'}
+    );
+    const cli = await CLI.runWith(['check', '--config', configPath]);
 
-      expect(await read(cli.stderr)).toBe('');
-      expect(await read(cli.stdout)).toContain(
-        'Segment User Id badid is not a valid UUID.'
-      );
-      expect(await cli.wait()).toBe(0);
-    } finally {
-      fs.unlinkSync(configPath);
-    }
+    expect(await read(cli.stderr)).toBe('');
+    expect(await read(cli.stdout)).toContain(
+      'Segment User Id badid is not a valid UUID.'
+    );
+    expect(await cli.wait()).toBe(0);
   });
 });

--- a/sources/buildkite-source/test/index.test.ts
+++ b/sources/buildkite-source/test/index.test.ts
@@ -66,17 +66,16 @@ describe('index', () => {
       return new Buildkite(null, null, new Date('2010-03-27T14:03:51-0800'));
     });
     const source = new sut.BuildkiteSource(logger);
-    await expect(
-      source.checkConnection({
-        token: '',
-        cutoff_days: 90,
-      })
-    ).resolves.toStrictEqual([
-      false,
-      new VError(
-        "Please verify your token is correct. Error: Cannot read property 'get' of null"
-      ),
-    ]);
+    const res = await source.checkConnection({
+      token: '',
+      cutoff_days: 90,
+    });
+
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toMatch(
+      /Please verify your token is correct. Error: Cannot read/
+    );
   });
 
   test('streams - organizations, use full_refresh sync mode', async () => {

--- a/sources/circleci-source/test/index.test.ts
+++ b/sources/circleci-source/test/index.test.ts
@@ -72,19 +72,16 @@ describe('index', () => {
       );
     });
     const source = new sut.CircleCISource(logger);
-    await expect(
-      source.checkConnection({
-        token: '',
-        org_slugs: ['org_slugs'],
-        repo_names: ['repo_names'],
-        cutoff_days: 90,
-      })
-    ).resolves.toStrictEqual([
-      false,
-      new VError(
-        "CircleCI API request failed: Cannot read property 'get' of null"
-      ),
-    ]);
+    const res = await source.checkConnection({
+      token: '',
+      org_slugs: ['org_slugs'],
+      repo_names: ['repo_names'],
+      cutoff_days: 90,
+    });
+
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toMatch(/CircleCI API request failed: Cannot read/);
   });
 
   test('streams - projects, use full_refresh sync mode', async () => {

--- a/sources/firehydrant-source/test/index.test.ts
+++ b/sources/firehydrant-source/test/index.test.ts
@@ -65,17 +65,16 @@ describe('index', () => {
       return new FireHydrant(null, null);
     });
     const source = new sut.FireHydrantSource(logger);
-    await expect(
-      source.checkConnection({
-        token: '',
-        cutoff_days: 90,
-      })
-    ).resolves.toStrictEqual([
-      false,
-      new VError(
-        "Please verify your token is correct. Error: Cannot read property 'get' of null"
-      ),
-    ]);
+    const res = await source.checkConnection({
+      token: '',
+      cutoff_days: 90,
+    });
+
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toMatch(
+      /Please verify your token is correct. Error: Cannot read/
+    );
   });
 
   test('streams - incidents, use full_refresh sync mode', async () => {

--- a/sources/gitlab-ci-source/test/index.test.ts
+++ b/sources/gitlab-ci-source/test/index.test.ts
@@ -62,12 +62,13 @@ describe('index', () => {
 
   test('check connection - incorrect config', async () => {
     const source = new sut.GitlabCiSource(logger);
-    await expect(source.checkConnection(config)).resolves.toStrictEqual([
-      false,
-      new VError(
-        'Please verify your token is correct. Error: Response code 401 (Unauthorized)'
-      ),
-    ]);
+    const res = await source.checkConnection(config);
+
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toStrictEqual(
+      'Please verify your token is correct. Error: Response code 401 (Unauthorized)'
+    );
   });
   test('streams - groups, use full_refresh sync mode', async () => {
     const fnGroupFunc = jest.fn();

--- a/sources/okta-source/test/index.test.ts
+++ b/sources/okta-source/test/index.test.ts
@@ -41,17 +41,15 @@ describe('index', () => {
 
   test('check connection bad token', async () => {
     const source = new sut.OktaSource(logger);
-    await expect(
-      source.checkConnection({
-        token: 'secrettoken',
-        domain_name: 'dev-12345678',
-      })
-    ).resolves.toStrictEqual([
-      false,
-      new VError(
-        'Connection check failed. Please verify your token is correct. Error: API responded with status 401'
-      ),
-    ]);
+    const res = await source.checkConnection({
+      token: 'secrettoken',
+      domain_name: 'dev-12345678',
+    });
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toMatch(
+      /Connection check failed. Please verify your token is correct. Error: API responded with status 401/
+    );
   });
 
   test('check connection good token', async () => {

--- a/sources/opsgenie-source/test/index.test.ts
+++ b/sources/opsgenie-source/test/index.test.ts
@@ -1,9 +1,9 @@
 import {AxiosInstance} from 'axios';
 import {
-    AirbyteLogger,
-    AirbyteLogLevel,
-    AirbyteSpec,
-    SyncMode,
+  AirbyteLogger,
+  AirbyteLogLevel,
+  AirbyteSpec,
+  SyncMode,
 } from 'faros-airbyte-cdk';
 import fs from 'fs-extra';
 import {VError} from 'verror';
@@ -12,152 +12,148 @@ import * as sut from '../src/index';
 import {OpsGenie} from '../src/opsgenie/opsgenie';
 
 function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
+  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
 }
 
 function readTestResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
+  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
 }
 
 describe('index', () => {
-    const logger = new AirbyteLogger(
-        // Shush messages in tests, unless in debug
-        process.env.LOG_LEVEL === 'debug'
-            ? AirbyteLogLevel.DEBUG
-            : AirbyteLogLevel.FATAL
+  const logger = new AirbyteLogger(
+    // Shush messages in tests, unless in debug
+    process.env.LOG_LEVEL === 'debug'
+      ? AirbyteLogLevel.DEBUG
+      : AirbyteLogLevel.FATAL
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('spec', async () => {
+    const source = new sut.OpsGenieSource(logger);
+    await expect(source.spec()).resolves.toStrictEqual(
+      new AirbyteSpec(readResourceFile('spec.json'))
     );
-
-    beforeEach(() => {
-        jest.clearAllMocks();
+  });
+  test('check connection', async () => {
+    OpsGenie.instance = jest.fn().mockImplementation(() => {
+      return new OpsGenie(
+        {
+          get: jest.fn().mockResolvedValue({}),
+        } as unknown as AxiosInstance,
+        new Date('2010-03-27T14:03:51-0800')
+      );
     });
 
-    afterEach(() => {
-        jest.restoreAllMocks();
+    const source = new sut.OpsGenieSource(logger);
+    await expect(
+      source.checkConnection({
+        token: '',
+      })
+    ).resolves.toStrictEqual([true, undefined]);
+  });
+
+  test('check connection - incorrect config', async () => {
+    OpsGenie.instance = jest.fn().mockImplementation(() => {
+      return new OpsGenie(null, null);
     });
-
-    test('spec', async () => {
-        const source = new sut.OpsGenieSource(logger);
-        await expect(source.spec()).resolves.toStrictEqual(
-            new AirbyteSpec(readResourceFile('spec.json'))
-        );
+    const source = new sut.OpsGenieSource(logger);
+    const res = await source.checkConnection({
+      token: '',
+      cutoff_days: 90,
     });
-    test('check connection', async () => {
-        OpsGenie.instance = jest.fn().mockImplementation(() => {
-            return new OpsGenie(
-                {
-                    get: jest.fn().mockResolvedValue({}),
-                } as unknown as AxiosInstance,
-                new Date('2010-03-27T14:03:51-0800')
-            );
-        });
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toMatch(
+      /Please verify your api key is correct. Error: Cannot read/
+    );
+  });
 
-        const source = new sut.OpsGenieSource(logger);
-        await expect(
-            source.checkConnection({
-                token: '',
-            })
-        ).resolves.toStrictEqual([true, undefined]);
+  test('streams - incidents, use full_refresh sync mode', async () => {
+    const fnIncidentsList = jest.fn();
+    OpsGenie.instance = jest.fn().mockImplementation(() => {
+      return new OpsGenie(
+        {
+          get: fnIncidentsList.mockResolvedValue({
+            data: {
+              data: readTestResourceFile('incidents.json'),
+              totalCount: 3,
+            },
+          }),
+        } as any,
+        new Date('2010-03-27T14:03:51-0800')
+      );
     });
+    const source = new sut.OpsGenieSource(logger);
+    const streams = source.streams({});
 
-    test('check connection - incorrect config', async () => {
-        OpsGenie.instance = jest.fn().mockImplementation(() => {
-            return new OpsGenie(null, null);
-        });
-        const source = new sut.OpsGenieSource(logger);
-        await expect(
-            source.checkConnection({
-                token: '',
-                cutoff_days: 90,
-            })
-        ).resolves.toStrictEqual([
-            false,
-            new VError(
-                "Please verify your api key is correct. Error: Cannot read property 'get' of null"
-            ),
-        ]);
+    const incidentsStream = streams[0];
+    const incidentsIter = incidentsStream.readRecords(SyncMode.FULL_REFRESH);
+    const incidents = [];
+    for await (const incident of incidentsIter) {
+      incidents.push(incident);
+    }
+    expect(fnIncidentsList).toHaveBeenCalledTimes(4);
+    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+  });
+
+  test('streams - teams, use full_refresh sync mode', async () => {
+    const fnTeamsList = jest.fn();
+    OpsGenie.instance = jest.fn().mockImplementation(() => {
+      return new OpsGenie(
+        {
+          get: fnTeamsList.mockResolvedValue({
+            data: {
+              data: readTestResourceFile('teams.json'),
+            },
+          }),
+        } as any,
+        new Date('2010-03-27T14:03:51-0800')
+      );
     });
+    const source = new sut.OpsGenieSource(logger);
+    const streams = source.streams({});
 
-    test('streams - incidents, use full_refresh sync mode', async () => {
-        const fnIncidentsList = jest.fn();
-        OpsGenie.instance = jest.fn().mockImplementation(() => {
-            return new OpsGenie(
-                {
-                    get: fnIncidentsList.mockResolvedValue({
-                        data: {
-                            data: readTestResourceFile('incidents.json'),
-                            totalCount: 3,
-                        },
-                    }),
-                } as any,
-                new Date('2010-03-27T14:03:51-0800')
-            );
-        });
-        const source = new sut.OpsGenieSource(logger);
-        const streams = source.streams({});
+    const teamsStream = streams[1];
+    const teamsIter = teamsStream.readRecords(SyncMode.FULL_REFRESH);
+    const teams = [];
+    for await (const team of teamsIter) {
+      teams.push(team);
+    }
+    expect(fnTeamsList).toHaveBeenCalledTimes(1);
+    expect(teams).toStrictEqual(readTestResourceFile('teams.json'));
+  });
 
-        const incidentsStream = streams[0];
-        const incidentsIter = incidentsStream.readRecords(
-            SyncMode.FULL_REFRESH
-        );
-        const incidents = [];
-        for await (const incident of incidentsIter) {
-            incidents.push(incident);
-        }
-        expect(fnIncidentsList).toHaveBeenCalledTimes(4);
-        expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+  test('streams - users, use full_refresh sync mode', async () => {
+    const fnUsersList = jest.fn();
+    OpsGenie.instance = jest.fn().mockImplementation(() => {
+      return new OpsGenie(
+        {
+          get: fnUsersList.mockResolvedValue({
+            data: {
+              data: readTestResourceFile('users.json'),
+            },
+          }),
+        } as any,
+        new Date('2010-03-27T14:03:51-0800')
+      );
     });
+    const source = new sut.OpsGenieSource(logger);
+    const streams = source.streams({});
 
-    test('streams - teams, use full_refresh sync mode', async () => {
-        const fnTeamsList = jest.fn();
-        OpsGenie.instance = jest.fn().mockImplementation(() => {
-            return new OpsGenie(
-                {
-                    get: fnTeamsList.mockResolvedValue({
-                        data: {
-                            data: readTestResourceFile('teams.json'),
-                        },
-                    }),
-                } as any,
-                new Date('2010-03-27T14:03:51-0800')
-            );
-        });
-        const source = new sut.OpsGenieSource(logger);
-        const streams = source.streams({});
-
-        const teamsStream = streams[1];
-        const teamsIter = teamsStream.readRecords(SyncMode.FULL_REFRESH);
-        const teams = [];
-        for await (const team of teamsIter) {
-            teams.push(team);
-        }
-        expect(fnTeamsList).toHaveBeenCalledTimes(1);
-        expect(teams).toStrictEqual(readTestResourceFile('teams.json'));
-    });
-
-    test('streams - users, use full_refresh sync mode', async () => {
-        const fnUsersList = jest.fn();
-        OpsGenie.instance = jest.fn().mockImplementation(() => {
-            return new OpsGenie(
-                {
-                    get: fnUsersList.mockResolvedValue({
-                        data: {
-                            data: readTestResourceFile('users.json'),
-                        },
-                    }),
-                } as any,
-                new Date('2010-03-27T14:03:51-0800')
-            );
-        });
-        const source = new sut.OpsGenieSource(logger);
-        const streams = source.streams({});
-
-        const usersStream = streams[2];
-        const usersIter = usersStream.readRecords(SyncMode.FULL_REFRESH);
-        const users = [];
-        for await (const user of usersIter) {
-            users.push(user);
-        }
-        expect(fnUsersList).toHaveBeenCalledTimes(1);
-        expect(users).toStrictEqual(readTestResourceFile('users.json'));
-    });
+    const usersStream = streams[2];
+    const usersIter = usersStream.readRecords(SyncMode.FULL_REFRESH);
+    const users = [];
+    for await (const user of usersIter) {
+      users.push(user);
+    }
+    expect(fnUsersList).toHaveBeenCalledTimes(1);
+    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+  });
 });

--- a/sources/squadcast-source/test/index.test.ts
+++ b/sources/squadcast-source/test/index.test.ts
@@ -69,10 +69,13 @@ describe('index', () => {
       );
     });
     const source = new sut.SquadcastSource(logger);
-    await expect(source.checkConnection({})).resolves.toStrictEqual([
-      false,
-      new VError('Please verify your token is correct. Error: some error'),
-    ]);
+    const res = await source.checkConnection({});
+
+    expect(res[0]).toBe(false);
+    expect(res[1]).toBeDefined();
+    expect(res[1].message).toMatch(
+      /Please verify your token is correct. Error: some error/
+    );
   });
 
   test('check connection - incorrect variables', async () => {


### PR DESCRIPTION
## Description

Remove fs.unlink since `temp` deletes files automagically + make tests work with Node 16 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

