### PR TITLE
support multiple azure pipeline projects

### DIFF
--- a/sources/azurepipeline-source/resources/spec.json
+++ b/sources/azurepipeline-source/resources/spec.json
@@ -4,7 +4,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Azure Pipeline Spec",
     "type": "object",
-    "required": ["access_token", "organization", "project", "cutoff_days"],
+    "required": [
+      "access_token",
+      "organization",
+      "project_names",
+      "cutoff_days"
+    ],
     "additionalProperties": true,
     "properties": {
       "access_token": {
@@ -18,9 +23,12 @@
         "title": "Organization",
         "description": "Azure Organization"
       },
-      "project": {
-        "type": "string",
-        "title": "Project",
+      "project_names": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "title": "Project Names",
         "description": "Azure Project"
       },
       "cutoff_days": {

--- a/sources/azurepipeline-source/src/streams/pipelines.ts
+++ b/sources/azurepipeline-source/src/streams/pipelines.ts
@@ -1,8 +1,17 @@
-import {AirbyteLogger, AirbyteStreamBase, StreamKey} from 'faros-airbyte-cdk';
+import {
+  AirbyteLogger,
+  AirbyteStreamBase,
+  StreamKey,
+  SyncMode,
+} from 'faros-airbyte-cdk';
 import {Dictionary} from 'ts-essentials';
 
 import {AzurePipeline, AzurePipelineConfig} from '../azurepipeline';
 import {Pipeline} from '../models';
+
+type StreamSlice = {
+  project: string;
+};
 
 export class Pipelines extends AirbyteStreamBase {
   constructor(
@@ -19,8 +28,20 @@ export class Pipelines extends AirbyteStreamBase {
     return 'id';
   }
 
-  async *readRecords(): AsyncGenerator<Pipeline> {
+  async *streamSlices(): AsyncGenerator<StreamSlice> {
+    for (const project of this.config.project_names) {
+      yield {
+        project,
+      };
+    }
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: StreamSlice
+  ): AsyncGenerator<Pipeline> {
     const azurePipeline = AzurePipeline.instance(this.config);
-    yield* azurePipeline.getPipelines();
+    yield* azurePipeline.getPipelines(streamSlice.project);
   }
 }

--- a/sources/azurepipeline-source/test/index.test.ts
+++ b/sources/azurepipeline-source/test/index.test.ts
@@ -54,6 +54,7 @@ describe('index', () => {
   });
 
   test('streams - pipelines, use full_refresh sync mode', async () => {
+    const projectNames = ['project'];
     const fnPipelinesFunc = jest.fn();
 
     AzurePipeline.instance = jest.fn().mockImplementation(() => {
@@ -65,14 +66,19 @@ describe('index', () => {
           }),
         } as any,
         null,
-        new Date('2010-03-27T14:03:51-0800')
+        new Date('2010-03-27T14:03:51-0800'),
+        projectNames
       );
     });
     const source = new sut.AzurePipelineSource(logger);
     const streams = source.streams({} as any);
 
     const pipelinesStream = streams[0];
-    const pipelineIter = pipelinesStream.readRecords(SyncMode.FULL_REFRESH);
+    const pipelineIter = pipelinesStream.readRecords(
+      SyncMode.FULL_REFRESH,
+      undefined,
+      {project: projectNames[0]}
+    );
     const pipelines = [];
     for await (const pipeline of pipelineIter) {
       pipelines.push(pipeline);
@@ -83,6 +89,7 @@ describe('index', () => {
   });
 
   test('streams - builds, use full_refresh sync mode', async () => {
+    const projectNames = ['project'];
     const fnBuildsFunc = jest.fn();
 
     AzurePipeline.instance = jest.fn().mockImplementation(() => {
@@ -94,14 +101,19 @@ describe('index', () => {
           }),
         } as any,
         null,
-        new Date('2010-03-27T14:03:51-0800')
+        new Date('2010-03-27T14:03:51-0800'),
+        projectNames
       );
     });
     const source = new sut.AzurePipelineSource(logger);
     const streams = source.streams({} as any);
 
     const buildsStream = streams[0];
-    const buildIter = buildsStream.readRecords(SyncMode.FULL_REFRESH);
+    const buildIter = buildsStream.readRecords(
+      SyncMode.FULL_REFRESH,
+      undefined,
+      {project: projectNames[0]}
+    );
     const builds = [];
     for await (const build of buildIter) {
       builds.push(build);
@@ -112,6 +124,7 @@ describe('index', () => {
   });
 
   test('streams - releases, use full_refresh sync mode', async () => {
+    const projectNames = ['project'];
     const fnReleasesFunc = jest.fn();
 
     AzurePipeline.instance = jest.fn().mockImplementation(() => {
@@ -123,14 +136,19 @@ describe('index', () => {
           }),
         } as any,
         null,
-        new Date('2010-03-27T14:03:51-0800')
+        new Date('2010-03-27T14:03:51-0800'),
+        projectNames
       );
     });
     const source = new sut.AzurePipelineSource(logger);
     const streams = source.streams({} as any);
 
     const releasesStream = streams[0];
-    const releaseIter = releasesStream.readRecords(SyncMode.FULL_REFRESH);
+    const releaseIter = releasesStream.readRecords(
+      SyncMode.FULL_REFRESH,
+      undefined,
+      {project: projectNames[0]}
+    );
     const releases = [];
     for await (const release of releaseIter) {
       releases.push(release);

--- a/sources/azurepipeline-source/test_files/invalid_config.json
+++ b/sources/azurepipeline-source/test_files/invalid_config.json
@@ -1,6 +1,6 @@
 {
   "access_token": "",
   "organization": "",
-  "project": "",
+  "project_names": [],
   "start_date": ""
 }


### PR DESCRIPTION
## Description

Support syncing multiple projects for the `Azure pipelines` connector. This includes: pipelines, build and releases

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

## Migration notes

Replace the config `project` with type `string` with `project_names` with type `string[]`

## Extra info

