### PR TITLE
Upgrade faros-js-client + tweak state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "condoit": "^2.1.0",
         "date-format": "^4.0.6",
         "faros-feeds-sdk": "^0.13.14",
-        "faros-js-client": "0.2.0",
+        "faros-js-client": "0.2.2",
         "fast-redact": "^3.0.2",
         "fs-extra": "^10.0.0",
         "git-url-parse": "^13.0.0",
@@ -8236,9 +8236,9 @@
       }
     },
     "node_modules/faros-js-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.0.tgz",
-      "integrity": "sha512-gImVDvx0JUTlCK9O8X1qj7ENXH9L6OslcmbUtZuIThs6cWcMoE5kpGnATIKCib8Qr8I1mDQQPnfMZ8AdzVT+yg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.2.tgz",
+      "integrity": "sha512-qCtxKBrOtuuUk9mvjGJHBXu1tCduAOtCMzxoNK2+VkehzK2lYMM/vspdd97RL1rwO/u2zzVi/RG0Mc1GYTpHhg==",
       "dependencies": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",
@@ -23298,9 +23298,9 @@
       }
     },
     "faros-js-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.0.tgz",
-      "integrity": "sha512-gImVDvx0JUTlCK9O8X1qj7ENXH9L6OslcmbUtZuIThs6cWcMoE5kpGnATIKCib8Qr8I1mDQQPnfMZ8AdzVT+yg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.2.tgz",
+      "integrity": "sha512-qCtxKBrOtuuUk9mvjGJHBXu1tCduAOtCMzxoNK2+VkehzK2lYMM/vspdd97RL1rwO/u2zzVi/RG0Mc1GYTpHhg==",
       "requires": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",

--- a/sources/faros-graphql-source/package.json
+++ b/sources/faros-graphql-source/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
-    "faros-js-client": "0.2.0",
+    "faros-js-client": "0.2.2",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/sources/faros-graphql-source/src/streams/faros-graph.ts
+++ b/sources/faros-graphql-source/src/streams/faros-graph.ts
@@ -124,7 +124,7 @@ export class FarosGraph extends AirbyteStreamBase {
     if (!incremental) {
       stateKey = createHash('md5').update(query).digest('hex');
       this.logger.debug(
-        `Used "${stateKey}" as key in state for query: "${query}"`
+        `Used "${stateKey}" as key to state for query: "${query}"`
       );
     }
 

--- a/sources/faros-graphql-source/test/index.test.ts
+++ b/sources/faros-graphql-source/test/index.test.ts
@@ -15,6 +15,8 @@ function readResourceFile(fileName: string): any {
   return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
 }
 
+const QUERY_HASH = 'acbd18db4cc2f85cedef654fccc4a4d8';
+
 const BASE_CONFIG = {
   query: 'foo',
   api_url: 'x',
@@ -163,7 +165,7 @@ describe('index', () => {
       SyncMode.INCREMENTAL,
       undefined,
       {query: 'foo', pathToModel: PATH_TO_MODEL},
-      {foo: {refreshedAtMillis: 1}}
+      {[QUERY_HASH]: {refreshedAtMillis: 1}}
     );
 
     const records = [];
@@ -173,7 +175,7 @@ describe('index', () => {
 
     expect(records).toMatchSnapshot();
     expect(stream.getUpdatedState(undefined, undefined)).toEqual({
-      foo: {refreshedAtMillis: 23},
+      [QUERY_HASH]: {refreshedAtMillis: 23},
     });
   });
 
@@ -192,7 +194,7 @@ describe('index', () => {
       SyncMode.INCREMENTAL,
       undefined,
       {query: 'foo', pathToModel: PATH_TO_MODEL},
-      {foo: {refreshedAtMillis: 1}}
+      {[QUERY_HASH]: {refreshedAtMillis: 1}}
     );
 
     const records = [];
@@ -202,7 +204,7 @@ describe('index', () => {
 
     expect(records).toMatchSnapshot();
     expect(stream.getUpdatedState(undefined, undefined)).toEqual({
-      foo: {refreshedAtMillis: 1700000000000},
+      [QUERY_HASH]: {refreshedAtMillis: 1700000000000},
     });
   });
 
@@ -221,7 +223,7 @@ describe('index', () => {
       SyncMode.INCREMENTAL,
       undefined,
       {query: 'foo', pathToModel: PATH_TO_MODEL},
-      {foo: {refreshedAtMillis: 1}}
+      {[QUERY_HASH]: {refreshedAtMillis: 1}}
     );
 
     const records = [];
@@ -231,7 +233,7 @@ describe('index', () => {
 
     expect(records).toMatchSnapshot();
     expect(stream.getUpdatedState(undefined, undefined)).toEqual({
-      foo: {refreshedAtMillis: 23},
+      [QUERY_HASH]: {refreshedAtMillis: 23},
     });
   });
 });


### PR DESCRIPTION
## Description

Upgrade faros-js-client and use references info when creating incremental queries (`V2` only) 
Also, tweak state management by using the input query (if provided) as state key. Otherwise we use the model names as keys