### PR TITLE
Make jsonata_expression multiline

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -164,7 +164,8 @@
         "order": 6,
         "type": "string",
         "title": "JSONata expression",
-        "description": "JSONata expression for converting input records. If provided applies the expression based on specified JSONata apply mode."
+        "description": "JSONata expression for converting input records. If provided applies the expression based on specified JSONata apply mode.",
+        "multiline": true
       },
       "jsonata_mode": {
         "order": 7,


### PR DESCRIPTION
## Description

JSONata expressions can be long. This will make it easier for copy/pasting since longer expressions are not written as a one-liner.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
