### PR TITLE
Adding alerts stream in OpsGenie Connector

### DIFF
--- a/sources/opsgenie-source/resources/schemas/alerts.json
+++ b/sources/opsgenie-source/resources/schemas/alerts.json
@@ -1,0 +1,105 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "tinyId": {
+        "type": "string"
+      },
+      "alias": {
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "acknowledged": {
+        "type": "boolean"
+      },
+      "isSeen": {
+        "type": "boolean"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+            "type": "string"
+          }
+      },
+      "snoozed": {
+        "type": "boolean"
+      },
+      "snoozedUntil": {
+        "type": "string"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "lastOccurredAt": {
+        "type": "string"
+      },
+      "createdAt": {
+        "type": "string"
+      },
+      "updatedAt": {
+        "type": "string"
+      },
+      "source": {
+        "type": "string"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "priority": {
+        "type": "string"
+      },
+      "responders": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+        }
+      },
+      "integration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "report": {
+        "type": "object",
+        "properties": {
+          "ackTime": {
+            "type": "integer"
+          },
+          "closeTime": {
+            "type": "integer"
+          },
+          "acknowledgedBy": {
+            "type": "string"
+          },
+          "closedBy": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }

--- a/sources/opsgenie-source/src/index.ts
+++ b/sources/opsgenie-source/src/index.ts
@@ -9,7 +9,7 @@ import {
 import VError from 'verror';
 
 import {OpsGenie, OpsGenieConfig} from './opsgenie/opsgenie';
-import {Incidents, Teams, Users} from './streams';
+import {Alerts, Incidents, Teams, Users} from './streams';
 
 /** The main entry point. */
 export function mainCommand(): Command {
@@ -36,6 +36,7 @@ export class OpsGenieSource extends AirbyteSourceBase<OpsGenieConfig> {
   streams(config: OpsGenieConfig): AirbyteStreamBase[] {
     return [
       new Incidents(config, this.logger),
+      new Alerts(config, this.logger),
       new Teams(config, this.logger),
       new Users(config, this.logger),
     ];

--- a/sources/opsgenie-source/src/opsgenie/models.ts
+++ b/sources/opsgenie-source/src/opsgenie/models.ts
@@ -48,6 +48,42 @@ export interface Incident {
   timelines: IncidentTimeline[];
 }
 
+interface Integration {
+  type: string;
+  id: string;
+  name: string;
+}
+
+interface Report {
+  ackTime: number;
+  closeTime: number;
+  acknowledgedBy: string;
+  closedBy: string;
+}
+
+export interface Alert {
+  id: string;
+  tinyId: string;
+  alias: string;
+  message: string;
+  status: string;
+  acknowledged: boolean;
+  isSeen: boolean;
+  tags: string[];
+  snoozed: boolean;
+  snoozedUntil: string;
+  count: number;
+  lastOccurredAt: string;
+  createdAt: string;
+  updatedAt: string;
+  source: string;
+  owner: string;
+  priority: string;
+  responders: Responder[];
+  integration: Integration;
+  report: Report;
+}
+
 export interface Team {
   id: string;
   name: string;

--- a/sources/opsgenie-source/src/opsgenie/opsgenie.ts
+++ b/sources/opsgenie-source/src/opsgenie/opsgenie.ts
@@ -50,6 +50,9 @@ export class OpsGenie {
     });
 
     const pageSize = config.page_size ?? DEFAULT_PAGE_SIZE;
+    if (Math.sign(pageSize) <= 0) {
+      throw new VError('Please add a positive value as page size');
+    }
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - config.cutoff_days);
     OpsGenie.opsGenie = new OpsGenie(httpClient, startDate, pageSize, logger);

--- a/sources/opsgenie-source/src/opsgenie/opsgenie.ts
+++ b/sources/opsgenie-source/src/opsgenie/opsgenie.ts
@@ -157,7 +157,7 @@ export class OpsGenie {
         params
       );
       for (const alert of response?.data?.data ?? []) {
-        if (new Date(alert.createdAt) >= startTimeMax) {
+        if (new Date(alert.createdAt) > startTimeMax) {
           const alertItem = alert;
           yield alertItem;
         }

--- a/sources/opsgenie-source/src/streams/alerts.ts
+++ b/sources/opsgenie-source/src/streams/alerts.ts
@@ -1,0 +1,58 @@
+import {
+  AirbyteLogger,
+  AirbyteStreamBase,
+  StreamKey,
+  SyncMode,
+} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {Alert} from '../opsgenie/models';
+import {OpsGenie, OpsGenieConfig} from '../opsgenie/opsgenie';
+interface AlertState {
+  lastCreatedAt?: Date;
+}
+export class Alerts extends AirbyteStreamBase {
+  constructor(
+    private readonly config: OpsGenieConfig,
+    protected readonly logger: AirbyteLogger
+  ) {
+    super(logger);
+  }
+
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/alerts.json');
+  }
+  get primaryKey(): StreamKey {
+    return 'id';
+  }
+  get cursorField(): string | string[] {
+    return 'createdAt';
+  }
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: Dictionary<any>,
+    streamState?: AlertState
+  ): AsyncGenerator<Alert> {
+    const lastCreatedAt =
+      syncMode === SyncMode.INCREMENTAL
+        ? new Date(streamState?.lastCreatedAt ?? 0)
+        : undefined;
+    const opsGenie = OpsGenie.instance(this.config, this.logger);
+    yield* opsGenie.getAlerts(lastCreatedAt);
+  }
+
+  getUpdatedState(
+    currentStreamState: AlertState,
+    latestRecord: Alert
+  ): AlertState {
+    const lastCreatedAt = new Date(latestRecord.createdAt);
+    return {
+      lastCreatedAt:
+        new Date(lastCreatedAt) >
+        new Date(currentStreamState?.lastCreatedAt ?? 0)
+          ? lastCreatedAt
+          : currentStreamState?.lastCreatedAt,
+    };
+  }
+}

--- a/sources/opsgenie-source/src/streams/index.ts
+++ b/sources/opsgenie-source/src/streams/index.ts
@@ -1,4 +1,5 @@
+import {Alerts} from './alerts';
 import {Incidents} from './incidents';
 import {Teams} from './teams';
 import {Users} from './users';
-export {Incidents, Users, Teams};
+export {Incidents, Alerts, Users, Teams};

--- a/sources/opsgenie-source/test_files/alerts.json
+++ b/sources/opsgenie-source/test_files/alerts.json
@@ -1,0 +1,80 @@
+[
+    {
+        "id": "80413a06-38d6-4c85-92b8-5ebc900d42e2",
+        "tinyId": "1791",
+        "alias": "event_573",
+        "message": "Our servers are in danger",
+        "status": "closed",
+        "acknowledged": false,
+        "isSeen": true,
+        "tags": [
+            "OverwriteQuietHours",
+            "Critical"
+        ],
+        "snoozed": true,
+        "snoozedUntil": "2017-04-03T20:32:35.143Z",
+        "count": 79,
+        "lastOccurredAt": "2017-04-03T20:05:50.894Z",
+        "createdAt": "2017-03-21T20:32:52.353Z",
+        "updatedAt": "2017-04-03T20:32:57.301Z",
+        "source": "Isengard",
+        "owner": "morpheus@opsgenie.com",
+        "priority": "P4",
+        "responders":[
+          {
+              "id":"4513b7ea-3b91-438f-b7e4-e3e54af9147c",
+              "type":"team"
+          },
+          {
+              "id":"bb4d9938-c3c2-455d-aaab-727aa701c0d8",
+              "type":"user"
+          },
+          {
+              "id":"aee8a0de-c80f-4515-a232-501c0bc9d715",
+              "type":"escalation"
+          },
+          {
+              "id":"80564037-1984-4f38-b98e-8a1f662df552",
+              "type":"schedule"
+          }
+        ],
+        "integration": {
+            "id": "4513b7ea-3b91-438f-b7e4-e3e54af9147c",
+            "name": "Nebuchadnezzar",
+            "type": "API"
+        },
+        "report": {
+            "ackTime": 15702,
+            "closeTime": 60503,
+            "acknowledgedBy": "agent_smith@opsgenie.com",
+            "closedBy": "neo@opsgenie.com"
+        }
+    },
+    {
+        "id": "70413a06-38d6-4c85-92b8-5ebc900d42e2",
+        "tinyId": "1792",
+        "alias": "event_574",
+        "message": "Sample Message",
+        "status": "open",
+        "acknowledged": false,
+        "isSeen": false,
+        "tags": [
+            "RandomTag"
+        ],
+        "snoozed": false,
+        "count": 1,
+        "lastOccurredAt": "2017-03-21T20:32:52.353Z",
+        "createdAt": "2017-03-21T20:32:52.353Z",
+        "updatedAt": "2017-04-03T20:32:57.301Z",
+        "source": "Zion",
+        "owner": "",
+        "priority": "P5",
+        "responders":[],
+        "integration": {
+            "id": "4513b7ea-3b91-b7e4-438f-e3e54af9147c",
+            "name": "My_Lovely_Amazon",
+            "type": "CloudWatch"
+        }
+    }
+
+]

--- a/sources/opsgenie-source/test_files/full_configured_catalog.json
+++ b/sources/opsgenie-source/test_files/full_configured_catalog.json
@@ -19,6 +19,23 @@
         },
         {
             "stream": {
+                "name": "alerts",
+                "json_schema": {},
+                "supported_sync_modes": [
+                    "full_refresh",
+                    "incremental"
+                ],
+                "source_defined_primary_key": [
+                    [
+                        "id"
+                    ]
+                ]
+            },
+            "sync_mode": "full_refresh",
+            "destination_sync_mode": "overwrite"
+        },
+        {
+            "stream": {
                 "name": "teams",
                 "json_schema": {},
                 "supported_sync_modes": [

--- a/sources/opsgenie-source/test_files/incremental_configured_catalog.json
+++ b/sources/opsgenie-source/test_files/incremental_configured_catalog.json
@@ -20,6 +20,27 @@
             },
             "sync_mode": "incremental",
             "destination_sync_mode": "append"
+        },
+        {
+            "stream": {
+                "name": "alerts",
+                "json_schema": {},
+                "supported_sync_modes": [
+                    "full_refresh",
+                    "incremental"
+                ],
+                "default_cursor_field": [
+                    "createdAt"
+                ],
+                "source_defined_cursor": true,
+                "source_defined_primary_key": [
+                    [
+                        "id"
+                    ]
+                ]
+            },
+            "sync_mode": "incremental",
+            "destination_sync_mode": "append"
         }
     ]
 }


### PR DESCRIPTION
## Description

> Provide description here

## Type of change
- [X] New feature

## Extra info

> Adding Alerts stream in OpsGenie connector

## Test Results

```
➜  opsgenie-source git:(mudasir/adding_alerts_stream_opsgenie) npm test

> opsgenie-source@0.0.1 test
> jest --verbose --color

 PASS  test/index.test.ts
  index
    ✓ spec (2 ms)
    ✓ check connection (1 ms)
    ✓ check connection - incorrect config (1 ms)
    ✓ streams - incidents, use full_refresh sync mode (2 ms)
    ✓ streams - incidents, paginate
    ✓ streams - teams, use full_refresh sync mode (1 ms)
    ✓ streams - users, use full_refresh sync mode (1 ms)
    ✓ streams - users, paginate
    ✓ streams - alerts, use full_refresh sync mode (1 ms)
    ✓ streams - alerts, paginate (1 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        0.45 s, estimated 5 s
Ran all test suites.
➜  opsgenie-source git:(mudasir/adding_alerts_stream_opsgenie) 
```