### PR TITLE
FAI-6116: Interpret Updates as Upserts

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -456,20 +456,17 @@ export class GraphQLClient {
   }
 
   private async writeUpdateRecord(record: UpdateRecord): Promise<void> {
+    const upsertRec = {
+      ...record.where,
+      ...pick(record.patch, record.mask),
+    };
+    const obj = this.createMutationObject(
+      record.model,
+      upsertRec,
+      record.origin
+    );
     const mutation = {
-      [`update_${record.model}`]: {
-        __args: {
-          where: this.createWhereClause(record.model, record.where),
-          _set: this.createMutationObject(
-            record.model,
-            record.patch,
-            record.origin
-          ).object,
-        },
-        returning: {
-          id: true,
-        },
-      },
+      [`insert_${record.model}_one`]: {__args: obj, id: true},
     };
     await this.postQuery({mutation}, `Failed to update ${record.model} record`);
   }

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -61,6 +61,16 @@ exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation 
 
 exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id uid } } }"`;
 
+exports[`graphql-client write batch upsert update as upsert 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"playg\\", source: \\"Bitbucket\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id source uid } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"repo1\\", organizationId: \\"4d1025a2cfb95b311b9871a49de3a56bf594beee\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id name organizationId } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 3`] = `"mutation { insert_vcs_Commit (objects: [{sha: \\"b500332b58c74fc15302c8961e54facf66c16c44\\", origin: \\"my-origin\\", repositoryId: \\"f9b8248bfcbd563eb23d05a8b1c188a873de787e\\"}], on_conflict: {constraint: vcs_Commit_pkey, update_columns: [origin]}) { returning { id repositoryId sha } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 4`] = `"mutation { insert_vcs_PullRequest (objects: [{number: 2, origin: \\"my-origin\\", repositoryId: \\"f9b8248bfcbd563eb23d05a8b1c188a873de787e\\"}], on_conflict: {constraint: vcs_PullRequest_pkey, update_columns: [origin]}) { returning { id number repositoryId } } }"`;
+
+exports[`graphql-client write batch upsert update as upsert 5`] = `"mutation { m0: insert_vcs_PullRequest_one (object: {number: 2, repository: {data: {name: \\"repo1\\", organization: {data: {uid: \\"playg\\", source: \\"Bitbucket\\"}, on_conflict: {constraint: vcs_Organization_pkey, update_columns: [refreshedAt]}}}, on_conflict: {constraint: vcs_Repository_pkey, update_columns: [refreshedAt]}}, mergeCommit: {data: {sha: \\"b500332b58c74fc15302c8961e54facf66c16c44\\", repository: {data: {name: \\"repo1\\", organization: {data: {uid: \\"playg\\", source: \\"Bitbucket\\"}, on_conflict: {constraint: vcs_Organization_pkey, update_columns: [refreshedAt]}}}, on_conflict: {constraint: vcs_Repository_pkey, update_columns: [refreshedAt]}}}, on_conflict: {constraint: vcs_Commit_pkey, update_columns: [refreshedAt]}}, mergedAt: \\"2022-09-21T03:00:27.505Z\\", origin: \\"my-origin\\"}, on_conflict: {constraint: vcs_PullRequest_pkey, update_columns: [mergeCommitId, mergedAt, origin]}) { id } }"`;
+
 exports[`groupByKeys 1 group of 2 1`] = `
 Array [
   Array [

--- a/destinations/airbyte-faros-destination/test/resources/hasura-schema.json
+++ b/destinations/airbyte-faros-destination/test/resources/hasura-schema.json
@@ -4,6 +4,10 @@
       "name",
       "repositoryId"
     ],
+    "vcs_Commit": [
+      "repositoryId",
+      "sha"
+    ],
     "vcs_Organization": [
       "source",
       "uid"
@@ -14,6 +18,14 @@
     ],
     "org_Employee": [
       "uid"
+    ],
+    "vcs_PullRequest": [
+      "number",
+      "repositoryId"
+    ],
+    "vcs_User": [
+      "source",
+      "uid"
     ]
   },
   "scalars": {
@@ -22,6 +34,16 @@
       "origin": "String",
       "refreshedAt": "timestamptz",
       "repositoryId": "String"
+    },
+    "vcs_Commit": {
+      "authorId": "String",
+      "createdAt": "timestamptz",
+      "htmlUrl": "String",
+      "message": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "repositoryId": "String",
+      "sha": "String"
     },
     "vcs_Organization": {
       "createdAt": "timestamptz",
@@ -68,10 +90,62 @@
       "terminatedAt": "timestamptz",
       "title": "String",
       "uid": "String"
+    },
+    "vcs_PullRequest": {
+      "authorId": "String",
+      "commentCount": "Int",
+      "commitCount": "Int",
+      "createdAt": "timestamptz",
+      "description": "String",
+      "diffStats": "jsonb",
+      "htmlUrl": "String",
+      "mergeCommitId": "String",
+      "mergedAt": "timestamptz",
+      "number": "Int",
+      "origin": "String",
+      "readyForReviewAt": "timestamptz",
+      "refreshedAt": "timestamptz",
+      "repositoryId": "String",
+      "state": "jsonb",
+      "title": "String",
+      "updatedAt": "timestamptz"
+    },
+    "vcs_User": {
+      "email": "String",
+      "htmlUrl": "String",
+      "inactive": "Boolean",
+      "name": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "source": "String",
+      "type": "jsonb",
+      "uid": "String"
     }
   },
   "references": {
     "vcs_Branch": {
+      "repositoryId": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      },
+      "repository": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      }
+    },
+    "vcs_Commit": {
+      "authorId": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "author": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
       "repositoryId": {
         "field": "repository",
         "model": "vcs_Repository",
@@ -137,19 +211,58 @@
         "model": "org_Employee",
         "foreignKey": "managerId"
       }
-    }
+    },
+    "vcs_PullRequest": {
+      "authorId": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "author": {
+        "field": "author",
+        "model": "vcs_User",
+        "foreignKey": "authorId"
+      },
+      "mergeCommitId": {
+        "field": "mergeCommit",
+        "model": "vcs_Commit",
+        "foreignKey": "mergeCommitId"
+      },
+      "mergeCommit": {
+        "field": "mergeCommit",
+        "model": "vcs_Commit",
+        "foreignKey": "mergeCommitId"
+      },
+      "repositoryId": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      },
+      "repository": {
+        "field": "repository",
+        "model": "vcs_Repository",
+        "foreignKey": "repositoryId"
+      }
+    },
+    "vcs_User": {}
   },
   "backReferences": {},
   "sortedModelDependencies": [
     "org_Employee",
     "vcs_Branch",
+    "vcs_PullRequest",
+    "vcs_Commit",
     "vcs_Repository",
-    "vcs_Organization"
+    "vcs_Organization",
+    "vcs_User"
   ],
   "tableNames": [
     "org_Employee",
     "vcs_Branch",
+    "vcs_PullRequest",
+    "vcs_Commit",
     "vcs_Organization",
-    "vcs_Repository"
+    "vcs_Repository",
+    "vcs_User"
   ]
 }


### PR DESCRIPTION
## Description

This PR changes the mutations created by `__Update` records from updates to upserts.  This change was necessary to allow `__Update` records to patch relationships.   When run as updates (that patch relationships), the prior implementation failed at in Hasura with errors like the following:

```
{
  "errors": [
    {
      "extensions": {
        "code": "validation-failed",
        "path": "$.selectionSet.update_vcs_PullRequest.args._set.mergeCommit"
      },
      "message": "field 'mergeCommit' not found in type: 'vcs_PullRequest_set_input'"
    }
  ]
}
```

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
