### PR TITLE
GitLab build createdAt and commit association

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
@@ -43,7 +43,7 @@ export class Pipelines extends GitlabConverter {
       startedAt: Utils.toDate(pipeline.created_at),
       endedAt,
     };
-    
+
     res.push({
       model: 'cicd_Build',
       record: build,
@@ -59,7 +59,7 @@ export class Pipelines extends GitlabConverter {
       res.push({
         model: 'cicd_BuildCommitAssociation',
         record: {
-          build: {uid: build.uid, pipeline},
+          build: {uid: build.uid, pipeline: pipelineKey},
           commit,
         },
       });

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
@@ -13,6 +13,7 @@ export class Pipelines extends GitlabConverter {
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const source = this.streamName.source;
     const pipeline = record.record.data;
+    const res: DestinationRecord[] = [];
 
     const repository = GitlabCommon.parseRepositoryKey(
       pipeline.web_url,
@@ -32,19 +33,38 @@ export class Pipelines extends GitlabConverter {
       uid: repository.name,
     };
 
-    return [
-      {
-        model: 'cicd_Build',
+    const build = {
+      uid: String(pipeline.id),
+      number: pipeline.id,
+      pipeline: pipelineKey,
+      status,
+      url: pipeline.web_url,
+      createdAt: Utils.toDate(pipeline.created_at),
+      startedAt: Utils.toDate(pipeline.created_at),
+      endedAt,
+    };
+    
+    res.push({
+      model: 'cicd_Build',
+      record: build,
+    });
+
+    if (pipeline.sha) {
+      const commit = {
+        sha: pipeline.sha,
+        uid: pipeline.sha,
+        repository: repository,
+      };
+
+      res.push({
+        model: 'cicd_BuildCommitAssociation',
         record: {
-          uid: String(pipeline.id),
-          number: pipeline.id,
-          pipeline: pipelineKey,
-          status,
-          url: pipeline.web_url,
-          startedAt: Utils.toDate(pipeline.created_at),
-          endedAt,
+          build: {uid: build.uid, pipeline},
+          commit,
         },
-      },
-    ];
+      });
+    }
+
+    return res;
   }
 }

--- a/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
@@ -30,6 +30,58 @@ describe('gitlab', () => {
     await mockttp.stop();
   });
 
+  test('process and write records', async () => {
+    await mockttp
+      .forPost('/graphs/test-graph/models')
+      .withQuery({schema: 'canonical'})
+      .once()
+      .thenReply(200, JSON.stringify({}));
+
+    await mockttp
+      .forPost('/graphs/test-graph/revisions')
+      .once()
+      .thenReply(
+        200,
+        JSON.stringify({
+          entrySchema: graphSchema,
+          revision: {uid: revisionId, lock: {state: {}}},
+        })
+      );
+
+    let entriesSize = 0;
+    await mockttp
+      .forPost(`/graphs/test-graph/revisions/${revisionId}/entries`)
+      .thenCallback(async (r) => {
+        entriesSize = r.body.buffer.length;
+        return {statusCode: 204};
+      });
+
+    await mockttp
+      .forPatch(`/graphs/test-graph/revisions/${revisionId}`)
+      .withJsonBodyIncluding({status: 'active'})
+      .once()
+      .thenReply(204);
+
+    const cli = await CLI.runWith([
+      'write',
+      '--config',
+      configPath,
+      '--catalog',
+      catalogPath,
+    ]);
+    cli.stdin.end(gitlabAllStreamsLog, 'utf8');
+
+    const stdout = await read(cli.stdout);
+    logger.debug(stdout);
+
+    expect(stdout).toMatch('Wrote 77 records');
+    expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
+    expect(await read(cli.stderr)).toBe('');
+    expect(await cli.wait()).toBe(0);
+    expect(entriesSize).toBeGreaterThan(0);
+  });
+
   test('process records from all streams', async () => {
     const cli = await CLI.runWith([
       'write',
@@ -71,6 +123,7 @@ describe('gitlab', () => {
 
     const writtenByModel = {
       cicd_Build: 2,
+      cicd_BuildCommitAssociation: 2,
       cicd_BuildStep: 8,
       cicd_Organization: 1,
       cicd_Pipeline: 1,


### PR DESCRIPTION
## Description

Add missing build createdAt and build commit association information to the GitLab pipeline converter

## Type of change
- [x] Bug fix

## Notes
Example of cicd_Build and cicd_BuildCommitAssociation written by the updated converter:
```
{"model":"cicd_Build","record":{
"uid":"391934778",
"number":391934778,
"pipeline":{"organization":{"uid":"test5726","source":"GitLab"},"uid":"test"},
"status":{"category":"Success","detail":"success"},
"url":"https://gitlab.com/test5726/test/-/pipelines/391934778",
"createdAt":"2021-10-20T12:39:08.402Z",
"startedAt":"2021-10-20T12:39:08.402Z",
"endedAt":"2021-10-20T15:57:22.441Z",
"source":"GitLab"}}

{"model":"cicd_BuildCommitAssociation","record":{
"build":{"uid":"391934778","pipeline":{"organization":{"uid":"test5726","source":"GitLab"},"uid":"test"}},
"commit":{"sha":"db6312e24b5d0eec709ce5987eb14df21ebc45e9","uid":"db6312e24b5d0eec709ce5987eb14df21ebc45e9","repository":{"name":"test","uid":"test","organization":{"uid":"test5726","source":"GitLab"}}},"source":"GitLab"}}
```
