### PR TITLE
FAI-3916 - Google Calendar fixes

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/googlecalendar/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/googlecalendar/common.ts
@@ -90,8 +90,11 @@ export class GoogleCalendarCommon {
 
   static EventVisibility(visibility: string): CategoryRef {
     const detail = visibility?.toLowerCase();
-    if (!detail)
-      return {category: EventVisibilityCategory.CUSTOM, detail: 'unknown'};
+    if (!detail) {
+      // We default to Busy, since Google Calendar doesn't return visibility value
+      // for "opaque" events
+      return {category: EventVisibilityCategory.BUSY, detail: 'unknown'};
+    }
 
     switch (detail) {
       case 'opaque':

--- a/sources/googlecalendar-source/resources/spec.json
+++ b/sources/googlecalendar-source/resources/spec.json
@@ -29,13 +29,15 @@
         "type": "integer",
         "title": "Events Max Results",
         "description": "Maximum number of events returned on one result page. The number of events in the resulting page may be less than this value, or none at all, even if there are more events matching the query. Incomplete pages can be detected by a non-empty nextPageToken field in the response",
-        "default": 2500,
-        "max": 2500
+        "default": 500,
+        "minimum": 1,
+        "maximum": 2500
       },
       "cutoff_days": {
         "type": "integer",
         "title": "Cutoff Days",
         "default": 90,
+        "minimum": 1,
         "description": "Fetch events created within the specified number of days"
       }
     }

--- a/sources/googlecalendar-source/resources/spec.json
+++ b/sources/googlecalendar-source/resources/spec.json
@@ -32,12 +32,11 @@
         "default": 2500,
         "max": 2500
       },
-      "calendars_max_results": {
+      "cutoff_days": {
         "type": "integer",
-        "title": "Calendars Max Results",
-        "description": "Maximum number of entries returned on one result page",
-        "default": 250,
-        "max": 250
+        "title": "Cutoff Days",
+        "default": 90,
+        "description": "Fetch events created within the specified number of days"
       }
     }
   }

--- a/sources/googlecalendar-source/src/googlecalendar.ts
+++ b/sources/googlecalendar-source/src/googlecalendar.ts
@@ -162,7 +162,7 @@ export class Googlecalendar {
 
       if (syncToken) {
         this.logger.debug(
-          `Incrementally sync events from syncToken: ${syncToken}`
+          `Incrementally syncing events with sync token ${syncToken}`
         );
         params.syncToken = syncToken;
       }
@@ -170,9 +170,7 @@ export class Googlecalendar {
       return this.client.events.list(params) as any;
     };
 
-    for await (const res of this.paginate(func, lastSyncToken, calendar.id)) {
-      yield res;
-    }
+    yield* this.paginate(func, lastSyncToken, calendar.id);
   }
 
   @Memoize((calendarId: string) => calendarId)

--- a/sources/googlecalendar-source/src/googlecalendar.ts
+++ b/sources/googlecalendar-source/src/googlecalendar.ts
@@ -5,7 +5,7 @@ import {VError} from 'verror';
 
 const DEFAULT_CALENDAR_ID = 'primary';
 const DEFAULT_EVENT_MAX_RESULTS = 2500;
-const DEFAULT_CALENDAR_LIST_MAX_RESULTS = 250;
+const DEFAULT_CUTOFF_DAYS = 90;
 
 /** SyncToken point to last variable. It makes the result of this list
  * request contain only entries that have changed since then */
@@ -20,12 +20,7 @@ export interface GoogleCalendarConfig extends AirbyteConfig {
   readonly private_key: string;
   readonly calendar_id?: string;
   readonly events_max_results?: number;
-  readonly calendars_max_results?: number;
-}
-
-interface MaxResults {
-  readonly events: number;
-  readonly calendars: number;
+  readonly cutoff_days?: number;
 }
 
 type PaginationReqFunc = (pageToken?: string) => Promise<any>;
