### PR TITLE
[Buildkite] Fix missing builds when large number of pipelines

### DIFF
--- a/sources/buildkite-source/src/buildkite/buildkite.ts
+++ b/sources/buildkite-source/src/buildkite/buildkite.ts
@@ -343,13 +343,11 @@ export class Buildkite {
     cursor?: string,
     createdAtFrom?: Date
   ): AsyncGenerator<Build> {
-    const res = await this.restClient.get<PipelineSlug[]>(
-      `organizations/${organization}/pipelines`
-    );
-    for (const item of res.data) {
+    const pipelines = this.getPipelines();
+    for await (const pipeline of pipelines) {
       yield* this.fetchOrganizationPipelineBuilds(
         organization,
-        item.slug,
+        pipeline.slug,
         cursor,
         createdAtFrom
       );

--- a/sources/buildkite-source/src/buildkite/buildkite.ts
+++ b/sources/buildkite-source/src/buildkite/buildkite.ts
@@ -318,7 +318,9 @@ export class Buildkite {
           const jobs = e.node.jobs?.edges.map((ee) => {
             return ee.node;
           });
-          e.node.jobs = jobs;
+          if (jobs) {
+            e.node.jobs = jobs;
+          }
           return this.setCursor(e);
         }),
         pageInfo: data.pipeline?.builds.pageInfo,

--- a/sources/buildkite-source/test/index.test.ts
+++ b/sources/buildkite-source/test/index.test.ts
@@ -143,22 +143,29 @@ describe('index', () => {
     Buildkite.instance = jest.fn().mockImplementation(() => {
       return new Buildkite(
         {
-          request: fnBuildsList.mockResolvedValue({
-            pipeline: {
-              builds: {
-                edges: readTestResourceFile('builds_input.json'),
-                pageInfo: {
-                  endCursor: undefined,
+          request: fnBuildsList
+            .mockResolvedValueOnce({
+              organization: {
+                pipelines: {
+                  edges: readTestResourceFile('pipelines_input.json'),
+                  pageInfo: {
+                    endCursor: undefined,
+                  },
                 },
               },
-            },
-          }),
+            })
+            .mockResolvedValueOnce({
+              pipeline: {
+                builds: {
+                  edges: readTestResourceFile('builds_input.json'),
+                  pageInfo: {
+                    endCursor: undefined,
+                  },
+                },
+              },
+            }),
         } as any,
-        {
-          get: fnBuildsList.mockResolvedValue({
-            data: readTestResourceFile('pipelines_all.json'),
-          }),
-        } as any,
+        null,
         new Date('2010-03-27T14:03:51-0800'),
         1000,
         'devcube'

--- a/sources/buildkite-source/test_files/builds.json
+++ b/sources/buildkite-source/test_files/builds.json
@@ -1,1 +1,52 @@
-[]
+[
+    {
+        "commit": "HEAD",
+        "createdAt": "2021-12-20T03:37:40.894Z",
+        "cursor": "kaEy",
+        "finishedAt": null,
+        "id": "QnVpbGQtLS00YzU1MTI2ZS0wZjhlLTRkNDgtOWNlMi03MDcxZmVjYjcwY2Q=",
+        "message": "test 1",
+        "number": 2,
+        "pipeline": {
+            "organization": {
+                "slug": "devcube"
+            },
+            "repository":  {
+                "provider": {
+                    "name": "GitHub"
+                },
+                "url": "git@github.com:huongtn/ECHTMen.git"
+            },
+        "slug": "kelvin-test"
+        },
+        "startedAt": null,
+        "state": "SCHEDULED",
+        "url": "https://buildkite.com/devcube/kelvin-test/builds/2",
+        "uuid": "4c55126e-0f8e-4d48-9ce2-7071fecb70cd"
+    },
+    {
+        "commit": "HEAD",
+        "createdAt": "2021-12-20T03:28:25.066Z",
+        "cursor": "kaEx",
+        "finishedAt": null,
+        "id": "QnVpbGQtLS1lZTAwZWNkNi04ZDk3LTQyNmQtOWYwZi0xYTYxOGI4ZjUwMjM=",
+        "message": "Test build",
+        "number": 1,
+        "pipeline": {
+            "organization": {
+                "slug": "devcube"
+            },
+            "repository": {
+                "provider": {
+                    "name": "GitHub"
+                },
+                "url": "git@github.com:huongtn/ECHTMen.git"
+            },
+            "slug": "kelvin-test"
+        },
+        "startedAt": null,
+        "state": "SCHEDULED",
+        "url": "https://buildkite.com/devcube/kelvin-test/builds/1",
+        "uuid": "ee00ecd6-8d97-426d-9f0f-1a618b8f5023"
+    }
+]


### PR DESCRIPTION
## Description
Use paginated GraphQL API to list pipelines in build stream

Currently, the builds stream (contrary to the pipelines stream) uses the REST API to get the list of pipelines to iterate over. That method does not paginate, which means that when one has more than 30 pipelines, builds will be missed.

We switch to the GraphQL API for listing pipelines, for which we paginate properly.

## Type of change
- [x] Bug fix
