### PR TITLE
FAI-6073 - Octopus source improvements

### DIFF
--- a/sources/octopus-source/resources/spec.json
+++ b/sources/octopus-source/resources/spec.json
@@ -29,7 +29,7 @@
         "type": "boolean",
         "title": "Fetch Deployment Process",
         "description": "Retrieve the deployment process for each deployment.",
-        "default": true
+        "default": false
       },
       "cutoff_days": {
         "type": "number",

--- a/sources/octopus-source/src/octopus.ts
+++ b/sources/octopus-source/src/octopus.ts
@@ -30,7 +30,7 @@ export class Octopus {
     private readonly logger: AirbyteLogger,
     cutoffDays?: number,
     private readonly lookBackDepth = 10,
-    private readonly fetchDeploymentProcess = true
+    private readonly fetchDeploymentProcess = false
   ) {
     this.cutoff = cutoffDays
       ? DateTime.now().minus({days: cutoffDays})

--- a/sources/octopus-source/src/octopus.ts
+++ b/sources/octopus-source/src/octopus.ts
@@ -161,12 +161,6 @@ export class Octopus {
           ),
         ]);
 
-        if (this.fetchDeploymentProcess && !process) {
-          this.logger.warn(
-            `Unable to retrieve deployment process for deployment: ${deployment.Id}`
-          );
-        }
-
         yield {
           ...deployment,
           SpaceName: spaceName,
@@ -195,6 +189,9 @@ export class Octopus {
 
       if (!process) {
         process = await this.client.getDeploymentProcess(deploymentProcessId);
+      }
+      if (!process) {
+        this.logger.warn(`Unable to retrieve deployment process`);
       }
     }
     return process;

--- a/sources/octopus-source/src/octopusClient.ts
+++ b/sources/octopus-source/src/octopusClient.ts
@@ -1,4 +1,4 @@
-import axios, {AxiosInstance, AxiosResponse} from 'axios';
+import axios, {AxiosError, AxiosInstance, AxiosResponse} from 'axios';
 import axiosRetry, {
   IAxiosRetryConfig,
   isIdempotentRequestError,
@@ -47,7 +47,6 @@ export class OctopusClient {
     this.pageSize = config?.pageSize ?? DEFAULT_PAGE_SIZE;
     this.logger = config.logger;
     const retries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
-    const logger = this.logger; // for axios-retry
 
     const cleanInstanceUrl = config.instanceUrl.replace(/\/$/, '');
 
@@ -69,16 +68,30 @@ export class OctopusClient {
       );
     };
 
+    const isNonRetryable500 = (error: AxiosError): boolean => {
+      return (
+        error.response &&
+        error.response.status >= 500 &&
+        error.response.status <= 599 &&
+        error.response.data?.ErrorMessage?.includes(
+          'We received a request for a version-controlled resource'
+        )
+      );
+    };
+
     if (retries > 0) {
       const retryConfig: IAxiosRetryConfig = {
         retryDelay: axiosRetry.exponentialDelay,
         shouldResetTimeout: true,
         retries,
-        retryCondition: (error: Error): boolean => {
-          return isNetworkError(error) || isIdempotentRequestError(error);
+        retryCondition: (error: AxiosError): boolean => {
+          return (
+            (isNetworkError(error) || isIdempotentRequestError(error)) &&
+            !isNonRetryable500(error)
+          );
         },
-        onRetry(retryCount, error, requestConfig) {
-          logger?.info(
+        onRetry: (retryCount, error, requestConfig) => {
+          this.logger?.info(
             `Retrying request ${requestConfig.url} due to an error: ${error.message} ` +
               `(attempt ${retryCount} of ${retries})`
           );
@@ -108,11 +121,28 @@ export class OctopusClient {
   @Memoize((projectId) => projectId)
   async getProjectDeploymentProcess(
     projectId: string
-  ): Promise<DeploymentProcess> {
-    const process = await this.get<OctopusDeploymentProcess>(
-      `projects/${projectId}/deploymentprocesses`
-    );
-    return cleanProcess(process);
+  ): Promise<DeploymentProcess | undefined> {
+    try {
+      const process = await this.get<OctopusDeploymentProcess>(
+        `/projects/${projectId}/deploymentprocesses`
+      );
+      return cleanProcess(process);
+    } catch (err: any) {
+      return undefined;
+    }
+  }
+
+  async getDeploymentProcess(
+    deploymentProcessId: string
+  ): Promise<DeploymentProcess | undefined> {
+    try {
+      const process = await this.get<OctopusDeploymentProcess>(
+        `/deploymentprocesses/${deploymentProcessId}`
+      );
+      return cleanProcess(process);
+    } catch (err: any) {
+      return undefined;
+    }
   }
 
   @Memoize((id) => id)

--- a/sources/octopus-source/test/index.test.ts
+++ b/sources/octopus-source/test/index.test.ts
@@ -43,7 +43,7 @@ describe('index', () => {
   } as any;
 
   beforeAll(async () => {
-    const octopus = new Octopus(mockOctopusClient, logger, undefined, 1);
+    const octopus = new Octopus(mockOctopusClient, logger, undefined, 1, true);
     await octopus.initialize(['Default']);
     Octopus.instance = jest.fn().mockImplementation(() => {
       return Promise.resolve(octopus);


### PR DESCRIPTION
## Description

Improvements to the Octopus source:
- In certain situations, a nonretryable 500 is responded from the octopus API when attempting to request a source controlled resource without a source controlled url. We should not retry these requests.
- Sometimes the project deployment process cannot be retrieved but the deployment specific process can be. We should fall back to the deployment specific process.
- Do not pull deployment process by default

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
