### PR TITLE
FAI-2934 - Upgrade Datadog client to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "root",
       "dependencies": {
-        "@datadog/datadog-api-client": "1.0.0-beta.8",
+        "@datadog/datadog-api-client": "1.2.0",
         "@gitbeaker/node": "^35.6.0",
         "@pagerduty/pdjs": "^2.2.4",
         "@snyk/docker-registry-v2-client": "^2.6.1",
@@ -20,6 +20,7 @@
         "commander": "^9.3.0",
         "condoit": "^2.1.0",
         "date-format": "^4.0.6",
+        "faros-airbyte-cdk": "^0.2.26",
         "faros-feeds-sdk": "^0.12.0",
         "fast-redact": "^3.0.2",
         "fs-extra": "^10.0.0",
@@ -1655,9 +1656,9 @@
       }
     },
     "node_modules/@datadog/datadog-api-client": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.0.0-beta.8.tgz",
-      "integrity": "sha512-CvybjktiBf0xJ9J85Rcl0DIiDQXkoN+5WhFBxIVsDnor3wX2MuJn9jg+1Ly3Ob3JONy8ITMAG9+IJhzRICwQ6A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.2.0.tgz",
+      "integrity": "sha512-u0yeEbtipiVjQOVjbsBLbnFmmDTd7Kahpy3UcB7Vn/z5+DBRPKhE31/KWpJ9/fg04t3ZlAUYzo93IR2xUf1iww==",
       "dependencies": {
         "@types/buffer-from": "^1.1.0",
         "@types/node": "*",
@@ -1670,7 +1671,6 @@
         "form-data": "^3.0.0",
         "loglevel": "^1.7.1",
         "pako": "^2.0.4",
-        "typedoc": "^0.22.11",
         "url-parse": "^1.4.3"
       },
       "engines": {
@@ -5157,9 +5157,9 @@
       }
     },
     "node_modules/axios-mock-adapter": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.1.tgz",
-      "integrity": "sha512-Pdm7nZuhkz/DSucQ4Bbo9qVBqfm9j7ev9ycTvIXHqvAjnJEjWPHKYfTfpounVp8MwjFFSHXGS7hCkTwAswtSTA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.2.tgz",
+      "integrity": "sha512-jzyNxU3JzB2XVhplZboUcF0YDs7xuExzoRSHXPHr+UQajaGmcTqvkkUADgkVI2WkGlpZ1zZlMVdcTMU0ejV8zQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "is-buffer": "^2.0.5"
@@ -5278,7 +5278,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-arraybuffer": {
       "version": "0.1.5",
@@ -7677,6 +7678,22 @@
         "node >=0.6.0"
       ]
     },
+    "node_modules/faros-airbyte-cdk": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/faros-airbyte-cdk/-/faros-airbyte-cdk-0.2.27.tgz",
+      "integrity": "sha512-EW6v+K6npMQUNp4DBqlFr9e6KYDQSX6RK3hnQBPOsCYCi58U28sMSce86LW1GQomqkh7tEQhZzqhWD29ymU5/g==",
+      "dependencies": {
+        "commander": "^9.3.0",
+        "fast-redact": "^3.0.2",
+        "json-schema-traverse": "^1.0.0",
+        "lodash": "^4.17.21",
+        "pino": "^7.5.1",
+        "verror": "^1.10.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/faros-feeds-sdk": {
       "version": "0.12.8",
       "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.12.8.tgz",
@@ -8085,7 +8102,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -9132,6 +9150,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10396,11 +10415,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg=="
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -11034,11 +11048,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
-    },
     "node_modules/luxon": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
@@ -11187,17 +11196,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/md5": {
@@ -14254,16 +14252,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -15206,68 +15194,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
-      "dependencies": {
-        "glob": "^8.0.3",
-        "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 12.10.0"
-      },
-      "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
-      }
-    },
-    "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typedoc/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15562,16 +15493,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -17267,9 +17188,9 @@
       }
     },
     "@datadog/datadog-api-client": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.0.0-beta.8.tgz",
-      "integrity": "sha512-CvybjktiBf0xJ9J85Rcl0DIiDQXkoN+5WhFBxIVsDnor3wX2MuJn9jg+1Ly3Ob3JONy8ITMAG9+IJhzRICwQ6A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.2.0.tgz",
+      "integrity": "sha512-u0yeEbtipiVjQOVjbsBLbnFmmDTd7Kahpy3UcB7Vn/z5+DBRPKhE31/KWpJ9/fg04t3ZlAUYzo93IR2xUf1iww==",
       "requires": {
         "@types/buffer-from": "^1.1.0",
         "@types/node": "*",
@@ -17282,7 +17203,6 @@
         "form-data": "^3.0.0",
         "loglevel": "^1.7.1",
         "pako": "^2.0.4",
-        "typedoc": "^0.22.11",
         "url-parse": "^1.4.3"
       }
     },
@@ -20161,9 +20081,9 @@
       }
     },
     "axios-mock-adapter": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.1.tgz",
