### PR TITLE
Add spec-pretty subcommand to all connectors

### DIFF
--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -42,6 +42,7 @@
     "json-schema-traverse": "^1.0.0",
     "lodash": "^4.17.21",
     "pino": "^8.5.0",
+    "table": "^6.8.1",
     "verror": "^1.10.1"
   },
   "jest": {

--- a/faros-airbyte-cdk/src/destinations/destination-runner.ts
+++ b/faros-airbyte-cdk/src/destinations/destination-runner.ts
@@ -26,9 +26,9 @@ export class AirbyteDestinationRunner<
       .name('main')
       .version('v' + PACKAGE_VERSION)
       .addCommand(this.specCommand())
+      .addCommand(this.specPrettyCommand())
       .addCommand(this.checkCommand())
-      .addCommand(this.writeCommand())
-      .addCommand(this.specPrettyCommand());
+      .addCommand(this.writeCommand());
   }
 
   specCommand(): Command {
@@ -107,7 +107,7 @@ export class AirbyteDestinationRunner<
   specPrettyCommand(): Command {
     return new Command()
       .command('spec-pretty')
-      .description('spec-pretty command')
+      .description('pretty spec command')
       .action(async () => {
         const spec = await this.destination.spec();
         const rows = traverseObject(

--- a/faros-airbyte-cdk/src/destinations/destination-runner.ts
+++ b/faros-airbyte-cdk/src/destinations/destination-runner.ts
@@ -4,6 +4,7 @@ import {Command} from 'commander';
 import path from 'path';
 
 import {wrapApiError} from '../errors';
+import {helpTable, traverseObject} from '../help';
 import {AirbyteLogger} from '../logger';
 import {AirbyteConfig, AirbyteSpec} from '../protocol';
 import {Runner} from '../runner';
@@ -26,7 +27,8 @@ export class AirbyteDestinationRunner<
       .version('v' + PACKAGE_VERSION)
       .addCommand(this.specCommand())
       .addCommand(this.checkCommand())
-      .addCommand(this.writeCommand());
+      .addCommand(this.writeCommand())
+      .addCommand(this.specPrettyCommand());
   }
 
   specCommand(): Command {
@@ -100,6 +102,30 @@ export class AirbyteDestinationRunner<
           }
         }
       );
+  }
+
+  specPrettyCommand(): Command {
+    return new Command()
+      .command('spec-pretty')
+      .description('spec-pretty command')
+      .action(async () => {
+        const spec = await this.destination.spec();
+        const rows = traverseObject(
+          spec.spec.connectionSpecification,
+          [
+            // Prefix argument names with --dst
+            '--dst',
+          ],
+          // Assign section = 0 to the root object's row, which
+          // will be removed, so that the remaining rows are
+          // numbered 1..N
+          0
+        );
+        // Drop the first row since it corresponds to the root
+        // (connectionSpecification) object
+        rows.shift();
+        console.log(helpTable(rows));
+      });
   }
 
   private async loadConfig(opts: {

--- a/faros-airbyte-cdk/src/help.ts
+++ b/faros-airbyte-cdk/src/help.ts
@@ -1,0 +1,161 @@
+import {ok} from 'assert';
+import _ from 'lodash';
+import {upperFirst} from 'lodash';
+import {table} from 'table';
+import {Dictionary} from 'ts-essentials';
+
+const INF_ORDER = 1000;
+
+export interface TableRow {
+  title: string;
+  path: string;
+  section: number;
+  description?: string;
+  required: boolean;
+  constValue?: string;
+  default?: any;
+  examples: ReadonlyArray<any>;
+  airbyte_secret?: boolean;
+  multiline?: boolean;
+  type: string;
+}
+
+function visitLeaf(
+  o: Dictionary<any>,
+  curPath: string[],
+  section: number,
+  required = false
+): TableRow {
+  const title =
+    o.title || curPath.slice(-1)[0].split('_').map(upperFirst).join(' ');
+  const leaf = {
+    title,
+    path: curPath.join('.'),
+    section,
+    required,
+    description: o.description,
+    airbyte_secret: o.airbyte_secret,
+    default: o.default,
+    constValue: o.const,
+    multiline: o.multiline,
+    examples: o.examples,
+    type: o.type === 'array' ? `array of ${o.items.type}` : o.type,
+  };
+
+  return leaf;
+}
+
+export function traverseObject(
+  startObject: Dictionary<any>,
+  startPath: string[],
+  section = 1,
+  required = false
+): TableRow[] {
+  const result: TableRow[] = [];
+  // Queue of objects to process in BFS
+  const process: [[Dictionary<any>, string[], number, boolean]] = [
+    [startObject, startPath, section, required],
+  ];
+  let newIdx = section + 1;
+  while (process.length > 0) {
+    const [curObject, curPath, idx, req] = process.shift();
+    if (curObject['type'] !== 'object') {
+      result.push(visitLeaf(curObject, curPath, idx, req));
+      continue;
+    }
+
+    ok(curObject.properties || curObject.oneOf);
+    ok(curObject.properties === undefined || curObject.oneOf === undefined);
+    ok(curObject.title);
+
+    if (curObject.properties) {
+      const children = Object.keys(curObject.properties).length;
+      ok(children > 0);
+      result.push({
+        title: curObject.title,
+        path: curPath.join('.'),
+        section: idx,
+        description: `Please configure argument${
+          children > 1 ? 's' : ''
+        } ${_.range(newIdx, newIdx + children).join()} as needed`,
+        required: req,
+        type: 'object',
+        examples: [],
+      });
+      const requiredProperties: string[] = curObject.required || [];
+      const cmp = (a, b) =>
+        (curObject.properties[a]['order'] ?? INF_ORDER) -
+        (curObject.properties[b]['order'] ?? INF_ORDER);
+      for (const propertyName of Object.keys(curObject.properties).sort(cmp)) {
+        process.push([
+          curObject.properties[propertyName],
+          curPath.concat(propertyName),
+          newIdx++,
+          requiredProperties.includes(propertyName),
+        ]);
+      }
+    } else {
+      const children = curObject.oneOf.length;
+      ok(children > 0);
+      result.push({
+        title: curObject.title,
+        path: curPath.join('.'),
+        section: idx,
+        description:
+          children > 1
+            ? `Please select and configure a single argument from ${_.range(
+                newIdx,
+                newIdx + children
+              ).join()}`
+            : `Please configure argument ${newIdx}`,
+        required: req,
+        type: 'object',
+        examples: [],
+      });
+      for (const choice of curObject.oneOf) {
+        process.push([choice, curPath, newIdx++, false]);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function helpTable(rows: ReadonlyArray<TableRow>): string {
+  const data = [
+    [
+      'Section ID',
+      'Title',
+      'Argument',
+      'Description',
+      'Required',
+      'Constant',
+      'Default',
+      'Examples',
+    ],
+  ];
+
+  const config = {
+    columns: {
+      1: {width: 15, wrapWord: true},
+      2: {width: 15, wrapWord: true},
+      3: {width: 30, wrapWord: true},
+      7: {width: 20, wrapWord: true},
+    },
+  };
+
+  for (const row of rows) {
+    data.push([
+      row.section,
+      row.title,
+      row.path,
+      row.description || '',
+      row.required ? 'Yes' : 'No',
+      row.constValue || '',
+      row.default ?? '',
+      row.examples ? row.examples.join('\n') : '',
+    ]);
+  }
+
+  return table(data, config);
+}

--- a/faros-airbyte-cdk/src/index.ts
+++ b/faros-airbyte-cdk/src/index.ts
@@ -8,3 +8,4 @@ export * from './sources/source';
 export * from './sources/source-runner';
 export * from './sources/streams/stream-base';
 export * from './utils';
+export * from './help';

--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -24,10 +24,10 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
       .name('main')
       .version('v' + PACKAGE_VERSION)
       .addCommand(this.specCommand())
+      .addCommand(this.specPrettyCommand())
       .addCommand(this.checkCommand())
       .addCommand(this.discoverCommand())
-      .addCommand(this.readCommand())
-      .addCommand(this.specPrettyCommand());
+      .addCommand(this.readCommand());
   }
 
   specCommand(): Command {
@@ -116,7 +116,7 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
   specPrettyCommand(): Command {
     return new Command()
       .command('spec-pretty')
-      .description('spec-pretty command')
+      .description('pretty spec command')
       .action(async () => {
         const spec = await this.source.spec();
         const rows = traverseObject(

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "parse-link-header": "^2.0.0",
         "pino": "^8.5.0",
         "statuspage.io": "^3.1.0",
+        "table": "^6.8.1",
         "toposort": "^2.0.2",
         "traverse": "^0.6.6",
         "turndown": "^7.1.1",
@@ -5385,7 +5386,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5394,7 +5394,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -5518,7 +5517,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6520,7 +6518,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -6531,8 +6528,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -7567,8 +7563,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -11720,6 +11715,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -14757,6 +14757,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -15461,7 +15469,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15475,7 +15482,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15484,7 +15490,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -15607,6 +15612,60 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/tar": {
       "version": "6.1.13",
@@ -16229,7 +16288,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -21128,14 +21186,12 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -21231,8 +21287,7 @@
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
       "version": "2.6.4",
@@ -21985,7 +22040,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -21993,8 +22047,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -22803,8 +22856,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -26002,6 +26054,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -28328,6 +28385,11 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -28878,7 +28940,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -28888,8 +28949,7 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         }
       }
     },
@@ -28897,7 +28957,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -28981,6 +29040,46 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "table": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
+      }
     },
     "tar": {
       "version": "6.1.13",
@@ -29443,7 +29542,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }


### PR DESCRIPTION
## Description

Add spec-pretty subcommand to all connectors. This command generates a help table from the connector's spec to guide a user on how to configure the connector via the command line args when using Faros [airbyte-local-cli](https://github.com/faros-ai/airbyte-local-cli)

Example output for a source:
![Screenshot 2023-01-25 at 12 30 21 AM](https://user-images.githubusercontent.com/99700024/214488355-f1fd4c27-38e6-4f2b-a28e-12f73dd40124.png)

Example output for a destination (truncated):
![Screenshot 2023-01-25 at 12 31 40 AM](https://user-images.githubusercontent.com/99700024/214488451-0862cdc6-131c-495d-a125-26d606d59b43.png)

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
