### PR TITLE
[datadog-source] Fix source configuration

### DIFF
--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -36,11 +36,7 @@
         "title": "Metrics",
         "description": "list of metrics to fetch and their configuration",
         "item": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "query": "string"
-          }
+          "type": "string"
         }
       },
       "metrics_max_window": {

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -33,15 +33,11 @@ export interface MetricPoint {
   tagSet: Array<string>;
 }
 
-interface MetricConfig {
-  query: string;
-}
-
 export interface DatadogConfig {
   readonly api_key: string;
   readonly application_key: string;
   readonly page_size?: number;
-  readonly metrics?: Array<MetricConfig>;
+  readonly metrics?: Array<string>;
   readonly metrics_max_window?: number;
 }
 

--- a/sources/datadog-source/src/streams/metrics.ts
+++ b/sources/datadog-source/src/streams/metrics.ts
@@ -43,15 +43,15 @@ export class Metrics extends AirbyteStreamBase {
     _streamSlice?: Dictionary<any, string>,
     streamState?: Dictionary<string, number>
   ): AsyncGenerator<Dictionary<any, string>, any, unknown> {
-    for (const metric of this.datadog.config.metrics ?? []) {
+    for (const metricQuery of this.datadog.config.metrics ?? []) {
       let from = 0;
-      const queryHash = createHash('md5').update(metric.query).digest('hex');
+      const queryHash = createHash('md5').update(metricQuery).digest('hex');
       if (syncMode === SyncMode.INCREMENTAL) {
         from = streamState[queryHash] ?? 0;
       }
       const maxTo = from + this.datadog.config.metrics_max_window;
       const to = Math.min(Date.now().valueOf(), maxTo);
-      yield* this.datadog.getMetrics(metric.query, queryHash, from, to);
+      yield* this.datadog.getMetrics(metricQuery, queryHash, from, to);
     }
   }
 }

--- a/sources/datadog-source/test/index.test.ts
+++ b/sources/datadog-source/test/index.test.ts
@@ -129,11 +129,7 @@ describe('index', () => {
           } as unknown as v1.MetricsApi,
         } as DatadogClient,
         {
-          metrics: [
-            {
-              query: 'system.cpu.idle{*}',
-            },
-          ],
+          metrics: ['system.cpu.idle{*}'],
         } as DatadogConfig,
         logger
       )
@@ -179,11 +175,7 @@ describe('index', () => {
           } as unknown as v1.MetricsApi,
         } as DatadogClient,
         {
-          metrics: [
-            {
-              query: 'system.cpu.idle{*}',
-            },
-          ],
+          metrics: ['system.cpu.idle{*}'],
         } as DatadogConfig,
         logger
       )


### PR DESCRIPTION
## Description

Airbyte UI does not support arrays of objects as configuration parameters for sources.
This change makes the Datadog source `metrics` config an array of strings instead of an array of objects.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

This is a follow-up fix from #569 

## Extra info

When we tried the new stream introduced in #569 on the Airbyte UI, we got the following error:

> Internal Server Error: malformed JsonSchema array type, must have items field in {"item":{"type":"object","properties":{"query":"string"},"additionalProperties":false},"type":"array","order":3,"title":"Metrics","description":"list of metrics to fetch and their configuration"}
