### PR TITLE
Bitbucket source: try URIencoding environment id if first attempt fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,15 +219,15 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.131.0.tgz",
-      "integrity": "sha512-iUnsTNFKXMUYZklgh8Ix1f5eLd+FDbGfKALrdCEHYtinSXgL1vee65tS8GSNXDRMR+l2Yd11z7Xex2YTPUOq/Q==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.137.0.tgz",
+      "integrity": "sha512-Trj511SneEVNtngKSstoV0DldCOpKznALzJM+T8h2inBfVayIAnXh138goO5Kfo6969w7H7pkaIJptKA3wS+yQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.131.0",
+        "@aws-sdk/client-sts": "3.137.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/credential-provider-node": "3.137.0",
         "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
@@ -243,15 +243,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -263,15 +263,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.131.0.tgz",
-      "integrity": "sha512-FG5pUjm31XhAdJnIkjQnpjTsp2hMixMtnh8NzaM/T6veS36LiykLH7pE+tDArj5lCrGU8vllmTS73I5XzYPFLA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.137.0.tgz",
+      "integrity": "sha512-lbWIvz1KqYM7LqumNjlCeE94mjgfcL+oWPXG7vq4bOqwnDv9G6pgKUyz8vnlYz6q6RB5EPif0bg3XS/choIGZQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.131.0",
+        "@aws-sdk/client-sts": "3.137.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/credential-provider-node": "3.137.0",
         "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
@@ -289,15 +289,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
-      "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.137.0.tgz",
+      "integrity": "sha512-l9y9usMuXGI+o1c/VO2qMccN0Bm0T5bFmmbRljB6kIzbJYXD/wVqR8GMZwSnFnz52cnURQ4pgqM1ETg54FlBYQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -332,15 +332,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -352,14 +352,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
-      "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.137.0.tgz",
+      "integrity": "sha512-yJqfkEq0DG9Ds+oif/sc02PX6vfSNcyRe3YcaW5P6ouMyhJRljSIVCnA6iPwJaTsmK9BE9PDgFD2v/GYM/XgOA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/credential-provider-node": "3.137.0",
         "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
@@ -376,15 +376,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -441,13 +441,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
-      "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.137.0.tgz",
+      "integrity": "sha512-FNSYjHaW83b4sQac+EWh/C6p1taBdvPOXFAVml1mPH49Nlkv9/E4bbjaWwgxvlxjqjNCbkDMKzhb19DN3gVulA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.131.0",
+        "@aws-sdk/credential-provider-sso": "3.137.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -459,15 +459,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
-      "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.137.0.tgz",
+      "integrity": "sha512-if4CzNSyPS3ZERLtDocNNC+l5ejK93d2hoOzNHP2qCmTppThEPWF2TH506ez0v0lbUzeI7qWgpYe9m4+BFLEwQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.131.0",
+        "@aws-sdk/credential-provider-ini": "3.137.0",
         "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.131.0",
+        "@aws-sdk/credential-provider-sso": "3.137.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -493,11 +493,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
-      "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.137.0.tgz",
+      "integrity": "sha512-Up2Q3tWSo6Mv2icXMrHa8dGtnC9yQAeUnftrIlvLXi3P9RjxlOPZCSg1NF8FOS90RdEgORlj/7LPlIniHgGUmg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.131.0",
+        "@aws-sdk/client-sso": "3.137.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
-      "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.137.0.tgz",
+      "integrity": "sha512-YAuWiSzHJGV9jQCjmcBWxbWRoq/3INEpdtfAdpR+X+sEZaRJESDGPt4or7WbQ9Tmbd/uZ0uQLYIed/NDSyJLLQ==",
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -930,9 +930,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.127.0.tgz",
-      "integrity": "sha512-e/vBm+EYSJ0R79591EPiCPE3aR5RKk5CjOkQjNxZIX8UPnIlo7xohTcebfR/iugSTxNrpfrFv+o4H5GjzAuhLA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.137.0.tgz",
+      "integrity": "sha512-9f5045wqPAcGLKIAXzZKHE2n42ilGo/g4rLSS09OXx9CoFT4lVdqZPqBqh/prDUMrqXge9FK3EH2VId7L5GpEQ==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.130.0.tgz",
-      "integrity": "sha512-0BWx7C6GhHBrjPUuSgMnRA4InxYisX6MIGs5yIHk2OArYkQLJMdeORYXXz1y40ahMihmtjD/Ap5xQGBm2vyffA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.137.0.tgz",
+      "integrity": "sha512-CvMpemcsOkoMEz0iALamyQBt1rHx98NvF/cay019F8m+umD03I8CclDugy/13DqESWfsVxn91lZY/DOnO+si7A==",
       "dependencies": {
         "@aws-sdk/config-resolver": "3.130.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -1559,9 +1559,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -6041,11 +6041,14 @@
       }
     },
     "node_modules/clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dependencies": {
         "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clubhouse-lib": {
@@ -6621,9 +6624,9 @@
       }
     },
     "node_modules/date-format": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.11.tgz",
