### PR TITLE
added changes to include description field in jenkins build datastream

### DIFF
--- a/sources/jenkins-source/resources/schemas/builds.json
+++ b/sources/jenkins-source/resources/schemas/builds.json
@@ -56,6 +56,9 @@
     },
     "url": {
       "type": "string"
+    },
+    "description": {
+      "type": "string"
     }
   },
   "required": [
@@ -68,6 +71,7 @@
     "number",
     "result",
     "timestamp",
-    "url"
+    "url",
+    "description"
   ]
 }

--- a/sources/jenkins-source/src/jenkins.ts
+++ b/sources/jenkins-source/src/jenkins.ts
@@ -6,7 +6,7 @@ import util from 'util';
 import {VError} from 'verror';
 
 const DEFAULT_PAGE_SIZE = 10;
-const FEED_ALL_FIELDS_PATTERN = `name,fullName,url,nextBuildNumber,lastCompletedBuild[number],%s[id,displayName,number,building,result,timestamp,duration,url,actions[lastBuiltRevision[SHA1],remoteUrls],fullName,fullDisplayName],jobs[*]`;
+const FEED_ALL_FIELDS_PATTERN = `name,fullName,url,nextBuildNumber,lastCompletedBuild[number],%s[id,displayName,number,building,description,result,timestamp,duration,url,actions[lastBuiltRevision[SHA1],remoteUrls],fullName,fullDisplayName],jobs[*]`;
 const FEED_JOBS_COUNT_PATTERN = 'jobs[name]';
 const FEED_MAX_DEPTH_CALC_PATTERN = 'fullName,nextBuildNumber,jobs[*]';
 const POTENTIAL_MAX_DEPTH = 10;
@@ -44,6 +44,7 @@ export interface Build {
   timestamp: number;
   url: string;
   fullDisplayName: string;
+  description: string;
 }
 
 export interface JenkinsState {


### PR DESCRIPTION
## Description

This change is to add description field in Jenkins builds data-stream
For the [jenkins-source](https://github.com/faros-ai/airbyte-connectors/tree/main/sources/jenkins-source) connector
The builds table is currently having the below columns:

    "result"
    "duration"
    "number"
    "displayname"
    "fulldisplayname"
    "id"
    "_class"
    "actions"
    "url"
    building"
    "timestamp"
    "_airbyte_ab_id"
    "_airbyte_emitted_at"
    "_airbyte_normalized_at"
    "_airbyte_builds_hashid"

description field is missing, which has the information like parameters used to execute the build job.
This is one of the important fields need.

The description field is available in the API response.
https://your.jenkins.url/job/$JOB_NAME/$BUILD_NUMBER/api/json?pretty=true

This can be be added to Jenkins connector by modifying the below files to include description.

    sources/jenkins-source/resources/schemas/builds.json
    sources/jenkins-source/src/jenkins.ts

## Type of change
- [x] New feature


## Related issues
https://github.com/faros-ai/airbyte-connectors/issues/1009

