### PR TITLE
FAI-4564: Read-path GraphQL v2 Perf Improvement

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -597,6 +597,7 @@ export class GraphQLClient {
     return obj;
   }
 
+  // TODO: (1) set origin at root only (2) mask update fields
   private createMutationObject(
     model: string,
     origin: string,
@@ -688,6 +689,8 @@ export class GraphQLClient {
     return serialize(strictPick(obj, this.schema.primaryKeys[model]));
   }
 
+  // This method assumes all objects contain the same
+  // set of fields.
   private toUpsertOp(model: string, modelUpserts: Upsert[]): UpsertOp {
     const upsertsByKey = new Map();
     // add FKs and index upsert by primary key
@@ -712,7 +715,7 @@ export class GraphQLClient {
       .sort()
       .reduce((a, v) => ({...a, [v]: true}), {});
     // all objects have same fields due to groupByAffectedFields call
-    // pull out fields of first as mask for update columns to ensure
+    // pull out fields of first as mask for update fields to ensure
     // fields that aren't in the data are not modified by the upsert
     const updateColumnMask = objects?.length
       ? new Set(Object.keys(objects[0]))

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -158,7 +158,7 @@ export function batchIterator<T>(
 }
 
 /**
- * Separates each level (i.e. Upsert[]) into groups of upserts
+ * Separates each level (i.e. Upsert[]) into arrays of upserts
  * that all operate on the same fields.
  */
 export function groupByAffectedFields(levels: Upsert[][]): Upsert[][] {
@@ -711,8 +711,9 @@ export class GraphQLClient {
     const keysObj = primaryKeys
       .sort()
       .reduce((a, v) => ({...a, [v]: true}), {});
-    // all objects have same fields; pull out fields of first
-    // as mask for update columns
+    // all objects have same fields due to groupByAffectedFields call
+    // pull out fields of first as mask for update columns to ensure
+    // fields that aren't in the data are not modified by the upsert
     const updateColumnMask = objects?.length
       ? new Set(Object.keys(objects[0]))
       : undefined;

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -780,7 +780,7 @@ export class GraphQLClient {
       ? updateColumns.filter((c) => updateFieldMask.has(c))
       : updateColumns;
     // if empty, use model keys to ensure queries always return results
-    if (!filteredUpdateFields.length) {
+    if (isEmpty(filteredUpdateFields)) {
       filteredUpdateFields.push(...this.schema.primaryKeys[model]);
     }
     return {

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`graphql-client basic batch mutation 1`] = `"mutation { m0: insert_vcs_Membership_one (object: {vcs_User: {data: {uid: \\"ashnet16\\", source: \\"GitHub\\", origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_User_pkey\\"}, update_columns: [{value: \\"refreshedAt\\"}]}}, vcs_Organization: {data: {uid: \\"faros-ai\\", source: \\"GitHub\\", origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_Organization_pkey\\"}, update_columns: [{value: \\"refreshedAt\\"}]}}, origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_Membership_pkey\\"}, update_columns: [{value: \\"origin\\"}, {value: \\"refreshedAt\\"}]}) { id } m1: insert_vcs_User_one (object: {uid: \\"betafood\\", type: {category: \\"User\\", detail: \\"user\\"}, source: \\"GitHub\\", origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_User_pkey\\"}, update_columns: [{value: \\"email\\"}, {value: \\"name\\"}, {value: \\"origin\\"}, {value: \\"refreshedAt\\"}, {value: \\"type\\"}, {value: \\"url\\"}]}) { id } }"`;
 
-exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}]) { returning { id source uid } } }"`;
+exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id source uid } } }"`;
 
-exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"metis\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}]) { returning { id name organizationId } } }"`;
+exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"metis\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id name organizationId } } }"`;
 
 exports[`graphql-client write batch upsert basic end-to-end 3`] = `"mutation { insert_vcs_Branch (objects: [{name: \\"foo\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"main\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin]}) { returning { id name repositoryId } } }"`;
 
@@ -36,7 +36,7 @@ Array [
 
 exports[`graphql-client write batch upsert record with null primary key field 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin]}) { returning { id source uid } } }"`;
 
-exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\"}, {uid: \\"9\\"}]) { returning { id uid } } }"`;
+exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\"}, {uid: \\"9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [uid]}) { returning { id uid } } }"`;
 
 exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: \\"9\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [origin]}) { returning { id uid } } }"`;
 

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`graphql-client basic batch mutation 1`] = `"mutation { m0: insert_vcs_Membership_one (object: {vcs_User: {data: {uid: \\"ashnet16\\", source: \\"GitHub\\", origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_User_pkey\\"}, update_columns: [{value: \\"refreshedAt\\"}]}}, vcs_Organization: {data: {uid: \\"faros-ai\\", source: \\"GitHub\\", origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_Organization_pkey\\"}, update_columns: [{value: \\"refreshedAt\\"}]}}, origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_Membership_pkey\\"}, update_columns: [{value: \\"origin\\"}, {value: \\"refreshedAt\\"}]}) { id } m1: insert_vcs_User_one (object: {uid: \\"betafood\\", type: {category: \\"User\\", detail: \\"user\\"}, source: \\"GitHub\\", origin: \\"myghsrc\\"}, on_conflict: {constraint: {value: \\"vcs_User_pkey\\"}, update_columns: [{value: \\"email\\"}, {value: \\"name\\"}, {value: \\"origin\\"}, {value: \\"refreshedAt\\"}, {value: \\"type\\"}, {value: \\"url\\"}]}) { id } }"`;
 
-exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [createdAt, htmlUrl, name, origin, refreshedAt, type]}) { returning { id source uid } } }"`;
+exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}]) { returning { id source uid } } }"`;
 
-exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"metis\\", origin: \\"mytestsource\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"hermes\\", origin: \\"mytestsource\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [createdAt, description, fullName, htmlUrl, included, language, mainBranch, origin, private, refreshedAt, size, topics, updatedAt]}) { returning { id name organizationId } } }"`;
+exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"metis\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}]) { returning { id name organizationId } } }"`;
 
-exports[`graphql-client write batch upsert basic end-to-end 3`] = `"mutation { insert_vcs_Branch (objects: [{name: \\"foo\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"main\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin, refreshedAt]}) { returning { id name repositoryId } } }"`;
+exports[`graphql-client write batch upsert basic end-to-end 3`] = `"mutation { insert_vcs_Branch (objects: [{name: \\"foo\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"main\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin]}) { returning { id name repositoryId } } }"`;
 
 exports[`graphql-client write batch upsert mergeByPrimaryKey 1`] = `
 Array [
@@ -34,11 +34,68 @@ Array [
 ]
 `;
 
-exports[`graphql-client write batch upsert record with null primary key field 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [createdAt, htmlUrl, name, origin, refreshedAt, type]}) { returning { id source uid } } }"`;
+exports[`graphql-client write batch upsert record with null primary key field 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin]}) { returning { id source uid } } }"`;
 
-exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\", origin: \\"mytestsource\\"}, {uid: \\"9\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [additionalFields, departmentId, employmentType, identityId, ignored, inactive, joinedAt, level, locationId, managerId, origin, refreshedAt, reportingChain, role, terminatedAt, title]}) { returning { id uid } } }"`;
+exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\"}, {uid: \\"9\\"}]) { returning { id uid } } }"`;
 
-exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [additionalFields, departmentId, employmentType, identityId, ignored, inactive, joinedAt, level, locationId, managerId, origin, refreshedAt, reportingChain, role, terminatedAt, title]}) { returning { id uid } } }"`;
+exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: \\"9\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [origin]}) { returning { id uid } } }"`;
+
+exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
+
+exports[`graphql-client write batch upsert self-referent model 4`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
+
+exports[`groupByAffectedFields noop 1`] = `
+Array [
+  Array [
+    "u0a",
+    "u0b",
+  ],
+  Array [
+    "u1a",
+    "u1b",
+  ],
+  Array [
+    "u2a",
+    "u2b",
+  ],
+]
+`;
+
+exports[`groupByAffectedFields one level 1`] = `
+Array [
+  Array [
+    "u0a",
+    "u0b",
+  ],
+  Array [
+    "u1a",
+    "u1b",
+  ],
+  Array [
+    "u2a",
+    "u2b",
+  ],
+]
+`;
+
+exports[`groupByAffectedFields two levels 1`] = `
+Array [
+  Array [
+    "u0a",
+    "u0b",
+  ],
+  Array [
+    "u1a",
+  ],
+  Array [
+    "u1b",
+  ],
+  Array [
+    "u2a",
+    "u2b",
+  ],
+]
+`;
 
 exports[`toLevels ignore other models 1`] = `
 Array [

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -42,8 +42,6 @@ exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation 
 
 exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
 
-exports[`graphql-client write batch upsert self-referent model 4`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
-
 exports[`groupByAffectedFields noop 1`] = `
 Array [
   Array [


### PR DESCRIPTION
## Description

Bug fix to address object count discrepancies between GraphQL v1 and v2 queries.  

Analysis of query results and input data indicated that v2 loading processing was not setting `origin` field in the same way as v1 process.  One major difference was v2 set `origin` on both root-level objects (i.e. those present as records in input file) and nested objects (aka references).  

After removing `origin` for reference objects a discrepancy remained.  This was traced to a bug in the `on_conflict` clause of the upsert and update statements.  Specifically, the `update_columns` field of `on_conflict` included all non-key fields regardless of the fields included in the data being processed. 

When updates were made the mismatch of `update_columns` and fields of object led to columns in `update_columns` but not in the incoming object to be nulled out.  

Details of change are as follows:

- set origin for root-level records (not nested objects) 
- group inserts by affected object fields
- match `on_conflict.update_columns` to affected object fields

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

