### PR TITLE
Adds `failure_type` to trace message and `stack_trace` to log message

### DIFF
--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -485,7 +485,8 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
           .promisify(fn)()
           .catch((err) =>
             this.logger.error(
-              `Failed to send write stats to Segment: ${err.message}`
+              `Failed to send write stats to Segment: ${err.message}`,
+              err.stack
             )
           );
       }
@@ -634,7 +635,8 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
     } catch (e: any) {
       stats.recordsErrored++;
       this.logger.error(
-        `Error processing input: ${e.message ?? JSON.stringify(e)}`
+        `Error processing input: ${e.message ?? JSON.stringify(e)}`,
+        e.stack
       );
       switch (this.invalidRecordStrategy) {
         case InvalidRecordStrategy.SKIP:
@@ -669,7 +671,7 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
         if (err.message.includes('Cannot find module ')) {
           this.logger.info(`No converter found for ${stream}`);
         } else {
-          this.logger.error(err.message);
+          this.logger.error(err.message, err.stack);
         }
       });
       if (converter) {

--- a/faros-airbyte-cdk/src/destinations/destination-runner.ts
+++ b/faros-airbyte-cdk/src/destinations/destination-runner.ts
@@ -92,7 +92,8 @@ export class AirbyteDestinationRunner<
             const w = wrapApiError(e);
             const s = JSON.stringify(w);
             this.logger.error(
-              `Encountered an error while writing to destination: ${w} - ${s}`
+              `Encountered an error while writing to destination: ${w} - ${s}`,
+              w.stack
             );
             throw e;
           } finally {
@@ -116,7 +117,8 @@ export class AirbyteDestinationRunner<
       const w = wrapApiError(e);
       const s = JSON.stringify(w);
       this.logger.error(
-        `Encountered an error while loading configuration: ${w} - ${s}`
+        `Encountered an error while loading configuration: ${w} - ${s}`,
+        w.stack
       );
       throw e;
     }

