### PR TITLE
[datadog-source] Add support for fetching metrics via the /api/v1/query endpoint

### DIFF
--- a/sources/datadog-source/README.md
+++ b/sources/datadog-source/README.md
@@ -4,10 +4,11 @@ This source streams data from the [Datadog APIs](https://docs.datadoghq.com/api/
 
 ## Streams
 
-| Model | Full | Incremental |
-|---|---|---|
-| Incidents  | ✅ | ✅ |
-| Users  | ✅ | ✅ |
+| Model     | Full | Incremental |
+|-----------|---|---|
+| Incidents | ✅ | ✅ |
+| Metrics   | ✅ | ✅ |
+| Users     | ✅ | ✅ |
 
 ## Testing
 

--- a/sources/datadog-source/acceptance-test-config.yml
+++ b/sources/datadog-source/acceptance-test-config.yml
@@ -22,4 +22,5 @@ tests:
       future_state_path: "test_files/abnormal_state.json"
       cursor_paths:
         incidents: [ "lastModified" ]
+        metrics: [ "timestamp" ]
         users: [ "lastModifiedAt" ]

--- a/sources/datadog-source/resources/schemas/metric.json
+++ b/sources/datadog-source/resources/schemas/metric.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "ID of the metric point. Composed by the hash of the query, the metric name and the timestamp.",
+      "example": "79054025255fb1a26e4bc422aef54eb4-system.cpu.idle-1575317847",
+      "type": "string"
+    },
+    "display_name": {
+      "description": "Display name of the metric.",
+      "example": "system.cpu.idle",
+      "type": "string"
+    },
+    "metric": {
+      "description": "Metric name.",
+      "example": "system.cpu.idle",
+      "type": "string"
+    },
+    "timestamp": {
+      "description": "The timestamp in seconds.",
+      "format": "integer",
+      "type": "number"
+    },
+    "value": {
+      "description": "A 32bit float gauge-type value.",
+      "format": "double",
+      "type": "number"
+    },
+    "primary_unit": {
+      "description": "Detailed information about the metric \"primary unit\" (for example, `bytes` in `bytes per second`),second describes the \"per unit\" (for example, `second` in `bytes per second`).",
+      "properties": {
+        "family": {
+          "description": "Unit family, allows for conversion between units of the same family, for scaling.",
+          "example": "time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "name": {
+          "description": "Unit name",
+          "example": "minute",
+          "type": "string"
+        },
+        "plural": {
+          "description": "Plural form of the unit name.",
+          "example": "minutes",
+          "type": "string"
+        },
+        "scale_factor": {
+          "description": "Factor for scaling between units of the same family.",
+          "example": 60,
+          "format": "double",
+          "type": "number"
+        },
+        "short_name": {
+          "description": "Abbreviation of the unit.",
+          "example": "min",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "per_unit": {
+      "description": "Detailed information about the metric \"per unit\" (for example, `second` in `bytes per second`).",
+      "properties": {
+        "family": {
+          "description": "Unit family, allows for conversion between units of the same family, for scaling.",
+          "example": "time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "name": {
+          "description": "Unit name",
+          "example": "minute",
+          "readOnly": true,
+          "type": "string"
+        },
+        "plural": {
+          "description": "Plural form of the unit name.",
+          "example": "minutes",
+          "type": "string"
+        },
+        "scale_factor": {
+          "description": "Factor for scaling between units of the same family.",
+          "example": 60,
+          "format": "double",
+          "type": "number"
+        },
+        "short_name": {
+          "description": "Abbreviation of the unit.",
+          "example": "min",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "scope": {
+      "description": "Metric scope, comma separated list of tags.",
+      "example": "host:foo,env:test",
+      "readOnly": true,
+      "type": "string"
+    },
+    "tag_set": {
+      "description": "Unique tags identifying this series.",
+      "items": {
+        "description": "Unique tags identifying this series.",
+        "type": "string"
+      },
+      "readOnly": true,
+      "type": "array"
+    }
+  }
+}

--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -29,6 +29,26 @@
         "title": "Page Size",
         "description": "used when retrieving paginated data from Datadog",
         "default": 100
+      },
+      "metrics": {
+        "order": 3,
+        "type": "array",
+        "title": "Metrics",
+        "description": "list of metrics to fetch and their configuration",
+        "item": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "query": "string"
+          }
+        }
+      },
+      "metrics_max_window": {
+        "order": 4,
+        "type": "integer",
+        "title": "Metrics Max Window",
+        "description": "max time window when fetching metrics, in milliseconds. Defaults to 1 week.",
+        "default": 604800000
       }
     }
   }

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -142,7 +142,7 @@ export class Datadog {
   // Retrieve the specified metric between from and to unix timestamps
   async *getMetrics(
     query: string,
-    query_hash: string,
+    queryHash: string,
     from: number,
     to: number
   ): AsyncGenerator<MetricPoint, any, any> {
@@ -155,7 +155,7 @@ export class Datadog {
       for (const metadata of res.series) {
         for (const point of metadata.pointlist) {
           yield {
-            id: `${query_hash}-${metadata.metric}-${point[0]}`,
+            id: `${queryHash}-${metadata.metric}-${point[0]}`,
             displayName: metadata.displayName,
             metric: metadata.metric,
             timestamp: point[0],

--- a/sources/datadog-source/src/index.ts
+++ b/sources/datadog-source/src/index.ts
@@ -10,7 +10,7 @@ import {
 import VError from 'verror';
 
 import {Datadog, DatadogConfig} from './datadog';
-import {Incidents, Users} from './streams';
+import {Incidents, Metrics, Users} from './streams';
 
 export function mainCommand(): Command {
   const logger = new AirbyteLogger();
@@ -35,6 +35,7 @@ export class DatadogSource extends AirbyteSourceBase {
     const datadog = Datadog.instance(config as DatadogConfig, this.logger);
     return [
       new Incidents(datadog, this.logger),
+      new Metrics(datadog, this.logger),
       new Users(datadog, this.logger),
     ];
   }

--- a/sources/datadog-source/src/streams/index.ts
+++ b/sources/datadog-source/src/streams/index.ts
@@ -1,4 +1,5 @@
 import {Incidents} from './incident';
+import {Metrics} from './metrics';
 import {Users} from './users';
 
-export {Incidents, Users};
+export {Incidents, Metrics, Users};

--- a/sources/datadog-source/src/streams/metrics.ts
+++ b/sources/datadog-source/src/streams/metrics.ts
@@ -1,0 +1,57 @@
+import {createHash} from 'crypto';
+import {
+  AirbyteLogger,
+  AirbyteStreamBase,
+  StreamKey,
+  SyncMode,
+} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {Datadog, MetricPoint} from '../datadog';
+
+export class Metrics extends AirbyteStreamBase {
+  constructor(
+    private readonly datadog: Datadog,
+    protected readonly logger: AirbyteLogger
+  ) {
+    super(logger);
+  }
+
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/metric.json');
+  }
+
+  get primaryKey(): StreamKey {
+    return ['id'];
+  }
+
+  get cursorField(): string | string[] {
+    return ['timestamp'];
+  }
+
+  getUpdatedState(
+    currentStreamState: Dictionary<string, number>,
+    latestRecord: MetricPoint
+  ): Dictionary<string, number> {
+    const queryHash = latestRecord.id.split('-')[0];
+    return {...currentStreamState, [queryHash]: latestRecord.timestamp};
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    _cursorField?: string[],
+    _streamSlice?: Dictionary<any, string>,
+    streamState?: Dictionary<string, number>
+  ): AsyncGenerator<Dictionary<any, string>, any, unknown> {
+    for (const metric of this.datadog.config.metrics ?? []) {
+      let from = 0;
+      const query_hash = createHash('md5').update(metric.query).digest('hex');
+      if (syncMode === SyncMode.INCREMENTAL) {
+        from = streamState[query_hash] ?? 0;
+      }
+      const max_to = from + this.datadog.config.metrics_max_window;
+      const to = Math.min(Date.now().valueOf(), max_to);
+      yield* this.datadog.getMetrics(metric.query, query_hash, from, to);
+    }
+  }
+}

--- a/sources/datadog-source/src/streams/metrics.ts
+++ b/sources/datadog-source/src/streams/metrics.ts
@@ -45,13 +45,13 @@ export class Metrics extends AirbyteStreamBase {
   ): AsyncGenerator<Dictionary<any, string>, any, unknown> {
     for (const metric of this.datadog.config.metrics ?? []) {
       let from = 0;
-      const query_hash = createHash('md5').update(metric.query).digest('hex');
+      const queryHash = createHash('md5').update(metric.query).digest('hex');
       if (syncMode === SyncMode.INCREMENTAL) {
-        from = streamState[query_hash] ?? 0;
+        from = streamState[queryHash] ?? 0;
       }
-      const max_to = from + this.datadog.config.metrics_max_window;
-      const to = Math.min(Date.now().valueOf(), max_to);
-      yield* this.datadog.getMetrics(metric.query, query_hash, from, to);
+      const maxTo = from + this.datadog.config.metrics_max_window;
+      const to = Math.min(Date.now().valueOf(), maxTo);
+      yield* this.datadog.getMetrics(metric.query, queryHash, from, to);
     }
   }
 }

--- a/sources/datadog-source/test_files/metrics.json
+++ b/sources/datadog-source/test_files/metrics.json
@@ -1,0 +1,37 @@
+{
+  "error": "string",
+  "from_date": "integer",
+  "group_by": [],
+  "message": "string",
+  "query": "string",
+  "res_type": "time_series",
+  "series": [
+    {
+      "aggr": "avg",
+      "displayName": "system.cpu.idle",
+      "end": "integer",
+      "expression": "system.cpu.idle{host:foo,env:test}",
+      "interval": "integer",
+      "length": "integer",
+      "metric": "system.cpu.idle",
+      "pointlist": [
+        [1575317847, 0.5]
+      ],
+      "queryIndex": "integer",
+      "scope": "host:foo,env:test",
+      "start": "integer",
+      "tagSet": [],
+      "unit": [
+        {
+          "family": "time",
+          "name": "minute",
+          "plural": "minutes",
+          "scale_factor": 60,
+          "short_name": "min"
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "to_date": "integer"
+}


### PR DESCRIPTION
## Description

* [datadog-source] Add support for fetching metrics via the /api/v1/query endpoint

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues
N/A

## Migration notes
N/A

## Extra info

This is my first time working with Airbyte and the Faros CDK, so comments/suggestions are welcome!
The biggest challenge I had building this connector is that the `api/v1/query` endpoint does not map directly to a specific resource like `users` or `incidents`. So I had to get creative in how to allow users to specify the metrics they'd like to fetch and keep a state for each of them.
