### PR TITLE
Fix lerna --scope option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "clean": "lerna run clean && rm -rf node_modules out",
     "lint": "lerna run lint",
     "prepare": "lerna bootstrap --hoist && husky install",
-    "test": "lerna run test -- -- --color",
-    "test-cov": "lerna run test -- -- --coverage --color"
+    "test": "lerna run test",
+    "test-cov": "lerna run test-cov"
   },
   "devDependencies": {
     "@types/analytics-node": "^3.1.8",


### PR DESCRIPTION
## Description

This change allows us to pass the `-- --scope ...` option when running `npm run test` or `npm run test-cov` from the project root (as stated in the README).
Before this change, the additional options configured in the global `package.json` would cause the `--scope` option to be forwarded to `jest` instead, causing an error.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

Fixes #567