### PR TITLE
Remove previously stored incident-application association(s) for processed incident(s)

### DIFF
--- a/destinations/airbyte-faros-destination/resources/source-specific-configs.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs.json
@@ -352,11 +352,11 @@
                     "Custom"
                   ]
                 },
-                "allow_multi_apps_per_incident": {
+                "remove_previous_incident_application_impacts": {
                   "type": "boolean",
-                  "title": "Multi-app Incidents",
-                  "description": "Allow storing multiple impacted applications per incident",
-                  "default": true
+                  "title": "Remove previously stored incident-application association(s) for processed incident(s)",
+                  "description": "When enabled, ensures that previously stored incident-application association(s) are removed from the graph.",
+                  "default": false
                 }
               }
             }

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs.json
@@ -352,10 +352,10 @@
                     "Custom"
                   ]
                 },
-                "remove_previous_incident_application_impacts": {
+                "store_current_incidents_associations": {
                   "type": "boolean",
-                  "title": "Remove previously stored incident-application association(s) for processed incident(s)",
-                  "description": "When enabled, ensures that previously stored incident-application association(s) are removed from the graph.",
+                  "title": "Only store current incidents associations",
+                  "description": "Only store current incidents associations in the graph.",
                   "default": false
                 }
               }

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/common.ts
@@ -28,7 +28,7 @@ interface ServiceNowConfig {
   application_field?: string;
   default_severity?: IncidentSeverityCategory;
   default_priority?: IncidentPriorityCategory;
-  remove_previous_incident_application_impacts?: boolean;
+  store_current_incidents_associations?: boolean;
 }
 
 /** ServiceNow converter base */
@@ -56,11 +56,11 @@ export abstract class ServiceNowConverter extends Converter {
     return this.config(ctx).application_field ?? DEFAULT_APPLICATION_FIELD;
   }
 
-  protected removePreviousIncidentApplicationImpacts(
+  protected onlyStoreCurrentIncidentsAssociations(
     ctx: StreamContext
   ): boolean {
     return (
-      this.config(ctx).remove_previous_incident_application_impacts ?? true
+      this.config(ctx).store_current_incidents_associations ?? false
     );
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/common.ts
@@ -28,7 +28,7 @@ interface ServiceNowConfig {
   application_field?: string;
   default_severity?: IncidentSeverityCategory;
   default_priority?: IncidentPriorityCategory;
-  allow_multi_apps_per_incident?: boolean;
+  remove_previous_incident_application_impacts?: boolean;
 }
 
 /** ServiceNow converter base */
@@ -56,7 +56,11 @@ export abstract class ServiceNowConverter extends Converter {
     return this.config(ctx).application_field ?? DEFAULT_APPLICATION_FIELD;
   }
 
-  protected allowMultiAppsPerIncident(ctx: StreamContext): boolean {
-    return this.config(ctx).allow_multi_apps_per_incident ?? true;
+  protected removePreviousIncidentApplicationImpacts(
+    ctx: StreamContext
+  ): boolean {
+    return (
+      this.config(ctx).remove_previous_incident_application_impacts ?? true
+    );
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
@@ -129,7 +129,7 @@ export class Incidents extends ServiceNowConverter {
     ctx: StreamContext
   ): boolean {
     if (
-      !this.removePreviousIncidentApplicationImpacts(ctx) ||
+      !this.onlyStoreCurrentIncidentsAssociations(ctx) ||
       ctx.streamsSyncMode[this.streamName.asString] ===
         DestinationSyncMode.OVERWRITE ||
       isNil(ctx.farosClient) ||


### PR DESCRIPTION
## Description

Ensures that when an incident is associated to more than one application in the processed records, all the associations (`incidentApplicationImpacts`) are persisted.

Also changes the configuration setting and wording of the behavior when turned on.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
