### PR TITLE
Lowercase source when converting StreamName to string

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/converter.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter.ts
@@ -16,9 +16,7 @@ export abstract class ConverterTyped<R> {
   get streamName(): StreamName {
     if (this.stream) return this.stream;
     this.stream = StreamName.fromString(
-      `${this.source.toLowerCase()}${StreamNameSeparator}${snakeCase(
-        this.constructor.name
-      )}`
+      `${this.source}${StreamNameSeparator}${snakeCase(this.constructor.name)}`
     );
     return this.stream;
   }
@@ -134,7 +132,7 @@ export class StreamName {
 
   get asString(): string {
     if (this.str) return this.str;
-    this.str = `${this.source}${StreamNameSeparator}${this.name}`;
+    this.str = `${this.source.toLowerCase()}${StreamNameSeparator}${this.name}`;
     return this.str;
   }
 

--- a/destinations/airbyte-faros-destination/test/converters/converter.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/converter.test.ts
@@ -1,0 +1,46 @@
+import {AirbyteLogger, AirbyteRecord} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {Converter, StreamContext} from '../../src';
+import {DestinationRecordTyped} from '../../src/converters/converter';
+
+describe('converter', () => {
+  class GroupUsers extends Converter {
+    source = 'MyCustomSource';
+    id(record: AirbyteRecord) {
+      return record.record.data.id;
+    }
+    get destinationModels(): readonly string[] {
+      return [];
+    }
+    async convert(
+      record: AirbyteRecord,
+      ctx: StreamContext
+    ): Promise<readonly DestinationRecordTyped<Dictionary<any, string>>[]> {
+      return [];
+    }
+  }
+
+  test('process stream names', () => {
+    const converter = new GroupUsers();
+    expect(converter.streamName.source).toEqual('MyCustomSource');
+    expect(converter.streamName.name).toEqual('group_users');
+    expect(converter.streamName.asString).toEqual(
+      'mycustomsource__group_users'
+    );
+  });
+
+  test('set and get records from StreamContext', () => {
+    const stream = new GroupUsers().streamName.asString;
+    const ctx = new StreamContext(new AirbyteLogger(), {});
+    const record = new AirbyteRecord({
+      stream,
+      emitted_at: 123,
+      data: {id: 'id1'},
+    });
+    ctx.set(stream, 'id1', record);
+    expect(ctx.get(stream, 'id1')).toEqual(record);
+    expect(ctx.get(stream, 'id2')).toBeUndefined();
+    expect(ctx.getAll(stream)).toEqual({id1: record});
+  });
+});


### PR DESCRIPTION
## Description

We need the sources to be lowercased so that the StreamName generated by a Converter is consistent with the StreamNames of dependencies.

Example:
The Jira Issues Converter needs to have the StreamName string `jira__issues` to match its dependencies https://github.com/faros-ai/airbyte-connectors/blob/main/destinations/airbyte-faros-destination/src/converters/jira/issues.ts#L60-L71

In a subsequent PR, I'm going to update all the converter dependencies to reference their own source instead of hardcoded strings, i.e. `this.source` instead of `'jira'`. However, `StreamName.asString()` still needs to lowercase the source to match the StreamNames used in generating the ConverterRegistry, where the paths to the converter files are used as keys.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
