### PR TITLE
Fix Graph API version check

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
@@ -1,6 +1,7 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {FarosGraphSchema} from 'faros-js-client';
 
+import {Edition} from '../../common/types';
 import {
   Converter,
   DestinationModel,
@@ -37,7 +38,10 @@ export class FarosFeed extends Converter {
 
     const [model, rec] = Object.entries(data).pop();
 
-    if (ctx.config.edition_configs.graphql_api !== 'v1') {
+    if (
+      ctx.config.edition_configs.edition === Edition.COMMUNITY ||
+      ctx.config.edition_configs.graphql_api === 'v2'
+    ) {
       // Ignore full model deletion records.
       // E.g., {"vcs_TeamMembership__Deletion":{"where":"my-source"}}
       // These are issued by the feed and are only applicable to the V1 API


### PR DESCRIPTION
## Description

Because of the way [withDefaults](https://github.com/faros-ai/airbyte-connectors/blob/main/faros-airbyte-cdk/src/utils.ts#L43) works, `graphql_api` defaults to `V1` also for Community edition.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
