### PR TITLE
Fix error handling in batch operations

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -196,24 +196,23 @@ export class GraphQLClient {
     const gql = GraphQLClient.batchMutation(queries);
     if (gql) {
       const res = await this.backend.postQuery(gql);
-      if (res.errors) {
+      if (res.data.errors) {
         this.logger.warn(
           `Error while saving batch: ${JSON.stringify(
-            res.errors
+            res.data.errors
           )}. Query: ${gql}`
         );
         // now try mutations individually and fail on the first bad one
         for (const op of this.writeBuffer) {
           const opGql = jsonToGraphQLQuery(op.query);
           const opRes = await this.backend.postQuery(opGql);
-          if (opRes.errors) {
+          this.writeBuffer.shift();
+          if (opRes.data.errors) {
             throw new VError(
               `${op.errorMsg} with query '${opGql}': ${JSON.stringify(
-                opRes.errors
+                opRes.data.errors
               )}`
             );
-          } else {
-            this.writeBuffer.shift();
           }
         }
       } else {


### PR DESCRIPTION
## Description

This PR fixes two issues:

1. The `errors` (if present) is a field under `response.data` instead of under `response`
2. We should always remove from the write buffer. We currently do not remove operations that fail in Hasura, so they are always kept around in the front of the buffer.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
