### PR TITLE
FAI-3028 Add uid to compute application model in ServiceNow

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/common/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/common/common.ts
@@ -1,5 +1,3 @@
-import {toLower} from 'lodash';
-
 /** Common functions shared across converters */
 export class Common {
   static computeApplication(
@@ -17,7 +15,7 @@ export class Common {
     name: string,
     platform?: string
   ): string {
-    if (!platform) return toLower(name);
-    return [toLower(name), toLower(platform)].join('_');
+    if (!platform) return name;
+    return [name, platform].join('_');
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/common/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/common/common.ts
@@ -1,0 +1,23 @@
+import {toLower} from 'lodash';
+
+/** Common functions shared across converters */
+export class Common {
+  static computeApplication(
+    name: string,
+    platform?: string
+  ): {name: string; platform?: string; uid: string} {
+    return {
+      name,
+      platform: platform ?? '',
+      uid: Common.computeApplicationUid(name, platform),
+    };
+  }
+
+  private static computeApplicationUid(
+    name: string,
+    platform?: string
+  ): string {
+    if (!platform) return toLower(name);
+    return [toLower(name), toLower(platform)].join('_');
+  }
+}

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
@@ -1,6 +1,7 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-feeds-sdk';
 
+import {Common} from '../common/common';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {
   IncidentPriorityCategory,
@@ -94,26 +95,22 @@ export class Incidents extends ServiceNowConverter {
     if (applicationName) {
       const applicationMapping = this.applicationMapping(ctx);
 
-      let application = {
-        name: applicationName,
-        platform: '',
-      };
+      let application = Common.computeApplication(applicationName, '');
 
       if (
         applicationName in applicationMapping &&
         applicationMapping[applicationName].name
       ) {
         const mappedApp = applicationMapping[applicationName];
-        application = {
-          name: mappedApp.name,
-          platform: mappedApp.platform ?? application.platform,
-        };
+        application = Common.computeApplication(
+          mappedApp.name,
+          mappedApp.platform ?? application.platform
+        );
       }
 
-      const appKey = JSON.stringify(application);
-      if (!this.seenApplications.has(appKey)) {
+      if (!this.seenApplications.has(application.uid)) {
         res.push({model: 'compute_Application', record: application});
-        this.seenApplications.add(appKey);
+        this.seenApplications.add(application.uid);
       }
 
       res.push({

--- a/destinations/airbyte-faros-destination/test/converters/common.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/common.test.ts
@@ -1,0 +1,31 @@
+import {Common} from '../../src/converters/common/common';
+
+describe('common', () => {
+  test('build computeApplication', async () => {
+    expect(Common.computeApplication('SomeApp')).toStrictEqual({
+      name: 'SomeApp',
+      platform: '',
+      uid: 'someapp',
+    });
+    expect(Common.computeApplication('SomeApp', undefined)).toStrictEqual({
+      name: 'SomeApp',
+      platform: '',
+      uid: 'someapp',
+    });
+    expect(Common.computeApplication('SomeApp', null)).toStrictEqual({
+      name: 'SomeApp',
+      platform: '',
+      uid: 'someapp',
+    });
+    expect(Common.computeApplication('SomeApp', '')).toStrictEqual({
+      name: 'SomeApp',
+      platform: '',
+      uid: 'someapp',
+    });
+    expect(Common.computeApplication('SomeApp', 'SomePlatform')).toStrictEqual({
+      name: 'SomeApp',
+      platform: 'SomePlatform',
+      uid: 'someapp_someplatform',
+    });
+  });
+});

--- a/destinations/airbyte-faros-destination/test/converters/common.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/common.test.ts
@@ -5,27 +5,27 @@ describe('common', () => {
     expect(Common.computeApplication('SomeApp')).toStrictEqual({
       name: 'SomeApp',
       platform: '',
-      uid: 'someapp',
+      uid: 'SomeApp',
     });
     expect(Common.computeApplication('SomeApp', undefined)).toStrictEqual({
       name: 'SomeApp',
       platform: '',
-      uid: 'someapp',
+      uid: 'SomeApp',
     });
     expect(Common.computeApplication('SomeApp', null)).toStrictEqual({
       name: 'SomeApp',
       platform: '',
-      uid: 'someapp',
+      uid: 'SomeApp',
     });
     expect(Common.computeApplication('SomeApp', '')).toStrictEqual({
       name: 'SomeApp',
       platform: '',
-      uid: 'someapp',
+      uid: 'SomeApp',
     });
     expect(Common.computeApplication('SomeApp', 'SomePlatform')).toStrictEqual({
       name: 'SomeApp',
       platform: 'SomePlatform',
-      uid: 'someapp_someplatform',
+      uid: 'SomeApp_SomePlatform',
     });
   });
 });


### PR DESCRIPTION
## Description

Add uid to compute application model in ServiceNow (for Faros Community Edition)

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
