### PR TITLE
Ignore feeds reset records when not writing to V1

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
@@ -37,6 +37,16 @@ export class FarosFeed extends Converter {
 
     const [model, rec] = Object.entries(data).pop();
 
+    if (ctx.config.edition_configs.graphql_api !== 'v1') {
+      // Ignore full model deletion records.
+      // E.g., {"vcs_TeamMembership__Deletion":{"where":"my-source"}}
+      // These are issued by the feed and are only applicable to the V1 API
+      if (model.endsWith('__Deletion') && Object.entries(rec).length == 1) {
+        const [key, value] = Object.entries(rec).pop();
+        if (key === 'where' && typeof value == 'string') return [];
+      }
+    }
+
     if (this.schema) {
       this.schema.fixTimestampFields(rec, model);
     }


### PR DESCRIPTION
## Description

Ignore feeds reset records when not writing to V1

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
