### PR TITLE
fix: create unique pipeline id based on project

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/semaphoreci/pipelines.ts
+++ b/destinations/airbyte-faros-destination/src/converters/semaphoreci/pipelines.ts
@@ -54,7 +54,7 @@ export class Pipelines extends SemaphoreCIConverter {
     const pipeline = {
       model: 'cicd_Pipeline',
       record: {
-        uid: pipelineRecord.name,
+        uid: `${project?.record?.data?.metadata.name}-${pipelineRecord.name}`,
         name: pipelineRecord.name,
         organization: organizationKey,
       },


### PR DESCRIPTION
## Description

Semaphore doesn't have a data model that represents uniqueness of a given pipeline. Currently we are taking the pipeline runs and using this to create a definition of a cicd_Pipeline. However, we are using the attribute `pipeline.name` as the unique identifier but this is not valid as pipelines across multiple repositories can have the same name.

This change concatenates the repository name to the `cicd_Pipeline`.`uid` which allow us to correctly create unique pipelines referencing their repository counter part

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues


## Migration notes

CICD data will need to be reloaded so that this change backfills existing loaded data 
