### PR TITLE
Honor deletion records

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
@@ -37,12 +37,6 @@ export class FarosFeed extends Converter {
 
     const [model, rec] = Object.entries(data).pop();
 
-    // Ignore full model deletion records. E.g., {"vcs_TeamMembership__Deletion":{"where":"my-source"}}
-    if (model.endsWith('__Deletion') && Object.entries(rec).length == 1) {
-      const [key, value] = Object.entries(rec).pop();
-      if (key === 'where' && typeof value == 'string') return [];
-    }
-
     if (this.schema) {
       if (model.endsWith('__Update')) {
         for (const key of ['mask', 'patch', 'where']) {

--- a/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
@@ -55,9 +55,12 @@ describe('faros_feeds', () => {
       .fromPairs()
       .value();
     const writtenByModel = {
+      cicd_ReleaseTagAssociation__Deletion: 1,
+      tms_Project__Deletion: 1,
       tms_TaskAssignment__Deletion: 1,
       tms_TaskBoard: 3,
       tms_TaskBoardProjectRelationship: 3,
+      tms_TaskBoardProjectRelationship__Deletion: 1,
       vcs_Commit: 34,
       vcs_Label: 2,
       vcs_Membership: 166,


### PR DESCRIPTION
## Description

I think I added this as a precaution to prevent accidentally dropping records, but it is actually unnecessary and results in different behavior of feed depending on whether it is run directly or via the Faros Feeds wrapper.

It is safe to remove because, if we run a full sync in Airbyte, [all](https://github.com/faros-ai/airbyte-connectors/blob/main/destinations/airbyte-faros-destination/src/converters/faros-feeds/model_names.ts) models are reset, so it doesn't matter what happens in the feed. Feeds will always issue deletion records for "non-incremental" models only (unless invoked with `--no-incremental`) so it's safe to process these deletion records.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
