### PR TITLE
Fix azure-repos-source readme and add version build-arg to all readmes

### DIFF
--- a/sources/agileaccelerator-source/README.md
+++ b/sources/agileaccelerator-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/agileaccelerator-source -t agileaccelerator-source
+docker build . --build-arg path=sources/agileaccelerator-source --build-arg version=0.0.1 -t agileaccelerator-source
 ```
 
 #### Run

--- a/sources/azure-repos-source/README.md
+++ b/sources/azure-repos-source/README.md
@@ -1,8 +1,8 @@
-# Azure-Repo Source
+# Azure-Repos Source
 
-This is the repository for the Azure-Repo source connector, written in Typescript.
+This is the repository for the Azure-Repos source connector, written in Typescript.
 For information about how to use this connector within Airbyte, see [the
-documentation](https://docs.airbyte.io/integrations/sources/azure-repo).
+documentation](https://docs.airbyte.io/integrations/sources/azure-repos).
 
 ## Local development
 
@@ -22,10 +22,10 @@ npm run prepare
 ```
 
 This will install all required dependencies and build all included connectors,
-including the Azure-Repo source connector.
+including the Azure-Repos source connector.
 
-Now you can cd into the Azure-Repo connector directory, `sources/azure-repo-source`,
-and iterate on the Azure-Repo source connector. After making code changes, run:
+Now you can cd into the Azure-Repos connector directory, `sources/azure-repos-source`,
+and iterate on the Azure-Repos source connector. After making code changes, run:
 
 ```
 npm run build
@@ -34,10 +34,10 @@ npm run build
 #### Create credentials
 
 Follow the instructions in the
-[documentation](https://docs.airbyte.io/integrations/sources/azure-repo) to
+[documentation](https://docs.airbyte.io/integrations/sources/azure-repos) to
 generate the necessary credentials. Then create a file `secrets/config.json`
 conforming to the `resources/spec.json` file. Note that any directory named
-`secrets` is gitignored across the entire `airbyte-connectors` repo, so there is
+`secrets` is gitignored across the entire `airbyte-connectors` repos, so there is
 no danger of accidentally checking in sensitive information. See
 `test_files/config.json` for a sample config file.
 
@@ -58,26 +58,26 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/azure-repo-source -t azure-repo-source
+docker build . --build-arg path=sources/azure-repos-source --build-arg version=0.0.1 -t azure-repos-source
 ```
 
 #### Run
 
-Then return to the Azure-Repo connector directory and run any of the connector
+Then return to the Azure-Repos connector directory and run any of the connector
 commands as follows:
 
 ```
-docker run --rm azure-repo-source spec
-docker run --rm -v $(pwd)/secrets:/secrets azure-repo-source check --config /secrets/config.json
-docker run --rm -v $(pwd)/secrets:/secrets azure-repo-source discover --config /secrets/config.json
-docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/test_files:/test_files azure-repo-source read --config /secrets/config.json --catalog /test_files/full_configured_catalog.json
+docker run --rm azure-repos-source spec
+docker run --rm -v $(pwd)/secrets:/secrets azure-repos-source check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets azure-repos-source discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/test_files:/test_files azure-repos-source read --config /secrets/config.json --catalog /test_files/full_configured_catalog.json
 ```
 
 ## Testing
 
 ### Unit Tests
 
-To run unit tests locally, from the Azure-Repo connector directory run:
+To run unit tests locally, from the Azure-Repos connector directory run:
 
 ```
 npm test
@@ -98,7 +98,7 @@ docker pull airbyte/source-acceptance-test
 To run the acceptance tests, from the root repository directory, run
 
 ```
-./scripts/source-acceptance-test.sh azure-repo-source
+./scripts/source-acceptance-test.sh azure-repos-source
 ```
 
 ## Dependency Management

--- a/sources/azureactivedirectory-source/README.md
+++ b/sources/azureactivedirectory-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/azureactivedirectory-source -t azureactivedirectory-source
+docker build . --build-arg path=sources/azureactivedirectory-source --build-arg version=0.0.1 -t azureactivedirectory-source
 ```
 
 #### Run

--- a/sources/azurepipeline-source/README.md
+++ b/sources/azurepipeline-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/azurepipeline-source -t azurepipeline-source
+docker build . --build-arg path=sources/azurepipeline-source --build-arg version=0.0.1 -t azurepipeline-source
 ```
 
 #### Run

--- a/sources/backlog-source/README.md
+++ b/sources/backlog-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/backlog-source -t backlog-source
+docker build . --build-arg path=sources/backlog-source --build-arg version=0.0.1 -t backlog-source
 ```
 
 #### Run

--- a/sources/bamboohr-source/README.md
+++ b/sources/bamboohr-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/bamboohr-source -t bamboohr-source
+docker build . --build-arg path=sources/bamboohr-source --build-arg version=0.0.1 -t bamboohr-source
 ```
 
 #### Run

--- a/sources/bitbucket-server-source/README.md
+++ b/sources/bitbucket-server-source/README.md
@@ -56,7 +56,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/bitbucket-server-source -t bitbucket-server-source
+docker build . --build-arg path=sources/bitbucket-server-source --build-arg version=0.0.1 -t bitbucket-server-source
 ```
 
 #### Run

