### PR TITLE
Azure Active Directory: make tenant_id secret

### DIFF
--- a/sources/azureactivedirectory-source/resources/spec.json
+++ b/sources/azureactivedirectory-source/resources/spec.json
@@ -22,7 +22,8 @@
       "tenant_id": {
         "type": "string",
         "title": "tenantID",
-        "description": "Azure Active Directory TenantID"
+        "description": "Azure Active Directory TenantID",
+        "airbyte_secret": true
       },
       "auth_version": {
         "type": "string",


### PR DESCRIPTION
## Description

The new source acceptance test image version enforces config params with certain names to be secret.
https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py#L58-L76

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
