### PR TITLE
[FAI-6075] Fix repo key for consistency

### DIFF
--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -400,7 +400,7 @@ export class BitbucketServer {
             limit: this.pageSize,
           }),
         async (data): Promise<Repository> => {
-          const fullName = repoFullName(data.project.key, data.slug);
+          const fullName = repoFullName(projectKey, data.slug);
           let mainBranch: string = undefined;
           try {
             const {data: defaultBranch} =
@@ -441,6 +441,7 @@ export class BitbucketServer {
     }
   }
 
+  @Memoize()
   async project(projectKey: string): Promise<Project> {
     try {
       const {data} = await this.client[MEP].projects.getProject({projectKey});
@@ -480,7 +481,7 @@ export class BitbucketServer {
 }
 
 function repoFullName(projectKey: string, repoSlug: string): string {
-  return `${projectKey}/${repoSlug}`;
+  return `${projectKey}/${repoSlug}`.toLowerCase();
 }
 
 function innerError(err: any): VError {

--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -197,10 +197,7 @@ export class BitbucketServer {
     }
   }
 
-  async *tags(
-    projectKey: string,
-    repositorySlug: string
-  ): AsyncGenerator<Tag> {
+  async *tags(projectKey: string, repositorySlug: string): AsyncGenerator<Tag> {
     const fullName = repoFullName(projectKey, repositorySlug);
     try {
       this.logger.debug(`Fetching tags for repository ${fullName}`);
@@ -217,7 +214,7 @@ export class BitbucketServer {
             ...data,
             computedProperties: {repository: {fullName}},
           } as Tag;
-        },
+        }
       );
     } catch (err) {
       throw new VError(
@@ -403,7 +400,7 @@ export class BitbucketServer {
             limit: this.pageSize,
           }),
         async (data): Promise<Repository> => {
-          const fullName = repoFullName(projectKey, data.slug);
+          const fullName = repoFullName(data.project.key, data.slug);
           let mainBranch: string = undefined;
           try {
             const {data: defaultBranch} =

--- a/sources/bitbucket-server-source/src/streams/commits.ts
+++ b/sources/bitbucket-server-source/src/streams/commits.ts
@@ -31,7 +31,8 @@ export class Commits extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of this.config.projects) {
+    for (const key of this.config.projects) {
+      const project = await this.fetchProjectKey(key);
       for (const repo of await this.server.repositories(
         project,
         this.config.repositories

--- a/sources/bitbucket-server-source/src/streams/common.ts
+++ b/sources/bitbucket-server-source/src/streams/common.ts
@@ -8,4 +8,9 @@ export abstract class StreamBase extends AirbyteStreamBase {
   get server(): BitbucketServer {
     return BitbucketServer.instance(this.config, this.logger);
   }
+
+  // Fetch the project key from the Bitbucket API in case it was renamed
+  async fetchProjectKey(configProjectKey: string): Promise<string> {
+    return (await this.server.project(configProjectKey)).key;
+  }
 }

--- a/sources/bitbucket-server-source/src/streams/project_users.ts
+++ b/sources/bitbucket-server-source/src/streams/project_users.ts
@@ -24,8 +24,8 @@ export class ProjectUsers extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of this.config.projects) {
-      yield {project};
+    for (const key of this.config.projects) {
+      yield {project: await this.fetchProjectKey(key)};
     }
   }
 

--- a/sources/bitbucket-server-source/src/streams/pull_request_substream.ts
+++ b/sources/bitbucket-server-source/src/streams/pull_request_substream.ts
@@ -25,7 +25,8 @@ export abstract class PullRequestSubStream extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of this.config.projects) {
+    for (const key of this.config.projects) {
+      const project = await this.fetchProjectKey(key);
       for (const repo of await this.server.repositories(
         project,
         this.config.repositories

--- a/sources/bitbucket-server-source/src/streams/pull_requests.ts
+++ b/sources/bitbucket-server-source/src/streams/pull_requests.ts
@@ -31,7 +31,8 @@ export class PullRequests extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of this.config.projects) {
+    for (const key of this.config.projects) {
+      const project = await this.fetchProjectKey(key);
       for (const repo of await this.server.repositories(
         project,
         this.config.repositories

--- a/sources/bitbucket-server-source/src/streams/repositories.ts
+++ b/sources/bitbucket-server-source/src/streams/repositories.ts
@@ -24,8 +24,8 @@ export class Repositories extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of this.config.projects) {
-      yield {project};
+    for (const key of this.config.projects) {
+      yield {project: await this.fetchProjectKey(key)};
     }
   }
 

--- a/sources/bitbucket-server-source/src/streams/tags.ts
+++ b/sources/bitbucket-server-source/src/streams/tags.ts
@@ -1,5 +1,5 @@
 import {AirbyteLogger, StreamKey, SyncMode} from 'faros-airbyte-cdk';
-import {Commit, Tag} from 'faros-airbyte-common/bitbucket-server';
+import {Tag} from 'faros-airbyte-common/bitbucket-server';
 import {Dictionary} from 'ts-essentials';
 
 import {BitbucketServerConfig} from '../bitbucket-server';
@@ -24,7 +24,8 @@ export class Tags extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of this.config.projects) {
+    for (const key of this.config.projects) {
+      const project = await this.fetchProjectKey(key);
       for (const repo of await this.server.repositories(
         project,
         this.config.repositories


### PR DESCRIPTION
When a project name changes bitbucket will redirect the old project calls to the new ID. This was messing us up because some of our streams were using the provided name (old) while other were using the returned name (new). This change makes sure we're always using the returned key for consistency. 