### PR TITLE
GitLab Converter: Process nested group repo keys correctly

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
@@ -94,7 +94,6 @@ export class GitlabCommon {
         },
       },
       this.tms_TaskBoard(projectKey, name),
-      this.tms_TaskBoardProjectRelationship(repository.organization, projectKey),
       // traverse the hierarchy to link boards for the sub groups and the project itself
       ...this.mapRepositoryHierarchy<DestinationRecord>(
         repository,

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
@@ -74,16 +74,20 @@ export class GitlabCommon {
   ): undefined | RepositoryKey {
     if (!webUrl) return undefined;
     const repositoryIndex = startIndex + 1;
+    
+    const nameParts: ReadonlyArray<string> = webUrl.split('/');
+    if (nameParts.length <= repositoryIndex) return undefined;
 
-    const orgRepo: ReadonlyArray<string> = webUrl.split('/');
-    if (orgRepo.length <= repositoryIndex) return undefined;
-
-    const organization = orgRepo[startIndex];
-    const repositoryName = orgRepo.slice(repositoryIndex, orgRepo.length).join(' / ');
+    const endIndex = nameParts.indexOf('-') == -1 ? nameParts.length : nameParts.indexOf('-');
+    
+    const organization = nameParts[startIndex].toLowerCase();
+    const repositoryUid = nameParts.slice(repositoryIndex, endIndex).join('/').toLowerCase();
+    const repositoryName = nameParts[endIndex - 1].toLowerCase()
+    
     return {
-      name: orgRepo[orgRepo.length - 1].toLowerCase(),
-      uid: repositoryName?.toLowerCase(),
-      organization: {uid: organization?.toLowerCase(), source},
+      name: repositoryName,
+      uid: repositoryUid,
+      organization: {uid: organization, source},
     };
   }
 
@@ -92,7 +96,7 @@ export class GitlabCommon {
       uid: String(pipelineId),
       pipeline: {
         organization: repository.organization,
-        uid: repository.name,
+        uid: repository.uid,
       },
     };
   }

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
@@ -76,12 +76,12 @@ export class GitlabCommon {
     const repositoryIndex = startIndex + 1;
 
     const orgRepo: ReadonlyArray<string> = webUrl.split('/');
-    if (orgRepo.length < repositoryIndex) return undefined;
+    if (orgRepo.length <= repositoryIndex) return undefined;
 
     const organization = orgRepo[startIndex];
-    const repositoryName = orgRepo[repositoryIndex];
+    const repositoryName = orgRepo.slice(repositoryIndex, orgRepo.length).join(' / ');
     return {
-      name: repositoryName?.toLowerCase(),
+      name: orgRepo[orgRepo.length - 1].toLowerCase(),
       uid: repositoryName?.toLowerCase(),
       organization: {uid: organization?.toLowerCase(), source},
     };

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/group_milestones.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/group_milestones.ts
@@ -11,12 +11,7 @@ export class GroupMilestones extends GitlabConverter {
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const source = this.streamName.source;
     const milestone = record.record.data;
-
-    const repository = GitlabCommon.parseRepositoryKey(
-      milestone.web_url,
-      source,
-      4
-    );
+    const group = GitlabCommon.parseGroupKey(milestone.web_url, source);
 
     return [
       {
@@ -28,7 +23,7 @@ export class GroupMilestones extends GitlabConverter {
             0,
             GitlabCommon.MAX_DESCRIPTION_LENGTH
           ),
-          project: repository ? {uid: repository.name, source} : null,
+          project: group,
           status: this.epicStatus(milestone.state),
           source,
         },

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/groups.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/groups.ts
@@ -46,13 +46,6 @@ export class Groups extends GitlabConverter {
           source,
         },
       });
-
-      res.push(
-        GitlabCommon.tms_TaskBoard(
-          { uid: group.full_path, source },
-          group.name,
-        )
-      );
     } else {
       res.push(
         GitlabCommon.tms_TaskBoard(

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/groups.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/groups.ts
@@ -8,6 +8,9 @@ export class Groups extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'cicd_Organization',
     'vcs_Organization',
+    'tms_Project',
+    'tms_TaskBoard',
+    'tms_TaskBoardProjectRelationship',
   ];
 
   async convert(
@@ -20,7 +23,7 @@ export class Groups extends GitlabConverter {
     res.push({
       model: 'cicd_Organization',
       record: {
-        uid: group.path,
+        uid: group.full_path,
         description: group.description?.substring(
           0,
           GitlabCommon.MAX_DESCRIPTION_LENGTH
@@ -34,7 +37,7 @@ export class Groups extends GitlabConverter {
     res.push({
       model: 'vcs_Organization',
       record: {
-        uid: group.path,
+        uid: group.full_path,
         name: group.name,
         htmlUrl: group.web_url,
         type: {category: 'Group', detail: ''},
@@ -42,6 +45,17 @@ export class Groups extends GitlabConverter {
         source,
       },
     });
+
+    // GitLab can track tasks at a group level as well
+    res.push(
+      ...GitlabCommon.tms_ProjectBoard_with_TaskBoard(
+        {uid: group.full_path, source},
+        group.name,
+        group.description,
+        group.created_at,
+        null
+      )
+    );
 
     return res;
   }

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/issues.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/issues.ts
@@ -106,13 +106,6 @@ export class Issues extends GitlabConverter {
     );
 
     res.push(
-      {
-        model: 'tms_TaskBoardRelationship',
-        record: {
-          task: taskKey,
-          board: repository.organization,
-        },
-      },
       ...GitlabCommon.mapRepositoryHierarchy<DestinationRecord>(
         repository,
         k => {

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/jobs.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/jobs.ts
@@ -45,7 +45,7 @@ export class Jobs extends GitlabConverter {
       uid: String(pipelineId),
       pipeline: {
         organization: repository.organization,
-        uid: repository.name,
+        uid: repository.uid,
       },
     };
 

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/pipelines.ts
@@ -29,7 +29,7 @@ export class Pipelines extends GitlabConverter {
 
     const pipelineKey = {
       organization: repository.organization,
-      uid: repository.name,
+      uid: repository.uid,
     };
 
     const build = {

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/project_milestones.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/project_milestones.ts
@@ -12,10 +12,7 @@ export class ProjectMilestones extends GitlabConverter {
     const source = this.streamName.source;
     const milestone = record.record.data;
 
-    const repository = GitlabCommon.parseRepositoryKey(
-      milestone.web_url,
-      source
-    );
+    const repository = GitlabCommon.parseRepositoryKey(milestone.web_url, source);
 
     return [
       {
@@ -27,7 +24,7 @@ export class ProjectMilestones extends GitlabConverter {
             0,
             GitlabCommon.MAX_DESCRIPTION_LENGTH
           ),
-          project: repository ? {uid: repository.name, source} : null,
+          project: {uid: repository.uid, source},
           status: this.epicStatus(milestone.state),
           source,
         },

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/projects.ts
@@ -27,7 +27,7 @@ export class Projects extends GitlabConverter {
     // Create a TMS Project/Board per repo that we sync
     res.push(
       ...GitlabCommon.tms_ProjectBoard_with_TaskBoard(
-        {uid: `${project.id}`, source},
+        {uid: repository.uid, source},
         repository.name,
         project.body,
         project.created_at,

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/projects.ts
@@ -27,8 +27,7 @@ export class Projects extends GitlabConverter {
     // Create a TMS Project/Board per repo that we sync
     res.push(
       ...GitlabCommon.tms_ProjectBoard_with_TaskBoard(
-        {uid: repository.uid, source},
-        repository.name,
+        repository,
         project.body,
         project.created_at,
         project.updated_at

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/releases.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/releases.ts
@@ -7,7 +7,7 @@ import {
   StreamContext,
   StreamName,
 } from '../converter';
-import {GitlabConverter} from './common';
+import {GitlabCommon, GitlabConverter} from './common';
 
 export class Releases extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
@@ -29,19 +29,13 @@ export class Releases extends GitlabConverter {
     const release = record.record.data;
     const res: DestinationRecord[] = [];
 
-    const [, owner, repo] = (
-      release.commit_path ||
-      release.tag_path ||
-      '/'
-    ).split('/');
-
-    if (!owner || !repo) {
+    if (!release._links || !release._links.self) {
       ctx.logger
-        .warn(`Could not find commit_path or tag_path from StreamContext for
-        this record: ${this.id}`);
+        .warn(`Could not find property for identifying release: ${this.id}`);
       return res;
     }
-
+    
+    const repository = GitlabCommon.parseRepositoryKey(release._links.self, source)
     const usersStream = this.usersStream.asString;
     const user = ctx.get(usersStream, String(release.author_id));
     const username = user?.record?.data?.username;
@@ -52,7 +46,7 @@ export class Releases extends GitlabConverter {
       record: {
         uid,
         name: release.name,
-        htmlUrl: release?._links?.self,
+        htmlUrl: release._links.self,
         description: release.description,
         createdAt: Utils.toDate(release.created_at),
         releasedAt: Utils.toDate(release.released_at),
@@ -67,11 +61,7 @@ export class Releases extends GitlabConverter {
         release: {uid, source},
         tag: {
           name: release.tag_name,
-          repository: {
-            name: repo?.toLowerCase(),
-            uid: repo?.toLowerCase(),
-            organization: {uid: owner?.toLowerCase(), source},
-          },
+          repository,
         },
       },
     });

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/releases.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/releases.ts
@@ -40,7 +40,7 @@ export class Releases extends GitlabConverter {
     const user = ctx.get(usersStream, String(release.author_id));
     const username = user?.record?.data?.username;
 
-    const uid = release.tag_name;
+    const uid = `${repository.uid}/${release.tag_name}`;
     res.push({
       model: 'cicd_Release',
       record: {

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/releases.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/releases.ts
@@ -46,7 +46,7 @@ export class Releases extends GitlabConverter {
       record: {
         uid,
         name: release.name,
-        htmlUrl: release._links.self,
+        url: release._links.self,
         description: release.description,
         createdAt: Utils.toDate(release.created_at),
         releasedAt: Utils.toDate(release.released_at),


### PR DESCRIPTION
## Description

GitLab supports nested groups which need to be considered when parsing the repo key. For example,

`top-level-group / nested-group / project`

Currently, `nested-group` is being treated as the project name and uid. This patch changes the parsing so that:

name = project
uid = nested-group / project

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change

## Related issues

Fix #891 