--- a/faros-airbyte-cdk/src/logger.ts
+++ b/faros-airbyte-cdk/src/logger.ts
@@ -2,13 +2,13 @@ import pino, {DestinationStream, Level, Logger} from 'pino';
 import stream from 'stream';
 
 import {
-  AirbyteFailureType,
   AirbyteLog,
   AirbyteLogLevel,
   AirbyteLogLevelOrder,
   AirbyteMessage,
   AirbyteMessageType,
-  AirbyteTraceMessage,
+  AirbyteTrace,
+  AirbyteTraceFailureType,
 } from './protocol';
 
 export class AirbyteLogger {
@@ -41,8 +41,8 @@ export class AirbyteLogger {
     this.write(AirbyteLog.make(AirbyteLogLevel.DEBUG, message, stack_trace));
   }
 
-  trace(error: any, failure_type?: AirbyteFailureType): void {
-    this.write(new AirbyteTraceMessage(error, failure_type));
+  trace(error: any, failure_type?: AirbyteTraceFailureType): void {
+    this.write(new AirbyteTrace(error, failure_type));
   }
 
   write(msg: AirbyteMessage): void {

--- a/faros-airbyte-cdk/src/logger.ts
+++ b/faros-airbyte-cdk/src/logger.ts
@@ -2,12 +2,13 @@ import pino, {DestinationStream, Level, Logger} from 'pino';
 import stream from 'stream';
 
 import {
-  AirbyteErrorTraceMessage,
+  AirbyteFailureType,
   AirbyteLog,
   AirbyteLogLevel,
   AirbyteLogLevelOrder,
   AirbyteMessage,
   AirbyteMessageType,
+  AirbyteTraceMessage,
 } from './protocol';
 
 export class AirbyteLogger {
@@ -24,28 +25,24 @@ export class AirbyteLogger {
     }
   }
 
-  error(message: string): void {
-    this.log(AirbyteLogLevel.ERROR, message);
+  error(message: string, stack_trace?: string): void {
+    this.write(AirbyteLog.make(AirbyteLogLevel.ERROR, message, stack_trace));
   }
 
-  warn(message: string): void {
-    this.log(AirbyteLogLevel.WARN, message);
+  warn(message: string, stack_trace?: string): void {
+    this.write(AirbyteLog.make(AirbyteLogLevel.WARN, message, stack_trace));
   }
 
-  info(message: string): void {
-    this.log(AirbyteLogLevel.INFO, message);
+  info(message: string, stack_trace?: string): void {
+    this.write(AirbyteLog.make(AirbyteLogLevel.INFO, message, stack_trace));
   }
 
-  debug(message: string): void {
-    this.log(AirbyteLogLevel.DEBUG, message);
+  debug(message: string, stack_trace?: string): void {
+    this.write(AirbyteLog.make(AirbyteLogLevel.DEBUG, message, stack_trace));
   }
 
-  trace(error: any): void {
-    this.write(new AirbyteErrorTraceMessage(error));
-  }
-
-  private log(level: AirbyteLogLevel, message: string): void {
-    this.write(AirbyteLog.make(level, message));
+  trace(error: any, failure_type?: AirbyteFailureType): void {
+    this.write(new AirbyteTraceMessage(error, failure_type));
   }
 
   write(msg: AirbyteMessage): void {

--- a/faros-airbyte-cdk/src/logger.ts
+++ b/faros-airbyte-cdk/src/logger.ts
@@ -41,8 +41,12 @@ export class AirbyteLogger {
     this.write(AirbyteLog.make(AirbyteLogLevel.DEBUG, message, stack_trace));
   }
 
-  trace(error: any, failure_type?: AirbyteTraceFailureType): void {
-    this.write(new AirbyteTrace(error, failure_type));
+  trace(message: string, stack_trace?: string): void {
+    this.write(AirbyteLog.make(AirbyteLogLevel.TRACE, message, stack_trace));
+  }
+
+  traceError(error: any, failure_type?: AirbyteTraceFailureType): void {
+    this.write(AirbyteTrace.make(error, failure_type));
   }
 
   write(msg: AirbyteMessage): void {

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -44,7 +44,7 @@ export enum AirbyteConnectionStatus {
   FAILED = 'FAILED',
 }
 
-export enum AirbyteFailureType {
+export enum AirbyteTraceFailureType {
   SYSTEM_ERROR = 'system_error',
   CONFIG_ERROR = 'config_error',
 }
@@ -66,6 +66,7 @@ export function parseAirbyteMessage(s: string): AirbyteMessage {
       case AirbyteMessageType.LOG:
       case AirbyteMessageType.SPEC:
       case AirbyteMessageType.STATE:
+      case AirbyteMessageType.TRACE:
         return res;
       default:
         throw new VError(`Unsupported message type ${res.type}`);
@@ -202,14 +203,14 @@ export interface AirbyteTraceError {
     message: string;
     internal_message?: string;
     stack_trace?: string;
-    failure_type?: AirbyteFailureType;
+    failure_type?: AirbyteTraceFailureType;
   };
 }
 
-export class AirbyteTraceMessage implements AirbyteMessage {
+export class AirbyteTrace implements AirbyteMessage {
   readonly type: AirbyteMessageType = AirbyteMessageType.TRACE;
   readonly trace: AirbyteTraceError;
-  constructor(err: any, failure_type?: AirbyteFailureType) {
+  constructor(err: any, failure_type?: AirbyteTraceFailureType) {
     const wrapped = wrapApiError(err);
     this.trace = {
       type: 'ERROR',

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -209,10 +209,22 @@ export interface AirbyteTraceError {
 
 export class AirbyteTrace implements AirbyteMessage {
   readonly type: AirbyteMessageType = AirbyteMessageType.TRACE;
-  readonly trace: AirbyteTraceError;
-  constructor(err: any, failure_type?: AirbyteTraceFailureType) {
+  constructor(
+    readonly trace: {
+      type: 'ERROR';
+      emitted_at: number;
+      error: {
+        message: string;
+        internal_message?: string;
+        stack_trace?: string;
+        failure_type?: AirbyteTraceFailureType;
+      };
+    }
+  ) {}
+
+  static make(err: any, failure_type?: AirbyteTraceFailureType): AirbyteTrace {
     const wrapped = wrapApiError(err);
-    this.trace = {
+    return new AirbyteTrace({
       type: 'ERROR',
       emitted_at: Date.now(),
       error: {
@@ -222,7 +234,7 @@ export class AirbyteTrace implements AirbyteMessage {
         failure_type,
         ...wrapped,
       },
-    };
+    });
   }
 }
 

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -195,7 +195,7 @@ export class AirbyteRecord implements AirbyteMessage {
   }
 }
 
-export interface AirbyteTrace {
+export interface AirbyteTraceError {
   type: 'ERROR';
   emitted_at: number;
   error: {
@@ -208,7 +208,7 @@ export interface AirbyteTrace {
 
 export class AirbyteTraceMessage implements AirbyteMessage {
   readonly type: AirbyteMessageType = AirbyteMessageType.TRACE;
-  readonly trace: AirbyteTrace;
+  readonly trace: AirbyteTraceError;
   constructor(err: any, failure_type?: AirbyteFailureType) {
     const wrapped = wrapApiError(err);
     this.trace = {

--- a/faros-airbyte-cdk/src/runner.ts
+++ b/faros-airbyte-cdk/src/runner.ts
@@ -7,7 +7,7 @@ export abstract class Runner {
       throw error;
     });
     process.on('uncaughtException', (error) => {
-      logger.trace(error, AirbyteTraceFailureType.SYSTEM_ERROR);
+      logger.traceError(error, AirbyteTraceFailureType.SYSTEM_ERROR);
       process.exit(1);
     });
   }

--- a/faros-airbyte-cdk/src/runner.ts
+++ b/faros-airbyte-cdk/src/runner.ts
@@ -1,4 +1,5 @@
 import {AirbyteLogger} from './logger';
+import {AirbyteFailureType} from './protocol';
 
 export abstract class Runner {
   constructor(protected readonly logger: AirbyteLogger) {
@@ -6,7 +7,7 @@ export abstract class Runner {
       throw error;
     });
     process.on('uncaughtException', (error) => {
-      logger.trace(error);
+      logger.trace(error, AirbyteFailureType.SYSTEM_ERROR);
       process.exit(1);
     });
   }

--- a/faros-airbyte-cdk/src/runner.ts
+++ b/faros-airbyte-cdk/src/runner.ts
@@ -1,5 +1,5 @@
 import {AirbyteLogger} from './logger';
-import {AirbyteFailureType} from './protocol';
+import {AirbyteTraceFailureType} from './protocol';
 
 export abstract class Runner {
   constructor(protected readonly logger: AirbyteLogger) {
@@ -7,7 +7,7 @@ export abstract class Runner {
       throw error;
     });
     process.on('uncaughtException', (error) => {
-      logger.trace(error, AirbyteFailureType.SYSTEM_ERROR);
+      logger.trace(error, AirbyteTraceFailureType.SYSTEM_ERROR);
       process.exit(1);
     });
   }

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -138,7 +138,8 @@ export abstract class AirbyteSourceBase<
         this.logger.error(
           `Encountered an error while reading stream ${streamName}: ${
             e.message ?? JSON.stringify(e)
-          }`
+          }`,
+          e.stack
         );
         throw e;
       }

--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -102,7 +102,8 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
             const w = wrapApiError(e);
             const s = JSON.stringify(w);
             this.logger.error(
-              `Encountered an error while reading from source: ${w} - ${s}`
+              `Encountered an error while reading from source: ${w} - ${s}`,
+              w.stack
             );
             throw e;
           }

--- a/sources/azureactivedirectory-source/src/azureactivedirectory.ts
+++ b/sources/azureactivedirectory-source/src/azureactivedirectory.ts
@@ -114,13 +114,14 @@ export class AzureActiveDirectory {
           yield item;
         }
       } catch (err: any) {
-        const errorMessage = wrapApiError(err).message;
+        const w = wrapApiError(err);
         this.logger.error(
           `Failed requesting '${path}' with params ${JSON.stringify(
             param
-          )}. Error: ${errorMessage}`
+          )}. Error: ${w.message}`,
+          w.stack
         );
-        throw new VError(errorMessage);
+        throw new VError(w.message);
       }
     } while (after);
   }
@@ -145,8 +146,9 @@ export class AzureActiveDirectory {
         if (managerItem.status === 200) {
           user.manager = managerItem.data.id;
         }
-      } catch (error) {
-        this.logger.error(error.toString());
+      } catch (e: any) {
+        const w = wrapApiError(e);
+        this.logger.error(w.message, w.stack);
       }
       yield user;
     }

--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -284,11 +284,12 @@ export class BitbucketServer {
               },
             },
           };
-        } catch (err) {
+        } catch (err: any) {
           this.logger.error(
             `Failed to parse raw diff for repository ${fullName} pull request ${
               pr.id
-            }: ${JSON.stringify(err)}`
+            }: ${JSON.stringify(err)}`,
+            err.stack
           );
         }
       }

--- a/sources/harness-source/src/harness.ts
+++ b/sources/harness-source/src/harness.ts
@@ -118,9 +118,9 @@ export class Harness {
         }
         offset += executions.pageInfo.limit ?? executions.nodes.length;
         hasMore = executions.pageInfo.hasMore;
-      } catch (ex: any) {
-        logger.error(ex);
-        throw ex;
+      } catch (e: any) {
+        logger.error(e, e.stack);
+        throw e;
       }
     } while (hasMore);
   }

--- a/sources/okta-source/src/okta.ts
+++ b/sources/okta-source/src/okta.ts
@@ -69,13 +69,14 @@ export class Okta {
           yield item;
         }
       } catch (err: any) {
-        const errorMessage = wrapApiError(err).message;
+        const w = wrapApiError(err);
         this.logger.error(
           `Failed requesting '${path}' with params ${JSON.stringify(
             finalParams
-          )}. Error: ${errorMessage}`
+          )}. Error: ${w.message}`,
+          w.stack
         );
-        throw new VError(errorMessage);
+        throw new VError(w.message);
       }
     } while (after);
   }

--- a/sources/phabricator-source/src/phabricator.ts
+++ b/sources/phabricator-source/src/phabricator.ts
@@ -484,11 +484,12 @@ export class Phabricator {
               pick(f, 'deletions', 'additions', 'from', 'to', 'deleted', 'new')
             ),
           };
-        } catch (err) {
+        } catch (err: any) {
           this.logger.error(
             `Failed to parse raw diff for ${revision.phid}: ${JSON.stringify(
               err
-            )}`
+            )}`,
+            err.stack
           );
         }
       }


### PR DESCRIPTION
## Description

Adds [`failure_type`](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml#L194) to trace message and [`stack_trace`](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml#L157) to log message

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Additional info
1. https://docs.airbyte.com/understanding-airbyte/airbyte-protocol/#airbytelogmessage
2. https://docs.airbyte.com/understanding-airbyte/airbyte-protocol/#changelog