### PR TITLE
fix: create unique pipeline id based on project

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/semaphoreci/pipelines.ts
+++ b/destinations/airbyte-faros-destination/src/converters/semaphoreci/pipelines.ts
@@ -54,7 +54,7 @@ export class Pipelines extends SemaphoreCIConverter {
     const pipeline = {
       model: 'cicd_Pipeline',
       record: {
-        uid: pipelineRecord.name,
+        uid: `${project?.record?.data?.metadata.name}-${pipelineRecord.name}`,
         name: pipelineRecord.name,
         organization: organizationKey,
       },


### PR DESCRIPTION
## Description

Semaphore data model doesn't have a concept of a templated pipeline, so we create these references and data model from the pipeline build executions as it can be seen [here](https://github.com/faros-ai/airbyte-connectors/blob/main/destinations/airbyte-faros-destination/src/converters/semaphoreci/pipelines.ts#L45-L61)

Currently we are using the **pipelineRecord.name** as the unique identifier for the pipeline record 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
