### PR TITLE
Octopus allow disabling fetching deployment process

### DIFF
--- a/sources/octopus-source/resources/spec.json
+++ b/sources/octopus-source/resources/spec.json
@@ -25,6 +25,12 @@
           "type": "string"
         }
       },
+      "fetch_deployment_process": {
+        "type": "boolean",
+        "title": "Fetch Deployment Process",
+        "description": "Retrieve the deployment process for each deployment.",
+        "default": true
+      },
       "cutoff_days": {
         "type": "number",
         "title": "Cutoff Days",

--- a/sources/octopus-source/src/models.ts
+++ b/sources/octopus-source/src/models.ts
@@ -26,7 +26,7 @@ export interface Deployment extends OctopusDeployment {
     readonly StartTime: string;
     readonly CompletedTime: string;
   };
-  readonly Process: DeploymentProcess;
+  readonly Process?: DeploymentProcess;
 }
 
 export interface Release extends OctopusRelease {


### PR DESCRIPTION
## Description

Older versions of octopus do not expose the API used to retrieve deployment processes. This PR allows disabling that call.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change