### PR TITLE
ServiceNow: Correct destination model list

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
@@ -20,6 +20,8 @@ export class Incidents extends ServiceNowConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'ims_Incident',
     'ims_IncidentAssignment',
+    'compute_Application',
+    'ims_IncidentApplicationImpact',
   ];
 
   private seenApplications = new Set<string>();


### PR DESCRIPTION
## Description

Add missing destination models. @cjwooo this is needed to delete all written models during `full_refresh` mode, right?

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change