### PR TITLE
Remove model & origin in ServiceNow destination + make sure we use the correct values in GraphQL writer

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-writer.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-writer.ts
@@ -28,7 +28,7 @@ export class GraphQLWriter {
   ) {}
 
   async write(result: any): Promise<boolean> {
-    const [baseModel, operation] = result.model.split('__', 2);
+    const [baseModel, operation] = (result.model as string).split('__', 2);
 
     if (!operation) {
       await this.graphQLClient.writeRecord(
@@ -39,10 +39,10 @@ export class GraphQLWriter {
       return false;
     } else if (Object.values(Operation).includes(operation as Operation)) {
       this.timestampedRecords.push({
+        ...result.record,
         model: baseModel,
         operation,
         origin: this.originProvider.getOrigin(result.record),
-        ...result.record,
       } as TimestampedRecord);
       return true;
     } else {

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
@@ -264,9 +264,7 @@ export class Incidents extends ServiceNowConverter {
             where: {
               incident: incAppImpact.incident,
               application: incAppImpact.application,
-              origin,
             },
-            model: 'ims_IncidentApplicationImpact',
           },
         });
       }


### PR DESCRIPTION
## Description

Remove model & origin in ServiceNow destination + make sure we use the correct values for origin, model and operation in GraphQL writer

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
