### PR TITLE
Fix pd pagination scenario 2

### DIFF
--- a/sources/pagerduty-source/src/pagerduty.ts
+++ b/sources/pagerduty-source/src/pagerduty.ts
@@ -175,9 +175,7 @@ export class Pagerduty {
       // Deal with PagerDuty 10000 records response limit
       if (
         response?.status == 400 &&
-        (response?.data?.error?.errors?.[0]?.includes(
-          'Offset must be less than'
-        ) ||
+        (response?.data?.error?.errors?.[0]?.includes('Offset must be less') ||
           response?.data?.error?.errors?.[0]?.includes('Offset+limit exceeds'))
       ) {
         this.logger.warn(

--- a/sources/pagerduty-source/src/pagerduty.ts
+++ b/sources/pagerduty-source/src/pagerduty.ts
@@ -175,8 +175,7 @@ export class Pagerduty {
       // Deal with PagerDuty 10000 records response limit
       if (
         response?.status == 400 &&
-        (response?.data?.error?.errors?.[0]?.includes('Offset must be less') ||
-          response?.data?.error?.errors?.[0]?.includes('Offset+limit exceeds'))
+        response?.data?.error?.errors?.[0]?.includes('Offset')
       ) {
         this.logger.warn(
           `Reached PagerDuty API response size limit of 10000 records.`

--- a/sources/pagerduty-source/src/streams/incidentLogEntries.ts
+++ b/sources/pagerduty-source/src/streams/incidentLogEntries.ts
@@ -53,7 +53,6 @@ export class IncidentLogEntries extends AirbyteStreamBase {
     yield* pagerduty.getIncidentLogEntries(
       since,
       now,
-      this.config.page_size,
       this.config.incident_log_entries_overview
     );
   }

--- a/sources/pagerduty-source/src/streams/incidents.ts
+++ b/sources/pagerduty-source/src/streams/incidents.ts
@@ -50,12 +50,7 @@ export class Incidents extends AirbyteStreamBase {
       ? DateTime.fromJSDate(new Date(lastSynced))
       : cutoffTimestamp;
 
-    yield* pagerduty.getIncidents(
-      since,
-      now,
-      this.config.page_size,
-      this.config.exclude_services
-    );
+    yield* pagerduty.getIncidents(since, now, this.config.exclude_services);
   }
 
   getUpdatedState(

--- a/sources/pagerduty-source/src/streams/services.ts
+++ b/sources/pagerduty-source/src/streams/services.ts
@@ -18,9 +18,6 @@ export class Services extends AirbyteStreamBase {
 
   async *readRecords(): AsyncGenerator<Dictionary<any, string>, any, unknown> {
     const pagerduty = Pagerduty.instance(this.config, this.logger);
-    yield* pagerduty.getServices(
-      this.config.service_details,
-      this.config.page_size
-    );
+    yield* pagerduty.getServices(this.config.service_details);
   }
 }

--- a/sources/pagerduty-source/src/streams/teams.ts
+++ b/sources/pagerduty-source/src/streams/teams.ts
@@ -18,6 +18,6 @@ export class Teams extends AirbyteStreamBase {
   async *readRecords(): AsyncGenerator<Priority> {
     const pagerduty = Pagerduty.instance(this.config, this.logger);
 
-    yield* pagerduty.getTeams(this.config.page_size);
+    yield* pagerduty.getTeams();
   }
 }

--- a/sources/pagerduty-source/src/streams/users.ts
+++ b/sources/pagerduty-source/src/streams/users.ts
@@ -1,12 +1,7 @@
-import {
-  AirbyteLogger,
-  AirbyteStreamBase,
-  StreamKey,
-  SyncMode,
-} from 'faros-airbyte-cdk';
+import {AirbyteLogger, AirbyteStreamBase, StreamKey} from 'faros-airbyte-cdk';
 import {Dictionary} from 'ts-essentials';
 
-import {Pagerduty, PagerdutyConfig, User} from '../pagerduty';
+import {Pagerduty, PagerdutyConfig} from '../pagerduty';
 
 export class Users extends AirbyteStreamBase {
   constructor(readonly config: PagerdutyConfig, logger: AirbyteLogger) {
@@ -22,6 +17,6 @@ export class Users extends AirbyteStreamBase {
 
   async *readRecords(): AsyncGenerator<Dictionary<any, string>, any, unknown> {
     const pagerduty = Pagerduty.instance(this.config, this.logger);
-    yield* pagerduty.getUsers(this.config.page_size);
+    yield* pagerduty.getUsers();
   }
 }

--- a/sources/pagerduty-source/test/pagerduty.test.ts
+++ b/sources/pagerduty-source/test/pagerduty.test.ts
@@ -2,7 +2,7 @@ import {AirbyteLogger, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import {DateTime} from 'luxon';
 
 import * as sut from '../src/pagerduty';
-import {LogEntry, PagerdutyResponse} from '../src/pagerduty';
+import {Incident, LogEntry, PagerdutyResponse} from '../src/pagerduty';
 
 describe('Pagerduty', () => {
   const logger = new AirbyteLogger(
@@ -24,20 +24,7 @@ describe('Pagerduty', () => {
   test('Handles 10000 pagination limit error - 1', async () => {
     const pd = new sut.Pagerduty(mockApi, logger);
 
-    const limitExceededResponse: PagerdutyResponse<LogEntry> = {
-      url: 'url',
-      status: 400,
-      statusText: 'Bad Request',
-      data: {
-        error: {
-          message: 'Invalid Input Provided',
-          code: 2001,
-          errors: ['Offset must be less than 10001.'],
-        },
-      },
-      resource: [],
-    };
-    const logEntry = {
+    const logEntry: LogEntry = {
       id: 'id',
       type: 'LogEntry',
       summary: 'Summary',
@@ -50,7 +37,6 @@ describe('Pagerduty', () => {
         summary: 'Summary',
         self: 'self',
         html_url: 'url',
-        created_at: '1',
       },
       service: {
         id: 'id',
@@ -58,27 +44,16 @@ describe('Pagerduty', () => {
         summary: 'Summary',
         self: 'self',
         html_url: 'url',
-        created_at: '1',
       },
-    };
-    const successResponse: PagerdutyResponse<LogEntry> = {
-      url: 'url',
-      status: 200,
-      statusText: 'OK',
-      data: {
-        log_entries: [
-          {
-            id: 'id',
-            type: 'trigger_log_entry',
-          },
-        ],
-      },
-      resource: [logEntry],
-      next: (): Promise<PagerdutyResponse<LogEntry>> =>
-        Promise.resolve(limitExceededResponse),
     };
 
-    mockGet.mockResolvedValue(successResponse);
+    const response = pagination10000Response<LogEntry>(
+      'Invalid Input Provided',
+      ['Offset must be less than 10001.'],
+      logEntry
+    );
+
+    mockGet.mockResolvedValue(response);
 
     const iter = pd.getIncidentLogEntries(
       DateTime.now().minus({hours: 12}),
@@ -96,63 +71,39 @@ describe('Pagerduty', () => {
   test('Handles 10000 pagination limit error - 2', async () => {
     const pd = new sut.Pagerduty(mockApi, logger);
 
-    const limitExceededResponse: PagerdutyResponse<LogEntry> = {
-      url: 'url',
-      status: 400,
-      statusText: 'Bad Request',
-      data: {
-        error: {
-          message: 'Arguments Caused Error',
-          code: 2001,
-          errors: [
-            'Offset+limit exceeds maximum allowed value of 10000. Please try to refine your search to reduce the returned set of records below this number, like adding a date range.',
-          ],
-        },
-      },
-      resource: [],
-    };
-    const logEntry = {
+    const incidentEntry: Incident = {
       id: 'id',
-      type: 'LogEntry',
-      summary: 'Summary',
-      self: 'self',
-      html_url: 'url',
-      created_at: '1',
-      incident: {
-        id: 'id',
-        type: 'Incident',
-        summary: 'Summary',
-        self: 'self',
-        html_url: 'url',
-        created_at: '1',
-      },
+      type: 'Incident',
+      description: 'description',
+      status: 'acknowledged',
+      acknowledgements: [],
+      incident_key: '',
+      urgency: 'high',
+      title: 'title',
       service: {
         id: 'id',
         type: 'Service',
         summary: 'Summary',
         self: 'self',
         html_url: 'url',
-        created_at: '1',
       },
-    };
-    const successResponse: PagerdutyResponse<LogEntry> = {
-      url: 'url',
-      status: 200,
-      statusText: 'OK',
-      data: {
-        log_entries: [
-          {
-            id: 'id',
-            type: 'trigger_log_entry',
-          },
-        ],
-      },
-      resource: [logEntry],
-      next: (): Promise<PagerdutyResponse<LogEntry>> =>
-        Promise.resolve(limitExceededResponse),
+      assignments: [],
+      last_status_change_at: '',
+      summary: 'Summary',
+      self: 'self',
+      html_url: 'url',
+      created_at: '1',
     };
 
-    mockGet.mockResolvedValue(successResponse);
+    const response = pagination10000Response<Incident>(
+      'Arguments Caused Error',
+      [
+        'Offset+limit exceeds maximum allowed value of 10000. Please try to refine your search to reduce the returned set of records below this number, like adding a date range.',
+      ],
+      incidentEntry
+    );
+
+    mockGet.mockResolvedValue(response);
 
     const iter = pd.getIncidentLogEntries(
       DateTime.now().minus({hours: 12}),
@@ -164,6 +115,37 @@ describe('Pagerduty', () => {
     }
 
     expect(mockGet).toBeCalledTimes(1);
-    expect(items).toEqual([logEntry]);
+    expect(items).toEqual([incidentEntry]);
   });
 });
+
+function pagination10000Response<T>(
+  message: string,
+  errors: string[],
+  item: T
+): PagerdutyResponse<T> {
+  const limitExceededResponse: PagerdutyResponse<T> = {
+    url: 'url',
+    status: 400,
+    statusText: 'Bad Request',
+    data: {
+      error: {
+        message,
+        code: 2001,
+        errors,
+      },
+    },
+    resource: [],
+  };
+  const successResponse: PagerdutyResponse<T> = {
+    url: 'url',
+    status: 200,
+    statusText: 'OK',
+    data: {},
+    resource: [item],
+    next: (): Promise<PagerdutyResponse<T>> =>
+      Promise.resolve(limitExceededResponse),
+  };
+
+  return successResponse;
+}

--- a/sources/pagerduty-source/test/pagerduty.test.ts
+++ b/sources/pagerduty-source/test/pagerduty.test.ts
@@ -21,7 +21,7 @@ describe('Pagerduty', () => {
     mockGet.mockReset();
   });
 
-  test('Handles 10000 pagination limit error', async () => {
+  test('Handles 10000 pagination limit error - 1', async () => {
     const pd = new sut.Pagerduty(mockApi, logger);
 
     const limitExceededResponse: PagerdutyResponse<LogEntry> = {
@@ -33,6 +33,80 @@ describe('Pagerduty', () => {
           message: 'Invalid Input Provided',
           code: 2001,
           errors: ['Offset must be less than 10001.'],
+        },
+      },
+      resource: [],
+    };
+    const logEntry = {
+      id: 'id',
+      type: 'LogEntry',
+      summary: 'Summary',
+      self: 'self',
+      html_url: 'url',
+      created_at: '1',
+      incident: {
+        id: 'id',
+        type: 'Incident',
+        summary: 'Summary',
+        self: 'self',
+        html_url: 'url',
+        created_at: '1',
+      },
+      service: {
+        id: 'id',
+        type: 'Service',
+        summary: 'Summary',
+        self: 'self',
+        html_url: 'url',
+        created_at: '1',
+      },
+    };
+    const successResponse: PagerdutyResponse<LogEntry> = {
+      url: 'url',
+      status: 200,
+      statusText: 'OK',
+      data: {
+        log_entries: [
+          {
+            id: 'id',
+            type: 'trigger_log_entry',
+          },
+        ],
+      },
+      resource: [logEntry],
+      next: (): Promise<PagerdutyResponse<LogEntry>> =>
+        Promise.resolve(limitExceededResponse),
+    };
+
+    mockGet.mockResolvedValue(successResponse);
+
+    const iter = pd.getIncidentLogEntries(
+      DateTime.now().minus({hours: 12}),
+      DateTime.now()
+    );
+    const items = [];
+    for await (const item of iter) {
+      items.push(item);
+    }
+
+    expect(mockGet).toBeCalledTimes(1);
+    expect(items).toEqual([logEntry]);
+  });
+
+  test('Handles 10000 pagination limit error - 2', async () => {
+    const pd = new sut.Pagerduty(mockApi, logger);
+
+    const limitExceededResponse: PagerdutyResponse<LogEntry> = {
+      url: 'url',
+      status: 400,
+      statusText: 'Bad Request',
+      data: {
+        error: {
+          message: 'Arguments Caused Error',
+          code: 2001,
+          errors: [
+            'Offset+limit exceeds maximum allowed value of 10000. Please try to refine your search to reduce the returned set of records below this number, like adding a date range.',
+          ],
         },
       },
       resource: [],


### PR DESCRIPTION
## Description

There is another way in which the API will response 400 when pagination exceeds 10,000 items. We need to handle that scenario as well.

```
Status code: 400: Bad Request. Data: {\"error\":{\"message\":\"Arguments Caused Error\",\"code\":2002,\"errors\":[\"Offset+limit exceeds maximum allowed value of 10000. Please try to refine your search to reduce the returned set of records below this number, like adding a date range.\"]}}"
```

I also noticed that we are including 2 `limit` params in our requests. We should not explicitly be setting `limit` but instead we should let the pd client set it based off of the configured page size (we are already setting this).

Notice the two limits:
```
https://api.pagerduty.com/incidents?limit=25&time_zone=UTC&since=2023-04-20T17%3A22%3A42.511%2B00%3A00&until=2023-04-21T17%3A22%3A42.511%2B00%3A00&limit=25&offset=10000
``` 

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change