@@ -37,7 +32,8 @@ export class Googlecalendar {
   constructor(
     private readonly client: calendar_v3.Calendar,
     private readonly calendarId: string,
-    private readonly maxResults: MaxResults,
+    private readonly eventsMaxResults: number,
+    private readonly cutoffDays: number,
     private readonly logger: AirbyteLogger
   ) {}
 
@@ -73,16 +69,17 @@ export class Googlecalendar {
       typeof config?.calendar_id === 'string'
         ? config.calendar_id
         : DEFAULT_CALENDAR_ID;
-    const maxResults = {
-      events: config.events_max_results ?? DEFAULT_EVENT_MAX_RESULTS,
-      calendars:
-        config.calendars_max_results ?? DEFAULT_CALENDAR_LIST_MAX_RESULTS,
-    };
+
+    const eventsMaxResults =
+      config.events_max_results ?? DEFAULT_EVENT_MAX_RESULTS;
+
+    const cutoffDays = config.cutoff_days ?? DEFAULT_CUTOFF_DAYS;
 
     Googlecalendar.googleCalendar = new Googlecalendar(
       calendar,
       calendarId,
-      maxResults,
+      eventsMaxResults,
+      cutoffDays,
       logger
     );
     return Googlecalendar.googleCalendar;
@@ -98,7 +95,10 @@ export class Googlecalendar {
     try {
       res = await func(pageToken, lastSyncToken);
     } catch (err: any) {
+      // A 410 status code, "Gone", indicates that the sync token is invalid.
+      // Read more - https://developers.google.com/calendar/api/guides/sync
       if (err?.status === 410) {
+        this.logger.debug('Invalid sync token, starting a full sync.');
         this.invokeCallWithErrorWrapper(func, message, pageToken);
       }
       this.wrapAndThrow(err, message);
@@ -129,7 +129,7 @@ export class Googlecalendar {
     do {
       const response = await this.invokeCallWithErrorWrapper(
         func,
-        undefined,
+        '',
         nextPageToken,
         lastSyncToken
       );
@@ -149,15 +149,21 @@ export class Googlecalendar {
   async *getEvents(lastSyncToken?: string): AsyncGenerator<Event> {
     const calendar = await this.getCalendar();
 
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - this.cutoffDays);
+
     const func = (pageToken?: string, syncToken?: string): Promise<Event> => {
       const params: calendar_v3.Params$Resource$Events$List = {
         calendarId: calendar.id,
         pageToken,
-        maxResults: this.maxResults.events,
+        maxResults: this.eventsMaxResults,
+        timeMin: startDate.toISOString(),
       };
 
       if (syncToken) {
-        this.logger.debug('Sync Events by syncToken column');
+        this.logger.debug(
+          `Incrementally sync events from syncToken: ${syncToken}`
+        );
         params.syncToken = syncToken;
       }
 

--- a/sources/googlecalendar-source/test/index.test.ts
+++ b/sources/googlecalendar-source/test/index.test.ts
@@ -46,7 +46,8 @@ describe('index', () => {
       return new Googlecalendar(
         {calendars: {get: jest.fn().mockResolvedValue({})}} as any,
         'primary',
-        {events: 100, calendars: 100},
+        100,
+        90,
         logger
       );
     });
@@ -65,7 +66,8 @@ describe('index', () => {
       return new Googlecalendar(
         {calendars: {get: jest.fn().mockRejectedValue('some text')}} as any,
         'primary',
-        {events: 100, calendars: 100},
+        100,
+        90,
         logger
       );
     });
@@ -96,7 +98,8 @@ describe('index', () => {
           },
         } as any,
         'primary',
-        {events: 100, calendars: 100},
+        100,
+        90,
         logger
       );
     });
@@ -135,7 +138,8 @@ describe('index', () => {
           },
         } as any,
         'primary',
-        {events: 100, calendars: 100},
+        100,
+        90,
         logger
       );
     });
@@ -187,7 +191,8 @@ describe('index', () => {
           },
         } as any,
         'primary',
-        {events: 100, calendars: 100},
+        100,
+        90,
         logger
       );
     });


### PR DESCRIPTION
## Description

1. Set default event visibility to Busy since Google Calendar doesn't return visibility value for "opaque" events
2. Added `cutoff_days` parameter for Google Calendar + logging

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
