### PR TITLE
Octopus strip '/' instance URL suffix if provided

### DIFF
--- a/sources/octopus-source/src/octopusClient.ts
+++ b/sources/octopus-source/src/octopusClient.ts
@@ -45,7 +45,7 @@ export class OctopusClient {
     const retries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
     const logger = this.logger; // for axios-retry
 
-    const cleanInstanceUrl = config.instanceUrl.replace(/\/+$/, '');
+    const cleanInstanceUrl = config.instanceUrl.replace(/\/$/, '');
 
     this.api = axios.create({
       baseURL: `${cleanInstanceUrl}/api`,

--- a/sources/octopus-source/src/octopusClient.ts
+++ b/sources/octopus-source/src/octopusClient.ts
@@ -45,13 +45,7 @@ export class OctopusClient {
     const retries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
     const logger = this.logger; // for axios-retry
 
-    const instanceUrlRegex = new RegExp(/^((https|http):\/\/[^/]*)\/?$/);
-    const urlRegexMatch = config.instanceUrl.match(instanceUrlRegex);
-
-    if (!urlRegexMatch) {
-      throw new VError(`Malformed Instance Url: ${config.instanceUrl}`);
-    }
-    const cleanInstanceUrl = urlRegexMatch[1];
+    const cleanInstanceUrl = config.instanceUrl.replace(/\/+$/, '');
 
     this.api = axios.create({
       baseURL: `${cleanInstanceUrl}/api`,

--- a/sources/octopus-source/src/octopusClient.ts
+++ b/sources/octopus-source/src/octopusClient.ts
@@ -45,8 +45,16 @@ export class OctopusClient {
     const retries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
     const logger = this.logger; // for axios-retry
 
+    const instanceUrlRegex = new RegExp(/^((https|http):\/\/[^/]*)\/?$/);
+    const urlRegexMatch = config.instanceUrl.match(instanceUrlRegex);
+
+    if (!urlRegexMatch) {
+      throw new VError(`Malformed Instance Url: ${config.instanceUrl}`);
+    }
+    const cleanInstanceUrl = urlRegexMatch[1];
+
     this.api = axios.create({
-      baseURL: `${config.instanceUrl}/api`,
+      baseURL: `${cleanInstanceUrl}/api`,
       headers: {
         'X-Octopus-ApiKey': config.apiKey,
       },

--- a/sources/octopus-source/test/octopusClient.test.ts
+++ b/sources/octopus-source/test/octopusClient.test.ts
@@ -37,14 +37,6 @@ describe('index', () => {
     mockGet.mockReset();
   });
 
-  test('client fails malformed instance URL', async () => {
-    const badInstanceUrl = 'https://test.octopus.app//';
-    const t = (): void => {
-      new sut.OctopusClient({...config, instanceUrl: badInstanceUrl});
-    };
-    expect(t).toThrow(`Malformed Instance Url: ${badInstanceUrl}`);
-  });
-
   test('client strips "/" suffix from instance URL if provided', async () => {
     const instanceUrl = 'https://test.octopus.app';
     const instanceUrlWithSuffix = `${instanceUrl}/`;

--- a/sources/octopus-source/test/octopusClient.test.ts
+++ b/sources/octopus-source/test/octopusClient.test.ts
@@ -28,12 +28,30 @@ describe('index', () => {
     request: jest.fn(),
   } as any;
 
-  beforeAll(() => {
+  beforeEach(() => {
+    mockedAxios.create.mockReset();
     mockedAxios.create.mockReturnValue(mockApi);
   });
 
   afterEach(() => {
     mockGet.mockReset();
+  });
+
+  test('client fails malformed instance URL', async () => {
+    const badInstanceUrl = 'https://test.octopus.app//';
+    const t = (): void => {
+      new sut.OctopusClient({...config, instanceUrl: badInstanceUrl});
+    };
+    expect(t).toThrow(`Malformed Instance Url: ${badInstanceUrl}`);
+  });
+
+  test('client strips "/" suffix from instance URL if provided', async () => {
+    const instanceUrl = 'https://test.octopus.app';
+    const instanceUrlWithSuffix = `${instanceUrl}/`;
+    new sut.OctopusClient({...config, instanceUrl: instanceUrlWithSuffix});
+    expect(mockedAxios.create).toBeCalledWith(
+      expect.objectContaining({baseURL: `${instanceUrl}/api`})
+    );
   });
 
   test('client correctly paginates', async () => {

--- a/sources/octopus-source/test/octopusClient.test.ts
+++ b/sources/octopus-source/test/octopusClient.test.ts
@@ -40,7 +40,11 @@ describe('index', () => {
   test('client strips "/" suffix from instance URL if provided', async () => {
     const instanceUrl = 'https://test.octopus.app';
     const instanceUrlWithSuffix = `${instanceUrl}/`;
-    new sut.OctopusClient({...config, instanceUrl: instanceUrlWithSuffix});
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const client = new sut.OctopusClient({
+      ...config,
+      instanceUrl: instanceUrlWithSuffix,
+    });
     expect(mockedAxios.create).toBeCalledWith(
       expect.objectContaining({baseURL: `${instanceUrl}/api`})
     );


### PR DESCRIPTION
## Description

Strip trailing `/` suffix off Octopus instance url if provided.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
