### PR TITLE
Add project name as pipeline name in GitLab

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
@@ -37,6 +37,7 @@ export class Pipelines extends GitlabConverter {
       number: pipeline.id,
       pipeline: pipelineKey,
       status,
+      name: repository.name,
       url: pipeline.web_url,
       createdAt: Utils.toDate(pipeline.created_at),
       startedAt: Utils.toDate(pipeline.created_at),


### PR DESCRIPTION
## Description

Right now, it is empty. Given that each project has only one pipeline defined (we do not do anything with stages), that would be helpful.

Given https://github.com/airbytehq/airbyte/issues/18173, the git dashboard at https://github.com/faros-ai/faros-community-edition/pull/231 benefits from having the pipeline name always filled with the relevant details

## Type of change
- [x] New feature

## Related issues
* https://github.com/airbytehq/airbyte/issues/18173
* https://github.com/faros-ai/faros-community-edition/pull/231