-      "integrity": "sha512-Pdm7nZuhkz/DSucQ4Bbo9qVBqfm9j7ev9ycTvIXHqvAjnJEjWPHKYfTfpounVp8MwjFFSHXGS7hCkTwAswtSTA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.2.tgz",
+      "integrity": "sha512-jzyNxU3JzB2XVhplZboUcF0YDs7xuExzoRSHXPHr+UQajaGmcTqvkkUADgkVI2WkGlpZ1zZlMVdcTMU0ejV8zQ==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "is-buffer": "^2.0.5"
@@ -20258,7 +20178,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -22101,6 +22022,19 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
       "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
     },
+    "faros-airbyte-cdk": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/faros-airbyte-cdk/-/faros-airbyte-cdk-0.2.27.tgz",
+      "integrity": "sha512-EW6v+K6npMQUNp4DBqlFr9e6KYDQSX6RK3hnQBPOsCYCi58U28sMSce86LW1GQomqkh7tEQhZzqhWD29ymU5/g==",
+      "requires": {
+        "commander": "^9.3.0",
+        "fast-redact": "^3.0.2",
+        "json-schema-traverse": "^1.0.0",
+        "lodash": "^4.17.21",
+        "pino": "^7.5.1",
+        "verror": "^1.10.1"
+      }
+    },
     "faros-feeds-sdk": {
       "version": "0.12.8",
       "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-0.12.8.tgz",
@@ -22427,7 +22361,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -23223,6 +23158,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -24202,11 +24138,6 @@
       "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
       "integrity": "sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA=="
     },
-    "jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg=="
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -24688,11 +24619,6 @@
       "integrity": "sha512-OIP3DwzRZDfLg9B9VP/huWBlpvbkmbfiBy8xmsXp4RPmE4A3MhwNozc5ZJ3fWnSg8fDcdlE/neRTPG2ycEKliw==",
       "dev": true
     },
-    "lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
-    },
     "luxon": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
@@ -24816,11 +24742,6 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
-    },
-    "marked": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw=="
     },
     "md5": {
       "version": "2.3.0",
@@ -27200,16 +27121,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
-      }
-    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -27912,52 +27823,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
-      "requires": {
-        "glob": "^8.0.3",
-        "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
     },
     "typescript-memoize": {
       "version": "1.1.0",
@@ -28203,16 +28073,6 @@
           "dev": true
         }
       }
-    },
-    "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "commander": "^9.3.0",
         "condoit": "^2.1.0",
         "date-format": "^4.0.6",
-        "faros-airbyte-cdk": "^0.2.26",
         "faros-feeds-sdk": "^0.12.0",
         "fast-redact": "^3.0.2",
         "fs-extra": "^10.0.0",
@@ -7677,22 +7676,6 @@
       "engines": [
         "node >=0.6.0"
       ]
-    },
-    "node_modules/faros-airbyte-cdk": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/faros-airbyte-cdk/-/faros-airbyte-cdk-0.2.27.tgz",
-      "integrity": "sha512-EW6v+K6npMQUNp4DBqlFr9e6KYDQSX6RK3hnQBPOsCYCi58U28sMSce86LW1GQomqkh7tEQhZzqhWD29ymU5/g==",
-      "dependencies": {
-        "commander": "^9.3.0",
-        "fast-redact": "^3.0.2",
-        "json-schema-traverse": "^1.0.0",
-        "lodash": "^4.17.21",
-        "pino": "^7.5.1",
-        "verror": "^1.10.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/faros-feeds-sdk": {
       "version": "0.12.8",
@@ -22021,19 +22004,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
       "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
-    },
-    "faros-airbyte-cdk": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/faros-airbyte-cdk/-/faros-airbyte-cdk-0.2.27.tgz",
-      "integrity": "sha512-EW6v+K6npMQUNp4DBqlFr9e6KYDQSX6RK3hnQBPOsCYCi58U28sMSce86LW1GQomqkh7tEQhZzqhWD29ymU5/g==",
-      "requires": {
-        "commander": "^9.3.0",
-        "fast-redact": "^3.0.2",
-        "json-schema-traverse": "^1.0.0",
-        "lodash": "^4.17.21",
-        "pino": "^7.5.1",
-        "verror": "^1.10.1"
-      }
     },
     "faros-feeds-sdk": {
       "version": "0.12.8",

--- a/sources/datadog-source/package.json
+++ b/sources/datadog-source/package.json
@@ -30,7 +30,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "1.0.0-beta.8",
+    "@datadog/datadog-api-client": "1.2.0",
     "axios": "^0.26.0",
     "commander": "^9.3.0",
     "faros-airbyte-cdk": "0.0.1",


### PR DESCRIPTION
## Description

Upgrade the Datadog API client to 1.2.0. There was some slight changes to the client's creation that needed to be updated. Also annoyingly they did not document correctly how to set unstable operations until yesterday.

**QUESTION:**
Are the changes in the package-lock.json correct? seems like a lot is changing...

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change