### PR TITLE
FAI-5599 Improve wizard boolean input

### DIFF
--- a/faros-airbyte-cdk/src/help.ts
+++ b/faros-airbyte-cdk/src/help.ts
@@ -281,13 +281,13 @@ async function promptLeaf(row: TableRow) {
       value: 'Skipped.',
     });
   }
-  if (row.default !== undefined) {
+  if (row.type !== 'boolean' && row.default !== undefined) {
     choices.push({
       message: `Use default (${row.default})`,
       value: 'Used default.',
     });
   }
-  if (row.examples?.length) {
+  if (row.type !== 'boolean' && row.examples?.length) {
     let idx = 0;
     for (const example of row.examples) {
       idx++;
@@ -297,10 +297,26 @@ async function promptLeaf(row: TableRow) {
 
   let choice = ' ';
   if (choices.length) {
-    choices.push({
-      message: 'Enter your own value',
-      value: ' ',
-    });
+    if (row.type === 'boolean') {
+      for (const choice of [false, true]) {
+        if (row.default === choice) {
+          choices.push({
+            message: `${row.default} (default)`,
+            value: `Used default (${row.default}).`,
+          });
+        } else {
+          choices.push({
+            message: `${choice}`,
+            value: `${choice}`,
+          });
+        }
+      }
+    } else {
+      choices.push({
+        message: 'Enter your own value',
+        value: ' ',
+      });
+    }
     const message = row.description
       ? `${row.title}: ${row.description}`
       : row.title;


### PR DESCRIPTION
Simplify boolean input by ignoring examples and just showing a dropdown with `false` and `true`. If there's a default, we indicate which one is it.

![Screenshot 2023-05-22 at 4 34 25 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/1e8770f6-f3d6-4a2d-9be4-349e052d7229)

![Screenshot 2023-05-22 at 4 33 58 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/6d87e21d-b934-41a7-ab8f-d69b4f56399b)

