### PR TITLE
fix: change customer.io api base url

### DIFF
--- a/sources/customer-io-source/src/customer-io/customer-io.ts
+++ b/sources/customer-io-source/src/customer-io/customer-io.ts
@@ -10,7 +10,7 @@ import {
   CustomerIONewsletter,
 } from './typings';
 
-const CUSTOMER_IO_BETA_API_URL = 'https://beta-api.customer.io/v1/api';
+const CUSTOMER_IO_BETA_API_URL = 'https://api.customer.io/v1';
 
 export interface CustomerIOConfig {
   app_api_key: string;


### PR DESCRIPTION
## Description

> Change Customer.io API base url to `https://api.customer.io/v1` instead of `https://beta-api.customer.io/v1/api` as it is mentioned [here](https://customer.io/docs/release-notes/2022-02-28-beta-api-official-release/)

## Notion Ticket

[Customer IO Internal Error](https://www.notion.so/rudderstacks/d8ea6e5cd7b2481db207d6b239676688?v=799e76e4eabd45b3ad80c87fdebdb765&p=835f01ddaf0b43db9ba3039b67941c29&pm=c)