### PR TITLE
FAI-3458: Clickup Converter - Only use one taskboard source

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -273,16 +273,12 @@
                     "type": "object",
                     "title": "Configuration",
                     "properties": {
-                      "taskboard_sources": {
-                        "type": "array",
-                        "items": {
-                          "type": "string",
-                          "enum": ["space", "folder", "list"]
-                        },
-                        "title": "TaskBoard Sources",
-                        "description": "List of ClickUp task grouping types that will be mapped to tms_TaskBoards",
-                        "default": ["space"],
-                        "examples": ["space", "folder", "list"]
+                      "taskboard_source": {
+                        "type": "string",
+                        "title": "TaskBoard Source",
+                        "description": "ClickUp task grouping type that will be mapped to tms_TaskBoards",
+                        "default": "space",
+                        "enum": ["space", "folder", "list"]
                       },
                       "truncate_limit": {
                         "type": "integer",

--- a/destinations/airbyte-faros-destination/src/converters/clickup/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/clickup/common.ts
@@ -6,11 +6,11 @@ import {Converter, StreamContext} from '../converter';
 type TaskBoardSource = 'space' | 'folder' | 'list';
 
 interface ClickUpConfig {
-  taskboard_sources?: ReadonlyArray<TaskBoardSource>;
+  taskboard_source?: TaskBoardSource;
   truncate_limit?: number;
 }
 
-const DEFAULT_TASKBOARD_SOURCES: ReadonlyArray<TaskBoardSource> = ['space'];
+const DEFAULT_TASKBOARD_SOURCE: TaskBoardSource = 'space';
 const DEFAULT_TRUNCATE_LIMIT = 10_000;
 
 export class ClickUpCommon {
@@ -46,12 +46,8 @@ export abstract class ClickUpConverter extends Converter {
     return ctx.config.source_specific_configs?.clickup ?? {};
   }
 
-  protected taskboardSources(
-    ctx: StreamContext
-  ): ReadonlyArray<TaskBoardSource> {
-    return (
-      this.clickupConfig(ctx).taskboard_sources ?? DEFAULT_TASKBOARD_SOURCES
-    );
+  protected taskboardSource(ctx: StreamContext): TaskBoardSource {
+    return this.clickupConfig(ctx).taskboard_source ?? DEFAULT_TASKBOARD_SOURCE;
   }
 
   protected truncateLimit(ctx: StreamContext): number {

--- a/destinations/airbyte-faros-destination/src/converters/clickup/folders.ts
+++ b/destinations/airbyte-faros-destination/src/converters/clickup/folders.ts
@@ -18,11 +18,11 @@ export class Folders extends ClickUpConverter {
     const source = this.streamName.source;
     const uid = folder.id;
     const results: DestinationRecord[] = [];
-    if (this.taskboardSources(ctx).includes('folder')) {
+    if (this.taskboardSource(ctx) === 'folder') {
       results.push(
         {
           model: 'tms_TaskBoard',
-          record: {uid, name: `${folder.name} (folder)`, source},
+          record: {uid, name: folder.name, source},
         },
         {
           model: 'tms_TaskBoardProjectRelationship',

--- a/destinations/airbyte-faros-destination/src/converters/clickup/lists.ts
+++ b/destinations/airbyte-faros-destination/src/converters/clickup/lists.ts
@@ -18,11 +18,11 @@ export class Lists extends ClickUpConverter {
     const source = this.streamName.source;
     const uid = list.id;
     const results: DestinationRecord[] = [];
-    if (this.taskboardSources(ctx).includes('list')) {
+    if (this.taskboardSource(ctx) === 'list') {
       results.push(
         {
           model: 'tms_TaskBoard',
-          record: {uid, name: `${list.name} (list)`, source},
+          record: {uid, name: list.name, source},
         },
         {
           model: 'tms_TaskBoardProjectRelationship',

--- a/destinations/airbyte-faros-destination/src/converters/clickup/spaces.ts
+++ b/destinations/airbyte-faros-destination/src/converters/clickup/spaces.ts
@@ -18,11 +18,11 @@ export class Spaces extends ClickUpConverter {
     const source = this.streamName.source;
     const uid = space.id;
     const results: DestinationRecord[] = [];
-    if (this.taskboardSources(ctx).includes('space')) {
+    if (this.taskboardSource(ctx) === 'space') {
       results.push(
         {
           model: 'tms_TaskBoard',
-          record: {uid, name: `${space.name} (space)`, source},
+          record: {uid, name: space.name, source},
         },
         {
           model: 'tms_TaskBoardProjectRelationship',

--- a/destinations/airbyte-faros-destination/src/converters/clickup/tasks.ts
+++ b/destinations/airbyte-faros-destination/src/converters/clickup/tasks.ts
@@ -111,14 +111,12 @@ export class Tasks extends ClickUpConverter {
       });
     }
 
-    const taskboardSources = this.taskboardSources(ctx);
-    for (const tbSource of taskboardSources) {
-      if (task[tbSource]?.id) {
-        results.push({
-          model: 'tms_TaskBoardRelationship',
-          record: {task: taskKey, board: {uid: task[tbSource].id, source}},
-        });
-      }
+    const taskboardSource = this.taskboardSource(ctx);
+    if (task[taskboardSource]?.id) {
+      results.push({
+        model: 'tms_TaskBoardRelationship',
+        record: {task: taskKey, board: {uid: task[taskboardSource].id, source}},
+      });
     }
 
     return results;

--- a/destinations/airbyte-faros-destination/test/converters/clickup.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/clickup.test.ts
@@ -20,7 +20,7 @@ describe('clickup', () => {
   beforeEach(async () => {
     await initMockttp(mockttp);
     configPath = await sourceSpecificTempConfig(mockttp.url, {
-      clickup: {taskboard_sources: ['space', 'folder', 'list']},
+      clickup: {taskboard_source: 'space'},
     });
   });
 
@@ -63,9 +63,9 @@ describe('clickup', () => {
       tms_Project: 3,
       tms_Task: 9,
       tms_TaskAssignment: 1,
-      tms_TaskBoard: 14,
-      tms_TaskBoardProjectRelationship: 14,
-      tms_TaskBoardRelationship: 27,
+      tms_TaskBoard: 7,
+      tms_TaskBoardProjectRelationship: 7,
+      tms_TaskBoardRelationship: 9,
       tms_TaskDependency: 1,
       tms_TaskProjectRelationship: 9,
       tms_TaskTag: 2,


### PR DESCRIPTION
## Description

If users request it, we'll support more than one taskboard source, but that will also require Faros UI changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
