### PR TITLE
Make it possible to partition full model queries

### DIFF
--- a/sources/faros-graphql-source/resources/spec.json
+++ b/sources/faros-graphql-source/resources/spec.json
@@ -84,16 +84,19 @@
         "description": "Legacy V1 schema as a gzip compressed, base 64 encoded text. Only used when 'Adapt V1 query' is enabled.",
         "multiline": true
       },
-      "replace_origin_map": {
+      "bucket_id": {
         "order": 9,
-        "type": "string",
-        "title": "Replace Records Origin",
-        "description": "JSON map to replace records origin values, where each entry (origin1, origin2) indicates that the output records' origin property should be replaced from 'origin1' by 'origin2'",
-        "multiline": true,
-        "default": "{}",
-        "examples": [
-          "{ \"originA\": \"originB\" }"
-        ]
+        "type": "integer",
+        "title": "Bucket Number",
+        "description": "Bucket number for this source to determine which portion of models to pull. Use it when distributing the load between multiple sources.",
+        "default": 1
+      },
+      "bucket_total": {
+        "order": 10,
+        "type": "integer",
+        "title": "Total Number of Buckets",
+        "description": "Total number of buckets to distribute models across. Use it when distributing the load between multiple sources.",
+        "default": 1
       }
     }
   }

--- a/sources/faros-graphql-source/resources/spec.json
+++ b/sources/faros-graphql-source/resources/spec.json
@@ -88,14 +88,14 @@
         "order": 9,
         "type": "integer",
         "title": "Bucket Number",
-        "description": "Bucket number for this source to determine which portion of models to pull. Use it when distributing the load between multiple sources.",
+        "description": "Bucket number for this source to determine which portion of models to pull. Use it when distributing the load between multiple sources. Cannot be used in combination with 'GraphQL query'",
         "default": 1
       },
       "bucket_total": {
         "order": 10,
         "type": "integer",
         "title": "Total Number of Buckets",
-        "description": "Total number of buckets to distribute models across. Use it when distributing the load between multiple sources.",
+        "description": "Total number of buckets to distribute models across. Use it when distributing the load between multiple sources. Cannot be used in combination with 'GraphQL query'",
         "default": 1
       }
     }

--- a/sources/faros-graphql-source/test/index.test.ts
+++ b/sources/faros-graphql-source/test/index.test.ts
@@ -199,6 +199,48 @@ describe('index', () => {
     ]);
   });
 
+  test('check buckets config', async () => {
+    const source = new sut.FarosGraphSource(logger);
+    graphExists = true;
+    const config = {
+      api_url: 'x',
+      api_key: 'y',
+      graphql_api: GraphQLVersion.V1,
+      graph: 'default',
+      result_model: ResultModel.Nested,
+    } as sut.GraphQLConfig;
+    await expect(
+      source.checkConnection({...config, bucket_id: 7, bucket_total: 10})
+    ).resolves.toStrictEqual([true, undefined]);
+    await expect(
+      source.checkConnection({...config, query: 'foo', bucket_id: 7})
+    ).resolves.toStrictEqual([
+      false,
+      new VError('Bucket id cannot be used in combination with query'),
+    ]);
+    await expect(
+      source.checkConnection({...config, query: 'foo', bucket_total: 10})
+    ).resolves.toStrictEqual([
+      false,
+      new VError('Bucket total cannot be used in combination with query'),
+    ]);
+    await expect(
+      source.checkConnection({...config, bucket_id: 0, bucket_total: 10})
+    ).resolves.toStrictEqual([false, new VError('Bucket id must be positive')]);
+    await expect(
+      source.checkConnection({...config, bucket_id: 7, bucket_total: -10})
+    ).resolves.toStrictEqual([
+      false,
+      new VError('Bucket total must be positive'),
+    ]);
+    await expect(
+      source.checkConnection({...config, bucket_id: 7, bucket_total: 4})
+    ).resolves.toStrictEqual([
+      false,
+      new VError('Bucket id (7) cannot be larger than Bucket total (4)'),
+    ]);
+  });
+
   test('full_refresh sync mode', async () => {
     const source = new sut.FarosGraphSource(logger);
     graphExists = true;


### PR DESCRIPTION
## Description

So that we can split reading a full graph into N buckets concurrently.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
