### PR TITLE
FAI-4901: Hasura End-to-End Testing

### DIFF
--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -34,15 +34,23 @@ Array [
 ]
 `;
 
+exports[`graphql-client write batch upsert on_conflict update_columns bug 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id source uid } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id name organizationId } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 3`] = `"mutation { insert_vcs_Branch (objects: [{name: \\"foo\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin]}) { returning { id name repositoryId } } }"`;
+
+exports[`graphql-client write batch upsert on_conflict update_columns bug 4`] = `"mutation { insert_vcs_Branch (objects: [{name: \\"main\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin]}) { returning { id name repositoryId } } }"`;
+
 exports[`graphql-client write batch upsert record with null primary key field 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin]}) { returning { id source uid } } }"`;
 
-exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\"}, {uid: \\"9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [uid]}) { returning { id uid } } }"`;
+exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [uid]}) { returning { id uid } } }"`;
 
 exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: \\"9\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [origin]}) { returning { id uid } } }"`;
 
 exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
 
-exports[`groupByAffectedFields noop 1`] = `
+exports[`groupByKeys one level 1`] = `
 Array [
   Array [
     "u0a",
@@ -50,42 +58,6 @@ Array [
   ],
   Array [
     "u1a",
-    "u1b",
-  ],
-  Array [
-    "u2a",
-    "u2b",
-  ],
-]
-`;
-
-exports[`groupByAffectedFields one level 1`] = `
-Array [
-  Array [
-    "u0a",
-    "u0b",
-  ],
-  Array [
-    "u1a",
-    "u1b",
-  ],
-  Array [
-    "u2a",
-    "u2b",
-  ],
-]
-`;
-
-exports[`groupByAffectedFields two levels 1`] = `
-Array [
-  Array [
-    "u0a",
-    "u0b",
-  ],
-  Array [
-    "u1a",
-  ],
-  Array [
     "u1b",
   ],
   Array [

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -50,7 +50,39 @@ exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation 
 
 exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
 
-exports[`groupByKeys one level 1`] = `
+exports[`groupByKeys 1 group of 2 1`] = `
+Array [
+  Array [
+    "u0a",
+    "u0b",
+  ],
+]
+`;
+
+exports[`groupByKeys 2 groups of 1 1`] = `
+Array [
+  Array [
+    "u0a",
+  ],
+  Array [
+    "u1a",
+  ],
+]
+`;
+
+exports[`groupByKeys 2 groups of mix 1`] = `
+Array [
+  Array [
+    "u0a",
+  ],
+  Array [
+    "u1a",
+    "u1b",
+  ],
+]
+`;
+
+exports[`groupByKeys 3 groups of 2 1`] = `
 Array [
   Array [
     "u0a",

--- a/destinations/airbyte-faros-destination/test/graphql-client.test.ts
+++ b/destinations/airbyte-faros-destination/test/graphql-client.test.ts
@@ -669,7 +669,16 @@ describe('groupByKeys', () => {
     }
     expect(res).toMatchSnapshot();
   }
-  test('one level', async () => {
+  test('3 groups of 2', async () => {
     await expectGroupByKeys([u0a, u0b, u1a, u1b, u2a, u2b]);
+  });
+  test('1 group of 2', async () => {
+    await expectGroupByKeys([u0a, u0b]);
+  });
+  test('2 groups of 1', async () => {
+    await expectGroupByKeys([u0a, u1a]);
+  });
+  test('2 groups of mix', async () => {
+    await expectGroupByKeys([u0a, u1a, u1b]);
   });
 });

--- a/destinations/airbyte-faros-destination/test/graphql-client.test.ts
+++ b/destinations/airbyte-faros-destination/test/graphql-client.test.ts
@@ -6,7 +6,7 @@ import {
   batchIterator,
   GraphQLBackend,
   GraphQLClient,
-  groupByAffectedFields,
+  groupByKeys,
   mergeByPrimaryKey,
   serialize,
   strictPick,
@@ -241,6 +241,95 @@ describe('graphql-client write batch upsert', () => {
     await client.writeRecord('vcs_Branch', record2, 'mytestsource');
     await client.flush();
     expect(queries).toEqual(3);
+  });
+  test('on_conflict update_columns bug', async () => {
+    const responses = [
+      JSON.parse(`
+    {
+      "data": {
+      "insert_vcs_Organization": {
+        "returning": [
+          {
+            "id": "t1|gql-e2e-v2|GitHub|faros-ai",
+            "uid": "faros-ai",
+            "source": "GitHub"
+            }
+          ]
+        }
+      }
+    }`),
+      JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Repository": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "hermes",
+              "organizationId": "t1|gql-e2e-v2|GitHub|faros-ai"
+            }
+          ]
+        }
+      }
+    }`),
+      JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Branch": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|foo|t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "foo",
+              "repositoryId": null
+            }
+          ]
+        }
+      }
+    }`),
+      JSON.parse(`
+    {
+      "data": {
+        "insert_vcs_Branch": {
+          "returning": [
+            {
+              "id": "t1|gql-e2e-v2|main|t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai",
+              "name": "main",
+              "repositoryId": "t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai"
+            }
+          ]
+        }
+      }
+    }`),
+    ];
+    const records = [
+      JSON.parse('{"name":"foo","uid":"foo"}'),
+      JSON.parse(
+        '{"name":"main","uid":"main","repository":{"name":"hermes","uid":"hermes","organization":{"uid":"faros-ai","source":"GitHub"}},"source":"GitHub"}'
+      ),
+    ];
+    let queries = 0;
+    const backend: GraphQLBackend = {
+      healthCheck() {
+        return Promise.resolve();
+      },
+      postQuery(query: any) {
+        expect(query).toMatchSnapshot();
+        return responses[queries++];
+      },
+    };
+    const client = new GraphQLClient(
+      new AirbyteLogger(AirbyteLogLevel.INFO),
+      schemaLoader,
+      backend,
+      10,
+      1
+    );
+    await client.loadSchema();
+    for (const record of records) {
+      await client.writeRecord('vcs_Branch', record, 'mytestsource');
+    }
+    await client.flush();
+    expect(queries).toEqual(responses.length);
   });
   test('record with null primary key field', async () => {
     const res1 = JSON.parse(`
