### PR TITLE
fix: change customer.io base url

### DIFF
--- a/sources/customer-io-source/src/customer-io/customer-io.ts
+++ b/sources/customer-io-source/src/customer-io/customer-io.ts
@@ -10,7 +10,7 @@ import {
   CustomerIONewsletter,
 } from './typings';
 
-const CUSTOMER_IO_BETA_API_URL = 'https://api.customer.io/v1';
+const CUSTOMER_IO_API_URL = 'https://api.customer.io/v1';
 
 export interface CustomerIOConfig {
   app_api_key: string;
@@ -35,7 +35,7 @@ export class CustomerIO {
     return new CustomerIO(
       axiosInstance ??
         axios.create({
-          baseURL: CUSTOMER_IO_BETA_API_URL,
+          baseURL: CUSTOMER_IO_API_URL,
           timeout: 30000,
           responseType: 'json',
           headers: {Authorization: `Bearer ${config.app_api_key}`},

--- a/sources/customer-io-source/src/customer-io/customer-io.ts
+++ b/sources/customer-io-source/src/customer-io/customer-io.ts
@@ -10,7 +10,7 @@ import {
   CustomerIONewsletter,
 } from './typings';
 
-const CUSTOMER_IO_BETA_API_URL = 'https://beta-api.customer.io/v1/api';
+const CUSTOMER_IO_BETA_API_URL = 'https://api.customer.io/v1';
 
 export interface CustomerIOConfig {
   app_api_key: string;


### PR DESCRIPTION
## Description

> Change Customer.io API base url to https://api.customer.io/v1 instead of https://beta-api.customer.io/v1/api as it is mentioned [here](https://customer.io/docs/release-notes/2022-02-28-beta-api-official-release/)


