### PR TITLE
Update to the Datadog source to allow multiple sites not just the default US one.

### DIFF
--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -42,6 +42,13 @@
         "title": "Metrics Max Window",
         "description": "max time window when fetching metrics, in milliseconds. Defaults to 1 week.",
         "default": 604800000
+      },
+      "site_url": {
+        "order": 5,
+        "type": "string",
+        "title": "Datadog site URL",
+        "description": "datadog site URL",
+        "default": "app.datadoghq.com"
       }
     }
   }

--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -47,7 +47,7 @@
         "order": 5,
         "type": "string",
         "title": "Datadog site URL",
-        "description": "datadog site URL",
+        "description": "Datadog site URL, e.g 'app.datadoghq.com'. See all available options here - https://docs.datadoghq.com/getting_started/site/",
         "default": "app.datadoghq.com"
       }
     }

--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -46,8 +46,8 @@
       "site_url": {
         "order": 5,
         "type": "string",
-        "title": "Datadog site URL",
-        "description": "Datadog site URL, e.g 'datadoghq.com'. See all available options here - https://docs.datadoghq.com/getting_started/site/",
+        "title": "Datadog Site",
+        "description": "Datadog Site parameter, e.g 'datadoghq.com'. See all available site options here - https://docs.datadoghq.com/getting_started/site/",
         "default": "datadoghq.com"
       }
     }

--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -43,7 +43,7 @@
         "description": "max time window when fetching metrics, in milliseconds. Defaults to 1 week.",
         "default": 604800000
       },
-      "site_url": {
+      "site": {
         "order": 5,
         "type": "string",
         "title": "Datadog Site",

--- a/sources/datadog-source/resources/spec.json
+++ b/sources/datadog-source/resources/spec.json
@@ -47,8 +47,8 @@
         "order": 5,
         "type": "string",
         "title": "Datadog site URL",
-        "description": "Datadog site URL, e.g 'app.datadoghq.com'. See all available options here - https://docs.datadoghq.com/getting_started/site/",
-        "default": "app.datadoghq.com"
+        "description": "Datadog site URL, e.g 'datadoghq.com'. See all available options here - https://docs.datadoghq.com/getting_started/site/",
+        "default": "datadoghq.com"
       }
     }
   }

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -66,7 +66,7 @@ export class Datadog {
 
     // Add ability to change sites to other regions.
     client.setServerVariables(clientConfig, {
-        site: config.site_url
+        site: config.site_url ?? 'app.datadoghq.com'
     });
 
 

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -3,6 +3,7 @@ import {AirbyteLogger} from 'faros-airbyte-cdk';
 import VError from 'verror';
 
 const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_SITE = 'datadoghq.com'; // See - https://docs.datadoghq.com/getting_started/site/
 
 interface PagedResult<T> {
   data?: Array<T>;
@@ -39,7 +40,7 @@ export interface DatadogConfig {
   readonly page_size?: number;
   readonly metrics?: Array<string>;
   readonly metrics_max_window?: number;
-  readonly site_url?: string;
+  readonly site?: string;
 }
 
 export interface DatadogClient {
@@ -67,7 +68,7 @@ export class Datadog {
 
     // Add ability to change sites to other regions.
     client.setServerVariables(clientConfig, {
-        site: config.site_url ?? 'datadoghq.com'
+        site: config.site ?? DEFAULT_SITE
     });
 
 

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -64,6 +64,12 @@ export class Datadog {
 
     const clientConfig = client.createConfiguration(configurationOpts);
 
+    // Add ability to change sites to other regions.
+    client.setServerVariables(clientConfig, {
+        site: config.site_url
+    });
+
+
     // Beta endpoints are unstable and need to be explicitly enabled
     clientConfig.unstableOperations['v2.listIncidents'] = true;
 

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -39,6 +39,7 @@ export interface DatadogConfig {
   readonly page_size?: number;
   readonly metrics?: Array<string>;
   readonly metrics_max_window?: number;
+  readonly site_url?: string;
 }
 
 export interface DatadogClient {
@@ -66,7 +67,7 @@ export class Datadog {
 
     // Add ability to change sites to other regions.
     client.setServerVariables(clientConfig, {
-        site: config.site_url ?? 'app.datadoghq.com'
+        site: config.site_url ?? 'datadoghq.com'
     });
 
 


### PR DESCRIPTION
## Description

Update to the datadog connector to allow multiple sites not just the default US one.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

https://github.com/faros-ai/airbyte-connectors/issues/856

## Migration notes

None there is now a default set to the original datadog site.
## Extra info

> Add any additional information
