### PR TITLE
Fix squadcast check connection and spec

### DIFF
--- a/sources/squadcast-source/resources/spec.json
+++ b/sources/squadcast-source/resources/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "SquadCast Spec",
     "type": "object",
-    "required": ["token", "cutoff_days"],
+    "required": ["token"],
     "additionalProperties": true,
     "properties": {
       "token": {
@@ -17,7 +17,7 @@
         "type": "integer",
         "title": "Cutoff Days",
         "default": 90,
-        "description": "Only fetch data updated after cutoff"
+        "description": "Only fetch data updated in the last number of days"
       },
       "incident_owner_id": {
         "type": "string",

--- a/sources/squadcast-source/resources/spec.json
+++ b/sources/squadcast-source/resources/spec.json
@@ -4,13 +4,15 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "SquadCast Spec",
     "type": "object",
-    "required": ["token"],
+    "required": [
+      "token"
+    ],
     "additionalProperties": true,
     "properties": {
       "token": {
         "type": "string",
         "title": "Token",
-        "description": "Get API Refresh Token on https://app.squadcast.com/user/USER_ID where USER_ID is user's ID",
+        "description": "Get API Refresh Token https://support.squadcast.com/terraform-and-api-documentation/public-api-refresh-token",
         "airbyte_secret": true
       },
       "cutoff_days": {

--- a/sources/squadcast-source/src/index.ts
+++ b/sources/squadcast-source/src/index.ts
@@ -26,8 +26,7 @@ export class SquadcastSource extends AirbyteSourceBase<SquadcastConfig> {
   }
   async checkConnection(config: SquadcastConfig): Promise<[boolean, VError]> {
     try {
-      const squadcast = await Squadcast.instance(config, this.logger);
-      await squadcast.checkConnection();
+      await Squadcast.instance(config, this.logger);
     } catch (err: any) {
       return [false, err];
     }


### PR DESCRIPTION
## Description

Responding to issues raised by community member: https://faroscommunity.slack.com/archives/C0335HMN2NQ/p1674575092950259

Noticed while debugging in my local that the `read` command was working but the `check` was not, while using the same refresh token.

Turns out the request in check connection was not failing because of an auth issue, the squadcast API was returning 400 with an error message `your query does not match any incidents. please tweak your query and try again`

Instead of relying on that request to check connection, we can rely on the creation of the access token from the refresh token as a sufficient check.

Also made changes to honor the default of 90 days for cutoff + updated some docs.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
