### PR TITLE
Remove metadata/refreshedAt from result record

### DIFF
--- a/sources/faros-graphql-source/src/streams/faros-graph.ts
+++ b/sources/faros-graphql-source/src/streams/faros-graph.ts
@@ -174,6 +174,10 @@ export class FarosGraph extends AirbyteStreamBase {
 
       this.state[query] = {refreshedAtMillis};
 
+      // Remove metadata/refreshedAt
+      // We only use these fields for updating the incremental state
+      const {metadata, refreshedAt, ...result} = item;
+
       yield _.set(
         {},
         this.config.result_model === ResultModel.Nested
@@ -187,7 +191,7 @@ export class FarosGraph extends AirbyteStreamBase {
             // }
             [...pathToModel.path, 0]
           : pathToModel.modelName,
-        item
+        result
       );
     }
   }

--- a/sources/faros-graphql-source/src/streams/faros-graph.ts
+++ b/sources/faros-graphql-source/src/streams/faros-graph.ts
@@ -16,7 +16,7 @@ import {
   toIncrementalV2,
 } from 'faros-js-client';
 import {FarosClient} from 'faros-js-client';
-import {max} from 'lodash';
+import {max, omit} from 'lodash';
 import _ from 'lodash';
 import {Dictionary} from 'ts-essentials';
 
@@ -176,7 +176,7 @@ export class FarosGraph extends AirbyteStreamBase {
 
       // Remove metadata/refreshedAt
       // We only use these fields for updating the incremental state
-      const {metadata, refreshedAt, ...result} = item;
+      const result = omit(item, ['metadata', 'refreshedAt']);
 
       yield _.set(
         {},

--- a/sources/faros-graphql-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/faros-graphql-source/test/__snapshots__/index.test.ts.snap
@@ -5,17 +5,11 @@ Array [
   Object {
     "D": Object {
       "k1": "v1",
-      "metadata": Object {
-        "refreshedAt": 12,
-      },
     },
   },
   Object {
     "D": Object {
       "k2": "v2",
-      "metadata": Object {
-        "refreshedAt": 23,
-      },
     },
   },
 ]
@@ -56,9 +50,6 @@ Array [
         "C": Array [
           Object {
             "k1": "v1",
-            "metadata": Object {
-              "refreshedAt": 12,
-            },
           },
         ],
       },
@@ -70,9 +61,6 @@ Array [
         "C": Array [
           Object {
             "k2": "v2",
-            "metadata": Object {
-              "refreshedAt": 23,
-            },
           },
         ],
       },
@@ -89,7 +77,6 @@ Array [
         "C": Array [
           Object {
             "k1": "v1",
-            "refreshedAt": "2022-10-19T22:02:14.483165+00:00",
           },
         ],
       },
@@ -101,7 +88,6 @@ Array [
         "C": Array [
           Object {
             "k2": "v2",
-            "refreshedAt": "2023-11-14T22:13:20.000Z",
           },
         ],
       },


### PR DESCRIPTION
## Description

Returning these fields causes issues in the destination:

```
errors":[{"extensions":{"code":"validation-failed","path":"$.selectionSet.insert_vcs_User.args.objects[0].refreshedAt"},"message":"field 'refreshedAt' not found in type: 'vcs_User_insert_input'"}]}}}
```

We could instead remove them in the destination, but since we only use them as a watermark for the incremental syncs and they get automatically updated on write, they're really not useful in the returned record.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
