### PR TITLE
Improve JSONata converter + bump faros-js-client

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -60,8 +60,7 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
-      ".d.ts",
-      ".js"
+      ".d.ts"
     ],
     "testTimeout": 30000,
     "globals": {

--- a/destinations/airbyte-faros-destination/src/converters/jsonata.ts
+++ b/destinations/airbyte-faros-destination/src/converters/jsonata.ts
@@ -1,12 +1,21 @@
+import {ok} from 'assert';
 import {AirbyteRecord} from 'faros-airbyte-cdk';
+import {FarosGraphSchema} from 'faros-js-client';
 import jsonata from 'jsonata';
 import {VError} from 'verror';
 
-import {Converter, DestinationModel, DestinationRecord} from './converter';
+import {
+  Converter,
+  DestinationModel,
+  DestinationRecord,
+  StreamContext,
+} from './converter';
 
 /** Record converter to convert records using provided JSONata expression */
 export class JSONataConverter extends Converter {
   source = 'JSONata';
+
+  private schema: FarosGraphSchema = undefined;
 
   constructor(
     private readonly jsonataExpr: jsonata.Expression,
@@ -20,11 +29,54 @@ export class JSONataConverter extends Converter {
   }
 
   async convert(
-    record: AirbyteRecord
+    record: AirbyteRecord,
+    ctx?: StreamContext
   ): Promise<ReadonlyArray<DestinationRecord>> {
-    const res = this.jsonataExpr.evaluate(record.record);
-    if (!res) return [];
-    if (!Array.isArray(res)) return [res];
+    if (!this.schema && ctx?.farosClient && ctx?.graph) {
+      this.schema = new FarosGraphSchema(
+        await ctx.farosClient.introspect(ctx.graph)
+      );
+    }
+
+    let jsonataResult = this.jsonataExpr.evaluate(record.record);
+    if (!jsonataResult) return [];
+    if (!Array.isArray(jsonataResult)) jsonataResult = [jsonataResult];
+
+    const res = [];
+    for (const result of jsonataResult) {
+      // We expect each jsonata result to conform to:
+      // { '<model>': {<record data>} } or
+      // { '<model>__<operation>': {<record data>} }
+      ok(
+        Object.keys(result).length == 1,
+        'jsonata result should contain a single key'
+      );
+
+      const [model, rec] = Object.entries(result).pop();
+
+      if (this.schema) {
+        if (model.endsWith('__Update')) {
+          for (const key of ['mask', 'patch', 'where']) {
+            this.schema.fixTimestampFields(
+              rec[key],
+              model.replace('__Update', '')
+            );
+          }
+        } else if (model.endsWith('__Deletion')) {
+          this.schema.fixTimestampFields(
+            rec['where'],
+            model.replace('__Deletion', '')
+          );
+        } else if (model.endsWith('__Upsert')) {
+          this.schema.fixTimestampFields(rec, model.replace('__Upsert', ''));
+        } else {
+          this.schema.fixTimestampFields(rec, model);
+        }
+      }
+
+      res.push({model, record: rec});
+    }
+
     return res;
   }
 

--- a/destinations/airbyte-faros-destination/test/converters/github.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/github.test.ts
@@ -151,8 +151,8 @@ describe('github', () => {
       ) +
         os.EOL +
         JSON.stringify(
-          AirbyteRecord.make('mytestsource__github__something_else', {
-            foo: 'bar',
+          AirbyteRecord.make('mytestsource__github__assignees', {
+            login: 'xyz',
           })
         ) +
         os.EOL,

--- a/destinations/airbyte-faros-destination/test/converters/jsonata.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jsonata.test.ts
@@ -1,0 +1,53 @@
+import {AirbyteRecord} from 'faros-airbyte-cdk';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  Converter,
+  ConverterTyped,
+  DestinationRecord,
+  DestinationRecordTyped,
+  StreamName,
+} from '../../src/converters/converter';
+import {JSONataConverter as sut} from '../../src/converters/jsonata';
+
+describe('jsonata', () => {
+  test('fails if empty destination models', async () => {
+    expect(() => sut.make('', [])).toThrow(
+      'Destination models cannot be empty'
+    );
+  });
+
+  test('fails if bad jsonata expression', async () => {
+    expect(() => sut.make('bad jsonata', ['A', 'B'])).toThrow(
+      'Failed to parse JSONata expression'
+    );
+  });
+
+  test('converts records', async () => {
+    expect(
+      await sut
+        .make("(data.({'Person': {'name':name}}))", ['Person'])
+        .convert(AirbyteRecord.make('X', {name: 'John Doe'}))
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "model": "Person",
+          "record": Object {
+            "name": "John Doe",
+          },
+        },
+      ]
+    `);
+  });
+
+  test('fails if bad jsonata result', async () => {
+    expect(async () => {
+      await sut
+        .make("(data.({'Person': {'name':name}, 'UnexpectedKey':1}))", [
+          'Person',
+        ])
+        .convert(AirbyteRecord.make('X', {name: 'John Doe'}));
+    }).rejects.toThrow('jsonata result should contain a single key');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "condoit": "^2.1.0",
         "date-format": "^4.0.6",
         "faros-feeds-sdk": "^1.0.1",
-        "faros-js-client": "^0.2.16",
+        "faros-js-client": "^0.2.19",
         "fast-redact": "^3.0.2",
         "fs-extra": "^11.1.0",
         "git-url-parse": "^13.0.0",
@@ -8253,9 +8253,9 @@
       }
     },
     "node_modules/faros-js-client": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.16.tgz",
-      "integrity": "sha512-OglBiYu7/uAIJwQ4f1S9X9umES12lWiAXfcTLEUmTaX5CPvdVyh1pxmSz9b3za4y0FblfjxFBT/Sfh0IW/FPtg==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.19.tgz",
+      "integrity": "sha512-yWMoL8A487Y8IYoMzSdp0Y8LYySqWmGePdQ1RZUue8rzbHkDvugg3yyYo1DyGwrNz3m+7VXEbjij7Z274jkytA==",
       "dependencies": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",
@@ -23328,9 +23328,9 @@
       }
     },
     "faros-js-client": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.16.tgz",
-      "integrity": "sha512-OglBiYu7/uAIJwQ4f1S9X9umES12lWiAXfcTLEUmTaX5CPvdVyh1pxmSz9b3za4y0FblfjxFBT/Sfh0IW/FPtg==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.19.tgz",
+      "integrity": "sha512-yWMoL8A487Y8IYoMzSdp0Y8LYySqWmGePdQ1RZUue8rzbHkDvugg3yyYo1DyGwrNz3m+7VXEbjij7Z274jkytA==",
       "requires": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",

--- a/sources/datadog-source/src/datadog.ts
+++ b/sources/datadog-source/src/datadog.ts
@@ -68,9 +68,8 @@ export class Datadog {
 
     // Add ability to change sites to other regions.
     client.setServerVariables(clientConfig, {
-        site: config.site ?? DEFAULT_SITE
+      site: config.site ?? DEFAULT_SITE,
     });
-
 
     // Beta endpoints are unstable and need to be explicitly enabled
     clientConfig.unstableOperations['v2.listIncidents'] = true;

--- a/sources/faros-graphql-source/package.json
+++ b/sources/faros-graphql-source/package.json
@@ -32,7 +32,7 @@
     "avsc": "5.7.7",
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
-    "faros-js-client": "^0.2.16",
+    "faros-js-client": "^0.2.19",
     "graphql": "^16.3.0",
     "verror": "^1.10.1"
   },


### PR DESCRIPTION
## Description

Improves the JSONata converter:

- Adds an assertion to enforce the shape of the jsonata results
- Fixes timestamps on output records
- Adds tests

## Type of change
- [ ] Bug fix
- [] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
