### PR TITLE
FAI-4951: graph-to-graph copy object count discrepancies

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -760,6 +760,16 @@ export class GraphQLClient {
     if (type === 'timestamptz') {
       // The field value may already be a string. E.g., if coming from the Faros Feeds source.
       return typeof value === 'string' ? value : timestamptz(value);
+    } else if (type.startsWith('_') && typeof value !== 'string') {
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `expected array for ${model}.${field} of type ${type}. Received: ${JSON.stringify(
+            value
+          )}`
+        );
+      }
+      // format array value as postgres literal
+      return `{${value.join(',')}}`;
     } else if (typeof value === 'object' || Array.isArray(value)) {
       return traverse(value).map(function (this, val) {
         if (val instanceof Date) {


### PR DESCRIPTION
## Description

With [Hasura #45](https://github.com/faros-ai/hasura/pull/45), we've altered schema to store string arrays with array field (i.e. `text []`) instead of `jsonb`.  This requires input to be formatted as [postgres array literal](https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT).

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
