### PR TITLE
Disable upsert batching for CE

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -54,12 +54,6 @@
                 "description": "The User UUID with which to track events in Segment. If not present, then reporting is disabled. See https://community.faros.ai/docs/telemetry for more details.",
                 "format": "uuid"
               },
-              "community_graphql_upsert_batch_size": {
-                "type": "integer",
-                "title": "GraphQL upsert batch size",
-                "description": "Maximum number of records to execute in a single GraphQL upsert.",
-                "default": 10000
-              },
               "community_graphql_batch_size": {
                 "type": "integer",
                 "title": "GraphQL mutation batch size",

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -202,7 +202,7 @@ function addLevel(u: Upsert): [Upsert, number][] {
  * Client for writing records as GraphQL mutations.  The client supports 3
  * kinds of writes: Upserts, Updates and Deletes.
  *
- * For upserts, the high-level algorithm is:
+ * For upserts (when upsertBatchSize is greater than 0), the high-level algorithm is:
  *
  * > For each record, build a tree of Upserts. The tree has more than one node if the current record represents a
  *   nested entity (e.g. branch record referencing repo which, in-turn, references org).
@@ -241,6 +241,14 @@ export class GraphQLClient {
     this.logger = logger;
     this.schemaLoader = schemaLoader;
     this.backend = backend;
+    assert(
+      upsertBatchSize >= 0,
+      `negative upsert batch size: ${upsertBatchSize}`
+    );
+    assert(
+      mutationBatchSize > 0,
+      `non-positive mutation batch size: ${mutationBatchSize}`
+    );
     this.upsertBatchSize = upsertBatchSize;
     this.mutationBatchSize = mutationBatchSize;
   }
@@ -323,9 +331,17 @@ export class GraphQLClient {
     if (!this.tableNames.has(model)) {
       throw new VError(`Table ${model} does not exist`);
     }
-    this.addUpsert(model, origin, record);
-    if (this.upsertBuffer.size() >= this.upsertBatchSize) {
-      await this.flushUpsertBuffer();
+    if (this.upsertBatchSize) {
+      this.addUpsert(model, origin, record);
+      if (this.upsertBuffer.size() >= this.upsertBatchSize) {
+        await this.flushUpsertBuffer();
+      }
+    } else {
+      const obj = this.createMutationObject(model, origin, record);
+      const mutation = {
+        [`insert_${model}_one`]: {__args: obj, id: true},
+      };
+      await this.postQuery({mutation}, `Failed to write ${model} record`);
     }
   }
 

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -241,16 +241,16 @@ export class GraphQLClient {
     this.logger = logger;
     this.schemaLoader = schemaLoader;
     this.backend = backend;
+    this.upsertBatchSize = upsertBatchSize ?? 10000;
+    this.mutationBatchSize = mutationBatchSize ?? 100;
     assert(
-      upsertBatchSize >= 0,
-      `negative upsert batch size: ${upsertBatchSize}`
+      this.upsertBatchSize >= 0,
+      `negative upsert batch size: ${this.upsertBatchSize}`
     );
     assert(
-      mutationBatchSize > 0,
-      `non-positive mutation batch size: ${mutationBatchSize}`
+      this.mutationBatchSize > 0,
+      `non-positive mutation batch size: ${this.mutationBatchSize}`
     );
-    this.upsertBatchSize = upsertBatchSize;
-    this.mutationBatchSize = mutationBatchSize;
   }
 
   async healthCheck(): Promise<void> {

--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -145,7 +145,7 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
         this.logger,
         schemaLoader,
         backend,
-        config.edition_configs.community_graphql_upsert_batch_size,
+        0,
         config.edition_configs.community_graphql_batch_size
       );
     } catch (e) {


### PR DESCRIPTION
## Description

Disabling the recently added upsert batching for CE.  The proximate issue is odd behavior from Hasura for batch inserts.  Specifically, the following query fails if it has more than one object:

 ```
mutation {
  insert_tms_User(objects: [
    {uid: "u1", source: "GitHub", origin: "mytestsource"},
    {uid: "u2", name: "chalenge", source: "GitHub", origin: "mytestsource"}, 
  ], on_conflict: {constraint: tms_User_pkey, 
    update_columns: [emailAddress, name, origin, refreshedAt]}) {
    returning {
      id
      source
      uid
    }
  }
}
```

The error given is:

```
{
  "error": {
    "exec_status": "FatalError",
    "hint": null,
    "message": "cannot insert into column 'id'",
    "status_code": "42601",
    "description": "Column 'id' is a generated column."
  }
}
```
There is no attempt to insert `id` here.  Our use of permissions must be preventing this in the SaaS product. 

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
