### PR TITLE
Enable service account impersonation in GoogleCalendar source connector

### DIFF
--- a/sources/googlecalendar-source/README.md
+++ b/sources/googlecalendar-source/README.md
@@ -46,6 +46,17 @@ Create credentials:
 - Create [Service Account](https://console.cloud.google.com/apis/credentials)
 - Use client_email and private_key from Service account
 
+#### Enable `domain-wide delegation` for service account (Workspace Admin only)
+
+In normal cases, one's calendar can only be accessed by its owner or specific users that it is shared to. This is good for personal use, but in an organization that required data from all members' calendars, using one service account for each member, or forcing all members to share their calendars with an account is troublesome.
+
+Google has introduced an feature named `domain-wide delegation`, in which it allows an service account to `call APIs on behalf of users in a Google Workspace organization`. With this, one service account can access all organization members' calendars without extra configuration efforts.
+
+Refer to this [link](https://developers.google.com/workspace/guides/create-credentials#optional_set_up_domain-wide_delegation_for_a_service_account) to know how to enable `domain-wide delegation` for the service acccount.
+
+
+
+
 ### Locally running the connector
 
 ```

--- a/sources/googlecalendar-source/src/googlecalendar.ts
+++ b/sources/googlecalendar-source/src/googlecalendar.ts
@@ -59,6 +59,9 @@ export class Googlecalendar {
         private_key: config.private_key.replace(/\\n/g, '\n'),
         client_email: config.client_email,
       },
+      clientOptions: {
+        subject: config.calendar_id
+      }
     });
 
     // Acquire an auth client, and bind it to all future calls


### PR DESCRIPTION
This enable service account impersonation (in case the user is organization manager & want to use a service account to access memebers' calendars)

## Description

Current implementation of GoogleCalendar source connector only allows calendar owner or invited accounts to access calendar.

In normal case, this is fine. But in an organization, when admins need to access members' calendars to calculate necessary metrics to determine productivity, forcing all members to share their calendar with an account is tricky.

This PR enable service account impersonation (together with domain-wide delegation), so that an authenticated service account can access organization members' calendars.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