--- a/sources/bitbucket-source/README.md
+++ b/sources/bitbucket-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/bitbucket-source -t bitbucket-source
+docker build . --build-arg path=sources/bitbucket-source --build-arg version=0.0.1 -t bitbucket-source
 ```
 
 #### Run

--- a/sources/buildkite-source/README.md
+++ b/sources/buildkite-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/buildkite-source -t buildkite-source
+docker build . --build-arg path=sources/buildkite-source --build-arg version=0.0.1 -t buildkite-source
 ```
 
 #### Run

--- a/sources/circleci-source/README.md
+++ b/sources/circleci-source/README.md
@@ -72,7 +72,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/circleci-source -t circleci-source
+docker build . --build-arg path=sources/circleci-source --build-arg version=0.0.1 -t circleci-source
 ```
 
 #### Run

--- a/sources/customer-io-source/README.md
+++ b/sources/customer-io-source/README.md
@@ -72,7 +72,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/customer-io-source -t customer-io-source
+docker build . --build-arg path=sources/customer-io-source --build-arg version=0.0.1 -t customer-io-source
 ```
 
 #### Run

--- a/sources/firehydrant-source/README.md
+++ b/sources/firehydrant-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/firehydrant-source -t firehydrant-source
+docker build . --build-arg path=sources/firehydrant-source --build-arg version=0.0.1 -t firehydrant-source
 ```
 
 #### Run

--- a/sources/gitlab-ci-source/README.md
+++ b/sources/gitlab-ci-source/README.md
@@ -62,7 +62,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/gitlab-ci-source -t gitlab-ci-source
+docker build . --build-arg path=sources/gitlab-ci-source --build-arg version=0.0.1 -t gitlab-ci-source
 ```
 
 #### Run

--- a/sources/googlecalendar-source/README.md
+++ b/sources/googlecalendar-source/README.md
@@ -75,7 +75,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/googlecalendar-source -t googlecalendar-source
+docker build . --build-arg path=sources/googlecalendar-source --build-arg version=0.0.1 -t googlecalendar-source
 ```
 
 #### Run

--- a/sources/harness-source/README.md
+++ b/sources/harness-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/harness-source -t harness-source
+docker build . --build-arg path=sources/harness-source --build-arg version=0.0.1 -t harness-source
 ```
 
 #### Run

--- a/sources/jenkins-source/README.md
+++ b/sources/jenkins-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/jenkins-source -t jenkins-source
+docker build . --build-arg path=sources/jenkins-source --build-arg version=0.0.1 -t jenkins-source
 ```
 
 #### Run

--- a/sources/opsgenie-source/README.md
+++ b/sources/opsgenie-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/opsgenie-source -t opsgenie-source
+docker build . --build-arg path=sources/opsgenie-source --build-arg version=0.0.1 -t opsgenie-source
 ```
 
 #### Run

--- a/sources/pagerduty-source/README.md
+++ b/sources/pagerduty-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/pagerduty-source -t pagerduty-source
+docker build . --build-arg path=sources/pagerduty-source --build-arg version=0.0.1 -t pagerduty-source
 ```
 
 #### Run

--- a/sources/phabricator-source/README.md
+++ b/sources/phabricator-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/phabricator-source -t phabricator-source
+docker build . --build-arg path=sources/phabricator-source --build-arg version=0.0.1 -t phabricator-source
 ```
 
 #### Run

--- a/sources/semaphoreci-source/README.md
+++ b/sources/semaphoreci-source/README.md
@@ -60,7 +60,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/semaphoreci-source -t semaphoreci-source
+docker build . --build-arg path=sources/semaphoreci-source --build-arg version=0.0.1 -t semaphoreci-source
 ```
 
 #### Run

--- a/sources/shortcut-source/README.md
+++ b/sources/shortcut-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/shortcut-source -t shortcut-source
+docker build . --build-arg path=sources/shortcut-source --build-arg version=0.0.1 -t shortcut-source
 ```
 
 #### Run

--- a/sources/squadcast-source/README.md
+++ b/sources/squadcast-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/squadcast-source -t squadcast-source
+docker build . --build-arg path=sources/squadcast-source --build-arg version=0.0.1 -t squadcast-source
 ```
 
 #### Run

--- a/sources/victorops-source/README.md
+++ b/sources/victorops-source/README.md
@@ -58,7 +58,7 @@ Go back to the root repository directory and run:
 First, make sure you build the latest Docker image:
 
 ```
-docker build . --build-arg path=sources/victorops-source -t victorops-source
+docker build . --build-arg path=sources/victorops-source --build-arg version=0.0.1 -t victorops-source
 ```
 
 #### Run


### PR DESCRIPTION
## Description

Change all references of `azure-repo` to `azure-repos` to match published image name and folder structure.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
