### PR TITLE
Add an option to enable keep alive in Faros Destination

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -709,6 +709,13 @@
             }
           }
         ]
+      },
+      "keep_alive": {
+        "order": 8,
+        "type": "boolean",
+        "title": "HTTP Keep Alive",
+        "description": "Maintains a connection between a client and your server",
+        "default": false
       }
     }
   }

--- a/destinations/airbyte-faros-destination/src/common/types.ts
+++ b/destinations/airbyte-faros-destination/src/common/types.ts
@@ -22,6 +22,7 @@ export interface DestinationConfig extends AirbyteConfig {
   readonly jsonata_mode?: JSONataApplyMode;
   readonly origin?: string;
   readonly source_specific_configs?: Dictionary<any>;
+  readonly keep_alive?: boolean;
 }
 
 export enum Operation {

--- a/destinations/airbyte-faros-destination/src/community/hasura-backend.ts
+++ b/destinations/airbyte-faros-destination/src/community/hasura-backend.ts
@@ -8,12 +8,12 @@ export class HasuraBackend implements GraphQLBackend {
 
   constructor(url: string, adminSecret?: string, httpAgents?: HttpAgents) {
     this.api = axios.create({
+      ...httpAgents,
       baseURL: url,
       headers: {
         'X-Hasura-Role': 'admin',
         ...(adminSecret && {'X-Hasura-Admin-Secret': adminSecret}),
       },
-      ...httpAgents,
     });
   }
 

--- a/destinations/airbyte-faros-destination/src/community/hasura-backend.ts
+++ b/destinations/airbyte-faros-destination/src/community/hasura-backend.ts
@@ -1,17 +1,19 @@
 import axios, {AxiosInstance} from 'axios';
 
 import {GraphQLBackend} from '../common/graphql-client';
+import {HttpAgents} from '../destination';
 
 export class HasuraBackend implements GraphQLBackend {
   private readonly api: AxiosInstance;
 
-  constructor(url: string, adminSecret?: string) {
+  constructor(url: string, adminSecret?: string, httpAgents?: HttpAgents) {
     this.api = axios.create({
       baseURL: url,
       headers: {
         'X-Hasura-Role': 'admin',
         ...(adminSecret && {'X-Hasura-Admin-Secret': adminSecret}),
       },
+      ...httpAgents,
     });
   }
 

--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -85,12 +85,12 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
 
   getFarosClient(): FarosClient {
     if (this.farosClient) return this.farosClient;
-    throw new VError('Faros client is not initialized');
+    throw new VError('Faros Client is not initialized');
   }
 
   getGraphQLClient(): GraphQLClient {
     if (this.graphQLClient) return this.graphQLClient;
-    throw new VError('GraphQL client is not initialized');
+    throw new VError('GraphQL Client is not initialized');
   }
 
   async spec(): Promise<AirbyteSpec> {


### PR DESCRIPTION
## Description

Axios keep alive defaults to false. Add an option to enable keep alive in Faros Destination.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change


## Additional info

https://github.com/axios/axios#request-config
