### PR TITLE
Better logging for sources

### DIFF
--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -230,6 +230,11 @@ export abstract class AirbyteSourceBase<
         recordCounter
       );
     }
+    this.logger.info(
+      `Last recorded state of ${streamName} stream is ${JSON.stringify(
+        streamState
+      )}`
+    );
   }
 
   private async *readFullRefresh(
@@ -258,11 +263,6 @@ export abstract class AirbyteSourceBase<
     connectorState: AirbyteState,
     recordCounter: number
   ): AirbyteStateMessage {
-    this.logger.info(
-      `Setting checkpoint state of ${streamName} stream to ${JSON.stringify(
-        streamState
-      )}`
-    );
     this.logger.info(`Read ${recordCounter} records from ${streamName} stream`);
     connectorState[streamName] = streamState;
     return new AirbyteStateMessage({data: connectorState});


### PR DESCRIPTION
## Description

1. Removed logging on every stream slice checkpoint operation (this should make logging less noisy)
2. Added logging on start & end of each stream slice with number of read records

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
