### PR TITLE
Fix datadog spec

### DIFF
--- a/sources/bamboohr-source/resources/spec.json
+++ b/sources/bamboohr-source/resources/spec.json
@@ -32,7 +32,7 @@
         "type": "array",
         "title": "Additional Fields",
         "description": "List of additional employee field names to fetch. Each field name must have an alias. See https://documentation.bamboohr.com/reference/metadata-get-a-list-of-fields.",
-        "item": {
+        "items": {
           "type": "string"
         }
       }

--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -35,7 +35,7 @@
         "type": "array",
         "title": "Metrics",
         "description": "list of metrics to fetch and their configuration",
-        "item": {
+        "items": {
           "type": "string"
         }
       },

--- a/sources/docker-source/resources/spec.json
+++ b/sources/docker-source/resources/spec.json
@@ -27,7 +27,7 @@
         "type": "array",
         "title": "Repositories",
         "description": "List of repositories to fetch tags for",
-        "item": {
+        "items": {
           "type": "string"
         }
       },


### PR DESCRIPTION
## Description
The current spec is not a valid JSON Schema. 
See `items` [here](https://json-schema.org/understanding-json-schema/reference/array.html).

## Type of change
- [x] Bug fix

## Related issues
https://github.com/faros-ai/faros-community-edition/pull/203 