### PR TITLE
FAI-6076 Honor full model deletion records coming from feeds

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/converter.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter.ts
@@ -76,6 +76,8 @@ export function parseObjectConfig<T>(obj: any, name: string): T | undefined {
 
 /** Stream context to store records by stream and other helpers */
 export class StreamContext {
+  resetData?: (models: ReadonlyArray<string>) => Promise<void>;
+
   constructor(
     readonly logger: AirbyteLogger,
     readonly config: DestinationConfig,

--- a/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-feeds/faros_feed.ts
@@ -47,7 +47,7 @@ export class FarosFeed extends Converter {
       // Full model deletion records.
       // E.g., {"vcs_TeamMembership__Deletion":{"where":"my-source"}}
       // These are issued by the feed and are only applicable to the V1 API
-      // We accumulate the model names in 'deleteModelEntries' to reset them in topological order
+      // We accumulate the model names in 'resetModels' to reset them in topological order
       if (model.endsWith('__Deletion') && Object.entries(rec).length == 1) {
         const [key, value] = Object.entries(rec).pop();
         if (key === 'where' && typeof value == 'string') {

--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -448,6 +448,9 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
         await graphQLClient.loadSchema();
         await graphQLClient.resetData(origin, deleteModelEntries);
 
+        streamContext.resetData = (models: ReadonlyArray<string>) =>
+          graphQLClient.resetData(origin, models);
+
         let originRemapper = undefined;
         if (config.accept_input_records_origin && config.replace_origin_map) {
           const originMap = JSON.parse(config.replace_origin_map);


### PR DESCRIPTION
## Description

For Community Edition, we need to make sure the deletions are processed in topological order.

For Cloud V2, the deletion records coming from feeds are not valid (they look like `{"vcs_TeamMembership__Deletion":{"where":"my-source"}` with `my-source` being the origin)

We instead accumulate all the model _**names**_ for which we get a full model deletion record and reuse `resetData` which takes care of both problems for us.

No changes needed for Cloud V1.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
