### PR TITLE
FAI-5468 - Make Statuspage page_ids param non-secret

### DIFF
--- a/sources/statuspage-source/resources/spec.json
+++ b/sources/statuspage-source/resources/spec.json
@@ -16,8 +16,7 @@
           "type": "string"
         },
         "title": "Page IDs",
-        "description": "List of Statuspage Page IDs. If empty, all pages will be fetched.",
-        "airbyte_secret": true
+        "description": "List of Statuspage Page IDs. If empty, all pages will be fetched."
       },
       "api_key": {
         "type": "string",


### PR DESCRIPTION
## Description

Non-string params marked as secrets cause Airbyte API errors, and are also not consumed properly during syncs.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
