### PR TITLE
FAI-5403: Mock-data feed sync write failure to V2 graph

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -122,7 +122,7 @@ export function serialize(obj: Dictionary<number | string>): string {
  */
 export function strictPick(obj: any, keys: string[], nullValue = 'null'): any {
   return keys.reduce(
-    (result, key) => set(result, key, obj[key] || nullValue),
+    (result, key) => set(result, key, obj[key] ?? nullValue),
     {}
   );
 }

--- a/destinations/airbyte-faros-destination/test/graphql-client.test.ts
+++ b/destinations/airbyte-faros-destination/test/graphql-client.test.ts
@@ -585,6 +585,7 @@ describe('graphql-client utilities', () => {
     expect(serialize({})).toEqual('');
   });
   test('strictPick', async () => {
+    expect(strictPick({z: 0, a: 'bar'}, ['z', 'b'])).toEqual({z: 0, b: 'null'});
     expect(strictPick({z: 1, a: 'bar'}, ['z', 'b'])).toEqual({z: 1, b: 'null'});
     expect(strictPick({z: 1, a: 'bar'}, ['b'])).toEqual({b: 'null'});
   });


### PR DESCRIPTION
## Description

Ensure null value replacement only happens for nullish keys.  

The use of `||` as a coalesce operator by itself was OK because we map keys to strings and strings to keys consistently.  

However, in the case of the `mock-data` feed we are inconsistent about the type of the `number` field for different model types.  

For example, notice the different types for `number` field in this record:

```
{
  "record": {
    "stream": "myfarosfeedssrc__faros_feeds__faros_feed",
    "emitted_at": 1678482135607,
    "data": {
      "vcs_PullRequestComment": {
        "pullRequest": {
          "number": 0,
          "repository": {
            "name": "solaris",
            "language": "javascript",
            "mainBranch": "main",
            "organization": {
              "uid": "faros-ai",
              "source": "Mock"
            }
          }
        },
        "number": "0",
        "createdAt": "2023-02-26T17:44:21.846Z",
        "author": {
          "uid": "sirius",
          "source": "GitHub"
        }
      }
    }
  },
  "type": "RECORD"
} 
```

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

