### PR TITLE
Set pino version to 8.5.0

### DIFF
--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -41,7 +41,7 @@
     "fast-redact": "^3.0.2",
     "json-schema-traverse": "^1.0.0",
     "lodash": "^4.17.21",
-    "pino": "^8.5.0",
+    "pino": "8.5.0",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "object-sizeof": "^1.6.1",
         "parse-diff": "^0.9.0",
         "parse-link-header": "^2.0.0",
-        "pino": "^8.5.0",
+        "pino": "8.5.0",
         "statuspage.io": "^3.1.0",
         "toposort": "^2.0.2",
         "traverse": "^0.6.6",


### PR DESCRIPTION
## Description

Set pino version to 8.5.0. This should fix the release of cdk package.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
