### PR TITLE
ClickUp test: ignore status_history fields because they contain relative timestamps

### DIFF
--- a/sources/clickup-source/acceptance-test-config.yml
+++ b/sources/clickup-source/acceptance-test-config.yml
@@ -18,6 +18,7 @@ tests:
     - config_path: "secrets/config.json"
       configured_catalog_path: "test_files/full_configured_catalog.json"
       ignored_fields:
+        status_histories: ["current_status", "status_history"]
         workspaces: ["members"]
   incremental:
     - config_path: "secrets/config.json"


### PR DESCRIPTION

## Description

> Provide description here

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
