### PR TITLE
Handle Pagerduty pagination 10000 limit

### DIFF
--- a/sources/pagerduty-source/src/pagerduty.ts
+++ b/sources/pagerduty-source/src/pagerduty.ts
@@ -172,6 +172,7 @@ export class Pagerduty {
     let fetchNextFunc;
 
     do {
+      // Deal with PagerDuty 10000 records response limit
       if (
         response?.status == 400 &&
         response?.data?.error?.errors?.[0]?.includes('Offset must be less than')

--- a/sources/pagerduty-source/src/pagerduty.ts
+++ b/sources/pagerduty-source/src/pagerduty.ts
@@ -152,17 +152,6 @@ export class Pagerduty {
       }
       errorMessage = `Error from ${url}. Message: ${errorMessage}`;
 
-      // Deal with PagerDuty 10000 records response limit
-      if (
-        err.status == 400 &&
-        err.data?.error?.errors?.[0]?.includes('Offset must be less than')
-      ) {
-        this.logger.warn(
-          `Reached PagerDuty API response size limit of 10000 records. Error: ${errorMessage}`
-        );
-        return undefined;
-      }
-
       if (++retries > this.maxRetries) {
         throw new VError('%s', errorMessage);
       } else {
@@ -183,6 +172,15 @@ export class Pagerduty {
     let fetchNextFunc;
 
     do {
+      if (
+        response?.status == 400 &&
+        response?.data?.error?.errors?.[0]?.includes('Offset must be less than')
+      ) {
+        this.logger.warn(
+          `Reached PagerDuty API response size limit of 10000 records.`
+        );
+        return undefined;
+      }
       if (response?.status >= 300) {
         throw new VError(
           '%s',

--- a/sources/pagerduty-source/test/pagerduty.test.ts
+++ b/sources/pagerduty-source/test/pagerduty.test.ts
@@ -75,7 +75,7 @@ describe('Pagerduty', () => {
       },
       resource: [logEntry],
       next: (): Promise<PagerdutyResponse<LogEntry>> =>
-        Promise.reject(limitExceededResponse),
+        Promise.resolve(limitExceededResponse),
     };
 
     mockGet.mockResolvedValue(successResponse);


### PR DESCRIPTION
## Description

pdjs (under the hood `cross-fetch`) does not reject 4xx responses. We need to check for them in non exceptional processing.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
