### PR TITLE
FAI-3026 - Retrieve active status from employmentHistoryStatus

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -674,7 +674,7 @@
                       "inactive_employment_history_status": {
                         "type": "string",
                         "title": "Inactive employmentHistoryStatus",
-                        "description": "The configured value for the employeeHistoryStatus that is equivalent to an employee being inactive",
+                        "description": "The configured value for the employeeHistoryStatus that is equivalent to an employee being inactive"
                       }
                     }
                   }

--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -670,6 +670,11 @@
                         "title": "Bootstrap Teams From Managers",
                         "description": "Assign employees to teams based off their managers.",
                         "default": false
+                      },
+                      "inactive_employment_history_status": {
+                        "type": "string",
+                        "title": "Inactive employmentHistoryStatus",
+                        "description": "The configured value for the employeeHistoryStatus that is equivalent to an employee being inactive",
                       }
                     }
                   }

--- a/destinations/airbyte-faros-destination/src/converters/bamboohr/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/bamboohr/common.ts
@@ -4,6 +4,7 @@ import {Converter, StreamContext} from '../converter';
 
 export interface BambooHRConfig {
   bootstrap_teams_from_managers?: boolean;
+  inactive_employment_history_status?: string;
 }
 
 /** BambooHR converter base */
@@ -20,5 +21,9 @@ export abstract class BambooHRConverter extends Converter {
 
   protected bootstrapTeamsFromManagers(ctx: StreamContext): boolean {
     return this.bamboohrConfig(ctx).bootstrap_teams_from_managers ?? false;
+  }
+
+  protected inactiveEmploymentHistoryStatus(ctx: StreamContext): string {
+    return this.bamboohrConfig(ctx).inactive_employment_history_status;
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/bamboohr/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/bamboohr/common.ts
@@ -23,7 +23,9 @@ export abstract class BambooHRConverter extends Converter {
     return this.bamboohrConfig(ctx).bootstrap_teams_from_managers ?? false;
   }
 
-  protected inactiveEmploymentHistoryStatus(ctx: StreamContext): string {
+  protected inactiveEmploymentHistoryStatus(
+    ctx: StreamContext
+  ): string | undefined {
     return this.bamboohrConfig(ctx).inactive_employment_history_status;
   }
 }


### PR DESCRIPTION
## Description

This PR allows for the configuration of the custom 'employmentHistoryStatus' value that is equivalent to 'inactive' that should be used to determine if a user is inactive in Faros. If this configuration is not provided, the converter will fall back to doing what it was doing before: looking at the 'status' field.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change