-      "integrity": "sha512-VS20KRyorrbMCQmpdl2hg5KaOUsda1RbnsJg461FfrcyCUg+pkd0b40BSW4niQyTheww4DBXQnS7HwSrKkipLw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.13.tgz",
+      "integrity": "sha512-bnYCwf8Emc3pTD8pXnre+wfnjGtfi5ncMDKy7+cWZXbmRAsdWkOQHrfC1yz/KiwP5thDp2kCHWYWKBX4HP1hoQ==",
       "engines": {
         "node": ">=4.0"
       }
@@ -7731,9 +7734,9 @@
       ]
     },
     "node_modules/faros-feeds-sdk": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.12.5.tgz",
-      "integrity": "sha512-7jhgXR+IqqwuqWODd0Yk8xIzU9sOwzHTBIHP3xvmmCLhPJa9JTGGqaZ+tOW5dBJhJSWNexUh+2hw4uPeAJ6aIw==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.12.6.tgz",
+      "integrity": "sha512-fmGtagotE27TCaEBpz/EZVXvIPr+9x566BAYQ/MVmFkGjtdIAT2VUWsaS7EAjouBfJuKvCvZmVkpPRmiX5BlUg==",
       "dependencies": {
         "@avro/common-types": "^0.2.0",
         "@avro/streams": "^1.0.10",
@@ -10558,9 +10561,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
-      "integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
+      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
       "dependencies": {
         "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
@@ -14057,11 +14060,14 @@
       }
     },
     "node_modules/responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -16208,15 +16214,15 @@
       }
     },
     "@aws-sdk/client-kms": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.131.0.tgz",
-      "integrity": "sha512-iUnsTNFKXMUYZklgh8Ix1f5eLd+FDbGfKALrdCEHYtinSXgL1vee65tS8GSNXDRMR+l2Yd11z7Xex2YTPUOq/Q==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.137.0.tgz",
+      "integrity": "sha512-Trj511SneEVNtngKSstoV0DldCOpKznALzJM+T8h2inBfVayIAnXh138goO5Kfo6969w7H7pkaIJptKA3wS+yQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.131.0",
+        "@aws-sdk/client-sts": "3.137.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/credential-provider-node": "3.137.0",
         "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
@@ -16232,15 +16238,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -16249,15 +16255,15 @@
       }
     },
     "@aws-sdk/client-sqs": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.131.0.tgz",
-      "integrity": "sha512-FG5pUjm31XhAdJnIkjQnpjTsp2hMixMtnh8NzaM/T6veS36LiykLH7pE+tDArj5lCrGU8vllmTS73I5XzYPFLA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.137.0.tgz",
+      "integrity": "sha512-lbWIvz1KqYM7LqumNjlCeE94mjgfcL+oWPXG7vq4bOqwnDv9G6pgKUyz8vnlYz6q6RB5EPif0bg3XS/choIGZQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.131.0",
+        "@aws-sdk/client-sts": "3.137.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/credential-provider-node": "3.137.0",
         "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
@@ -16275,15 +16281,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -16294,9 +16300,9 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
-      "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.137.0.tgz",
+      "integrity": "sha512-l9y9usMuXGI+o1c/VO2qMccN0Bm0T5bFmmbRljB6kIzbJYXD/wVqR8GMZwSnFnz52cnURQ4pgqM1ETg54FlBYQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -16315,15 +16321,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -16332,14 +16338,14 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
-      "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.137.0.tgz",
+      "integrity": "sha512-yJqfkEq0DG9Ds+oif/sc02PX6vfSNcyRe3YcaW5P6ouMyhJRljSIVCnA6iPwJaTsmK9BE9PDgFD2v/GYM/XgOA==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/credential-provider-node": "3.137.0",
         "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
@@ -16356,15 +16362,15 @@
         "@aws-sdk/node-config-provider": "3.127.0",
         "@aws-sdk/node-http-handler": "3.127.0",
         "@aws-sdk/protocol-http": "3.127.0",
-        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/smithy-client": "3.137.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/url-parser": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
-        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.137.0",
+        "@aws-sdk/util-defaults-mode-node": "3.137.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
         "@aws-sdk/util-utf8-browser": "3.109.0",
@@ -16409,13 +16415,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
-      "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.137.0.tgz",
+      "integrity": "sha512-FNSYjHaW83b4sQac+EWh/C6p1taBdvPOXFAVml1mPH49Nlkv9/E4bbjaWwgxvlxjqjNCbkDMKzhb19DN3gVulA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.131.0",
+        "@aws-sdk/credential-provider-sso": "3.137.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -16424,15 +16430,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
-      "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.137.0.tgz",
+      "integrity": "sha512-if4CzNSyPS3ZERLtDocNNC+l5ejK93d2hoOzNHP2qCmTppThEPWF2TH506ez0v0lbUzeI7qWgpYe9m4+BFLEwQ==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.131.0",
+        "@aws-sdk/credential-provider-ini": "3.137.0",
         "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.131.0",
