### PR TITLE
Bump faros-destination faros-js-client to v0.2.26

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -39,7 +39,7 @@
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
     "faros-feeds-sdk": "^1.1.1",
-    "faros-js-client": "^0.2.20",
+    "faros-js-client": "^0.2.26",
     "fs-extra": "^11.1.0",
     "git-url-parse": "^13.0.0",
     "graphql": "^16.3.0",


### PR DESCRIPTION
## Description

v0.2.26 includes a more robust retry mechanism for many forms of network errors.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
