### PR TITLE
fix: update json schema incidents for datadog

### DIFF
--- a/sources/datadog-source/resources/schemas/incident.json
+++ b/sources/datadog-source/resources/schemas/incident.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["id"],
   "properties": {
     "attributes": {
       "type": "object",
@@ -141,10 +140,8 @@
         "lastModifiedByUser": {
           "type": "object",
           "properties": {
-            "properties": {
-              "id": {
-                "type": "string"
-              }
+            "id": {
+              "type": "string"
             }
           }
         }

--- a/sources/datadog-source/resources/schemas/incident.json
+++ b/sources/datadog-source/resources/schemas/incident.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "required": ["id"],
   "properties": {
     "attributes": {
       "type": "object",


### PR DESCRIPTION
## Description

When we tried to get incidents from datadog,  always throw the following error

![image](https://user-images.githubusercontent.com/24238061/215550261-a7d1ed2a-e0fe-4525-984e-2c42416d3253.png)

Also, this json schema was malformed because it had a duplicate `properties` key

After update json schema for incidenst, it works.
> 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