+        "@aws-sdk/credential-provider-sso": "3.137.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -16452,11 +16458,11 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.131.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
-      "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.137.0.tgz",
+      "integrity": "sha512-Up2Q3tWSo6Mv2icXMrHa8dGtnC9yQAeUnftrIlvLXi3P9RjxlOPZCSg1NF8FOS90RdEgORlj/7LPlIniHgGUmg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.131.0",
+        "@aws-sdk/client-sso": "3.137.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -16724,9 +16730,9 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
-      "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.137.0.tgz",
+      "integrity": "sha512-YAuWiSzHJGV9jQCjmcBWxbWRoq/3INEpdtfAdpR+X+sEZaRJESDGPt4or7WbQ9Tmbd/uZ0uQLYIed/NDSyJLLQ==",
       "requires": {
         "@aws-sdk/middleware-stack": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -16799,9 +16805,9 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.127.0.tgz",
-      "integrity": "sha512-e/vBm+EYSJ0R79591EPiCPE3aR5RKk5CjOkQjNxZIX8UPnIlo7xohTcebfR/iugSTxNrpfrFv+o4H5GjzAuhLA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.137.0.tgz",
+      "integrity": "sha512-9f5045wqPAcGLKIAXzZKHE2n42ilGo/g4rLSS09OXx9CoFT4lVdqZPqBqh/prDUMrqXge9FK3EH2VId7L5GpEQ==",
       "requires": {
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -16810,9 +16816,9 @@
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.130.0.tgz",
-      "integrity": "sha512-0BWx7C6GhHBrjPUuSgMnRA4InxYisX6MIGs5yIHk2OArYkQLJMdeORYXXz1y40ahMihmtjD/Ap5xQGBm2vyffA==",
+      "version": "3.137.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.137.0.tgz",
+      "integrity": "sha512-CvMpemcsOkoMEz0iALamyQBt1rHx98NvF/cay019F8m+umD03I8CclDugy/13DqESWfsVxn91lZY/DOnO+si7A==",
       "requires": {
         "@aws-sdk/config-resolver": "3.130.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
@@ -17271,9 +17277,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -20897,9 +20903,9 @@
       }
     },
     "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -21372,9 +21378,9 @@
       }
     },
     "date-format": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.11.tgz",
-      "integrity": "sha512-VS20KRyorrbMCQmpdl2hg5KaOUsda1RbnsJg461FfrcyCUg+pkd0b40BSW4niQyTheww4DBXQnS7HwSrKkipLw=="
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.13.tgz",
+      "integrity": "sha512-bnYCwf8Emc3pTD8pXnre+wfnjGtfi5ncMDKy7+cWZXbmRAsdWkOQHrfC1yz/KiwP5thDp2kCHWYWKBX4HP1hoQ=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -22216,9 +22222,9 @@
       "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
     },
     "faros-feeds-sdk": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.12.5.tgz",
-      "integrity": "sha512-7jhgXR+IqqwuqWODd0Yk8xIzU9sOwzHTBIHP3xvmmCLhPJa9JTGGqaZ+tOW5dBJhJSWNexUh+2hw4uPeAJ6aIw==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.12.6.tgz",
+      "integrity": "sha512-fmGtagotE27TCaEBpz/EZVXvIPr+9x566BAYQ/MVmFkGjtdIAT2VUWsaS7EAjouBfJuKvCvZmVkpPRmiX5BlUg==",
       "requires": {
         "@avro/common-types": "^0.2.0",
         "@avro/streams": "^1.0.10",
@@ -24412,9 +24418,9 @@
       }
     },
     "keyv": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
-      "integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
+      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
       "requires": {
         "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
@@ -27123,9 +27129,9 @@
       "dev": true
     },
     "responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "requires": {
         "lowercase-keys": "^2.0.0"
       }

--- a/sources/bitbucket-source/src/bitbucket/bitbucket.ts
+++ b/sources/bitbucket-source/src/bitbucket/bitbucket.ts
@@ -244,6 +244,9 @@ export class Bitbucket {
       return await this.doGetEnvironment(workspace, repoSlug, envID);
     } catch (err) {
       try {
+        this.logger.debug(
+          `Error fetching ${envID} environment for repository "${workspace}/${repoSlug}"`
+        );
         return await this.doGetEnvironment(
           workspace,
           repoSlug,


### PR DESCRIPTION
## Description

Address certain cases where the `getEnvironment` endpoint of the Bitbucket API requires the environment id to be URIencoded.

Related thread: https://faroscommunity.slack.com/archives/C0335HMN2NQ/p1658348344173329

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
