### PR TITLE
Add shared consts to oneOf objects

### DIFF
--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/agileaccelerator.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/agileaccelerator.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "AgileAccelerator",
+          "order": 0
+        },
         "max_description_length": {
           "type": "integer",
           "title": "Max Description Length",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/azurepipeline.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/azurepipeline.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Azure pipeline",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Azure pipeline Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/backlog.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/backlog.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Backlog",
+          "order": 0
+        },
         "max_description_length": {
           "type": "integer",
           "title": "Max Description Length",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/bamboohr.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/bamboohr.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "BambooHR",
+          "order": 0
+        },
         "bootstrap_teams_from_managers": {
           "type": "boolean",
           "title": "Bootstrap Teams From Managers",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/bitbucket.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/bitbucket.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Bitbucket",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/clickup.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/clickup.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "ClickUp",
+          "order": 0
+        },
         "taskboard_source": {
           "type": "string",
           "title": "TaskBoard Source",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/datadog.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/datadog.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Datadog",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/docker.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/docker.json
@@ -10,6 +10,11 @@
         "organization"
       ],
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Docker",
+          "order": 0
+        },
         "label_prefix": {
           "type": "string",
           "title": "Label Prefix",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/firehydrant.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/firehydrant.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "FireHydrant",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/jenkins.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/jenkins.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Jenkins",
+          "order": 0
+        },
         "create_commit_records": {
           "type": "boolean",
           "title": "Create Commit Records",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/jira.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/jira.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Jira",
+          "order": 0
+        },
         "use_board_ownership": {
           "type": "boolean",
           "title": "Use Board Ownership",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/notion.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/notion.json
@@ -6,7 +6,13 @@
     {
       "type": "object",
       "title": "None",
-      "properties": {}
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Notion_None",
+          "order": 0
+        }
+      }
     },
     {
       "type": "object",
@@ -15,6 +21,11 @@
         "kind_property"
       ],
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Notion",
+          "order": 0
+        },
         "kind_property": {
           "type": "string",
           "title": "Kind Property",
@@ -32,6 +43,11 @@
                 "kind"
               ],
               "properties": {
+                "option_title": {
+                  "type": "string",
+                  "const": "Projects",
+                  "order": 0
+                },
                 "kind": {
                   "type": "string",
                   "title": "Project Kind",
@@ -72,6 +88,11 @@
                 "kind"
               ],
               "properties": {
+                "option_title": {
+                  "type": "string",
+                  "const": "Epics",
+                  "order": 0
+                },
                 "kind": {
                   "type": "string",
                   "title": "Epic Kind",
@@ -124,6 +145,11 @@
                 "kind"
               ],
               "properties": {
+                "option_title": {
+                  "type": "string",
+                  "const": "Sprints",
+                  "order": 0
+                },
                 "kind": {
                   "type": "string",
                   "title": "Sprint Kind",
@@ -188,6 +214,11 @@
                 "kind"
               ],
               "properties": {
+                "option_title": {
+                  "type": "string",
+                  "const": "Tasks",
+                  "order": 0
+                },
                 "kind": {
                   "type": "string",
                   "title": "Task Kind",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/opsgenie.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/opsgenie.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "OpsGenie",
+          "order": 0
+        },
         "max_description_length": {
           "type": "integer",
           "title": "Max Description Length",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/pagerduty.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/pagerduty.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "PagerDuty",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/phabricator.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/phabricator.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Phabricator",
+          "order": 0
+        },
         "max_description_length": {
           "type": "integer",
           "title": "Max Description Length",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/servicenow.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/servicenow.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "ServiceNow",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/spec.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/spec.json
@@ -8,6 +8,10 @@
       "type": "object",
       "title": "Configurations",
       "properties": {
+        "option_title": {
+          "type": "string",
+          "const": "Source-specific configs"
+        },
         "agileaccelerator": {
           "$ref": "agileaccelerator.json"
         },

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/squadcast.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/squadcast.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "SquadCast",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/statuspage.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/statuspage.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "Statuspage",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",

--- a/destinations/airbyte-faros-destination/resources/source-specific-configs/victorops.json
+++ b/destinations/airbyte-faros-destination/resources/source-specific-configs/victorops.json
@@ -7,6 +7,11 @@
       "type": "object",
       "title": "Configuration",
       "properties": {
+        "source_type": {
+          "type": "string",
+          "const": "VictorOps",
+          "order": 0
+        },
         "application_mapping": {
           "type": "string",
           "title": "Application Mapping",


### PR DESCRIPTION
## Description

Replaces https://github.com/faros-ai/airbyte-connectors/pull/865.
This PR makes the spec compatible for newer versions of Airbyte without changing the locations of anything in the resulting config object.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
