### PR TITLE
FAI-3587: Validate Dashboard sync for Faros tenant's V2 graph

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -2,7 +2,7 @@ import dateformat from 'date-format';
 import {AirbyteLogger} from 'faros-airbyte-cdk';
 import {Schema, SchemaLoader} from 'faros-feeds-sdk';
 import {EnumType, jsonToGraphQLQuery} from 'json-to-graphql-query';
-import {difference, intersection} from 'lodash';
+import {difference, intersection, isNil} from 'lodash';
 import traverse from 'traverse';
 import {Dictionary} from 'ts-essentials';
 import {VError} from 'verror';
@@ -306,7 +306,7 @@ export class GraphQLClient {
         );
       } else {
         const val = this.formatFieldValue(model, field, value);
-        if (val) obj[field] = val;
+        if (!isNil(val)) obj[field] = val;
       }
     }
     obj['origin'] = origin;
@@ -317,7 +317,7 @@ export class GraphQLClient {
   }
 
   private formatFieldValue(model: string, field: string, value: any): any {
-    if (!value) return undefined;
+    if (isNil(value)) return undefined;
     const type = this.schema.scalars[model][field];
     if (!type) {
       this.logger.debug(`Could not find type of ${field} in ${model}`);


### PR DESCRIPTION
## Description

Ensure falsy values like `""` and `0` are valid field values.  This was discovered while reconciling Clio v1 vs. Hasura v2 Aion extract tables.  In a [converter](https://github.com/faros-ai/airbyte-connectors/blob/main/destinations/airbyte-faros-destination/src/converters/common/common.ts#L9) we explicitly set a field to `""`.  The prior logic was converting this back to `undefined`.  

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change