### PR TITLE
Fix test cli stream reading logic and spec test

### DIFF
--- a/destinations/airbyte-faros-destination/test/cli.ts
+++ b/destinations/airbyte-faros-destination/test/cli.ts
@@ -8,7 +8,7 @@ export async function read(s: Readable): Promise<string> {
   for await (const line of s) {
     lines.push(line);
   }
-  return lines.join('\n');
+  return lines.join('');
 }
 
 export interface CLIOptions {

--- a/destinations/airbyte-faros-destination/test/index.test.ts
+++ b/destinations/airbyte-faros-destination/test/index.test.ts
@@ -37,7 +37,6 @@ describe('index', () => {
 
   test('spec', async () => {
     const cli = await CLI.runWith(['spec']);
-    const maxCheckLength = 16384;
     const expectedSpec =
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       JSON.stringify(
@@ -45,10 +44,8 @@ describe('index', () => {
           path.join(__dirname, '../resources/spec.json')
         )
       ) + os.EOL;
+    expect(await read(cli.stdout)).toBe(expectedSpec);
     expect(await read(cli.stderr)).toBe('');
-    expect((await read(cli.stdout)).substring(0, maxCheckLength)).toBe(
-      expectedSpec.substring(0, maxCheckLength)
-    );
     expect(await cli.wait()).toBe(0);
   });
 


### PR DESCRIPTION
## Description

If the expected test output exceeds 8192 characters, `stdout` must be read and tested before `stderr`. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