@@ -562,47 +651,16 @@ describe('toLevels', () => {
   });
 });
 
-describe('groupByAffectedFields', () => {
-  const u0a: Upsert = {
-    id: 'u0a',
-    model: 'm',
-    object: {f1: 'f1a', f2: 'f2a', f3: 'f3a'},
-    foreignKeys: {},
-  };
-  const u0b: Upsert = {
-    id: 'u0b',
-    model: 'm',
-    object: {f1: 'f1b', f2: 'f2b', f3: 'f3b'},
-    foreignKeys: {},
-  };
-  const u1a: Upsert = {
-    id: 'u1a',
-    model: 'm',
-    object: {f1: 'f1a'},
-    foreignKeys: {},
-  };
-  const u1b: Upsert = {
-    id: 'u1b',
-    model: 'm',
-    object: {f1: 'f1b'},
-    foreignKeys: {},
-  };
-  const u2a: Upsert = {
-    id: 'u2a',
-    model: 'm',
-    object: {f3: 'f3'},
-    foreignKeys: {},
-  };
-  const u2b: Upsert = {
-    id: 'u2b',
-    model: 'm',
-    object: {f3: 'f3'},
-    foreignKeys: {},
-  };
-  async function expectGroupByAffectedFields(
-    upserts: Upsert[][]
-  ): Promise<void> {
-    const iterator = batchIterator(groupByAffectedFields(upserts), (batch) => {
+describe('groupByKeys', () => {
+  const u0a = {id: 'u0a', f1: 'f1a', f2: 'f2a', f3: 'f3a'};
+  const u0b = {id: 'u0b', f1: 'f1b', f2: 'f2b', f3: 'f3b'};
+  const u1a = {id: 'u1a', f1: 'f1a'};
+  const u1b = {id: 'u1b', f1: 'f1b'};
+  const u2a = {id: 'u2a', f3: 'f3'};
+  const u2b = {id: 'u2b', f3: 'f3'};
+
+  async function expectGroupByKeys(objects: any[]): Promise<void> {
+    const iterator = batchIterator(groupByKeys(objects), (batch) => {
       return Promise.resolve(batch.map((u) => u.id).sort());
     });
     const res = [];
@@ -612,19 +670,6 @@ describe('groupByAffectedFields', () => {
     expect(res).toMatchSnapshot();
   }
   test('one level', async () => {
-    await expectGroupByAffectedFields([[u0a, u0b, u1a, u1b, u2a, u2b]]);
-  });
-  test('two levels', async () => {
-    await expectGroupByAffectedFields([
-      [u0a, u0b, u1a],
-      [u1b, u2a, u2b],
-    ]);
-  });
-  test('noop', async () => {
-    await expectGroupByAffectedFields([
-      [u0a, u0b],
-      [u1a, u1b],
-      [u2a, u2b],
-    ]);
+    await expectGroupByKeys([u0a, u0b, u1a, u1b, u2a, u2b]);
   });
 });


### PR DESCRIPTION
## Description

This PR fixes 2 bugs that present in similar ways but due to different codes paths have different solutions 

### SaaS Bug

In #862, we added a step to batch processing to separate objects into groups by the keys present in the objects.  We then constructed `on_conflict.update_columns` arrays based on the keys of each group.  This was done to fix a bug that nulled out fields of existing rows that were present in the `update_columns` array but not present in the object.

The (flawed) procedure for doing this was roughly:

1. for each batch separate objects into groups by keys of objects
2. add FKs to objects from prior batches
3. using first object of a group as prototype, construct `update_columns` for the group.

This procedure was flawed because the 2nd step could alter keys of a subset of group.  Said another way, not all objects in the group are guaranteed to have the same set of FKs added.  In the specific case we encountered, the first object used for computing `update_columns` did not have data for a particular FK.  A subsequent object did and since the `update_columns` didn't include the FK column, that object's FK was not upsert'ed into the database.

The fix is to reorder steps 1 & 2 so we add all possible data to the objects prior to grouping by keys.  

### CE Bug

WIP

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
