### PR TITLE
CircleCI: Fixes differences in pipeline and organization UIDs

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/circleci/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/circleci/common.ts
@@ -9,7 +9,7 @@ export class CircleCICommon {
     return {
       uid: `${toLower(pipeline.id)}_${toLower(workflow.id)}`,
       pipeline: {
-        uid: pipeline.project_slug,
+        uid: this.getProject(pipeline.project_slug),
         organization: {
           uid: this.getOrganization(pipeline.project_slug),
           source,

--- a/destinations/airbyte-faros-destination/src/converters/circleci/projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/circleci/projects.ts
@@ -2,7 +2,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {toLower} from 'lodash';
 
 import {DestinationModel, DestinationRecord} from '../converter';
-import {CircleCIConverter} from './common';
+import {CircleCICommon, CircleCIConverter} from './common';
 import {Project} from './models';
 
 export class Projects extends CircleCIConverter {
@@ -15,13 +15,13 @@ export class Projects extends CircleCIConverter {
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const source = this.streamName.source;
     const project = record.record.data as Project;
-    const uid = toLower(project.id);
-    const orgSlug = toLower(project.organization_slug);
+    const projectUid = CircleCICommon.getProject(project.slug);
+    const orgUid = CircleCICommon.getOrganization(project.slug);
     const res: DestinationRecord[] = [];
     res.push({
       model: 'cicd_Organization',
       record: {
-        uid: orgSlug,
+        uid: orgUid,
         name: project.organization_name,
         source,
       },
@@ -29,9 +29,9 @@ export class Projects extends CircleCIConverter {
     res.push({
       model: 'cicd_Pipeline',
       record: {
-        uid,
+        uid: projectUid,
         name: project.name,
-        organization: {uid: orgSlug, source},
+        organization: {uid: orgUid, source},
       },
     });
     return res;


### PR DESCRIPTION
Fixes differences in pipeline and organization UIDs

## Description
> Currently different in the project vs pipeline streams. Leads to duplication of cicd_Pipeline entries with different IDs. 

## Type of change
- [x] Bug fix

## Migration notes

> Full resync will be necessary

## Extra info

> We always use the full project slug and common methods, because the Circle CI API documentation is incorrect on fields like organization_slug.
