### PR TITLE
FAI-6311 - Statuspage connector updates

### DIFF
--- a/sources/statuspage-source/resources/schemas/component_groups.json
+++ b/sources/statuspage-source/resources/schemas/component_groups.json
@@ -12,7 +12,10 @@
       "type": "string"
     },
     "description": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "components": {
       "type": "array",

--- a/sources/statuspage-source/resources/schemas/component_groups.json
+++ b/sources/statuspage-source/resources/schemas/component_groups.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "page_id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "position": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    }
+  }
+}

--- a/sources/statuspage-source/resources/schemas/components.json
+++ b/sources/statuspage-source/resources/schemas/components.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "page_id": {
+      "type": "string"
+    },
+    "group_id": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "group": {
+      "type": "boolean"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "position": {
+      "type": "integer"
+    },
+    "status": {
+      "type": "string"
+    },
+    "showcase": {
+      "type": "boolean"
+    },
+    "only_show_if_degraded": {
+      "type": "boolean"
+    },
+    "automation_email": {
+      "type": "string"
+    },
+    "start_date": {
+      "type": "string"
+    }
+  }
+}

--- a/sources/statuspage-source/resources/schemas/components.json
+++ b/sources/statuspage-source/resources/schemas/components.json
@@ -9,7 +9,10 @@
       "type": "string"
     },
     "group_id": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "created_at": {
       "type": "string"
@@ -24,7 +27,10 @@
       "type": "string"
     },
     "description": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "position": {
       "type": "integer"
@@ -42,7 +48,10 @@
       "type": "string"
     },
     "start_date": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }

--- a/sources/statuspage-source/src/index.ts
+++ b/sources/statuspage-source/src/index.ts
@@ -9,7 +9,7 @@ import {
 import VError from 'verror';
 
 import {Statuspage, StatuspageConfig} from './statuspage';
-import {Incidents, Pages, Users} from './streams';
+import {ComponentGroups, Components, Incidents, Pages, Users} from './streams';
 
 /** The main entry point. */
 export function mainCommand(): Command {
@@ -34,7 +34,7 @@ export class StatuspageSource extends AirbyteSourceBase<StatuspageConfig> {
     return [true, undefined];
   }
   streams(config: StatuspageConfig): AirbyteStreamBase[] {
-    return [Incidents, Pages, Users].map(
+    return [ComponentGroups, Components, Incidents, Pages, Users].map(
       (Stream) => new Stream(config, this.logger)
     );
   }

--- a/sources/statuspage-source/src/statuspage.ts
+++ b/sources/statuspage-source/src/statuspage.ts
@@ -3,7 +3,7 @@ import {AirbyteLogger, wrapApiError} from 'faros-airbyte-cdk';
 import {Memoize} from 'typescript-memoize';
 import {VError} from 'verror';
 
-import {Incident, Page, User} from './types';
+import {Component, ComponentGroup, Incident, Page, User} from './types';
 
 const BASE_URL = 'https://api.statuspage.io/v1/';
 const DEFAULT_MAX_RETRIES = 3;
@@ -176,6 +176,24 @@ export class Statuspage {
       }
     } else {
       this.logger.warn('Org_id not provided. Cannot fetch Statuspage users.');
+    }
+  }
+
+  async *getComponents(pageId: string): AsyncGenerator<Component> {
+    for await (const component of this.paginate<Component>(
+      `/pages/${pageId}/components`,
+      'per_page'
+    )) {
+      yield component;
+    }
+  }
+
+  async *getComponentGroups(pageId: string): AsyncGenerator<ComponentGroup> {
+    for await (const group of this.paginate<ComponentGroup>(
+      `/pages/${pageId}/component-groups`,
+      'per_page'
+    )) {
+      yield group;
     }
   }
 }

--- a/sources/statuspage-source/src/streams/component_groups.ts
+++ b/sources/statuspage-source/src/streams/component_groups.ts
@@ -1,0 +1,34 @@
+import {StreamKey, SyncMode} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {ComponentGroup} from '../types';
+import {StatuspageStreamBase} from './common';
+
+interface StreamSlice {
+  pageId: string;
+}
+
+export class ComponentGroups extends StatuspageStreamBase {
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/components.json');
+  }
+
+  get primaryKey(): StreamKey {
+    return 'id';
+  }
+
+  async *streamSlices(): AsyncGenerator<StreamSlice> {
+    for (const page of await this.statuspage.getPages(this.cfg.page_ids)) {
+      yield {pageId: page.id};
+    }
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: StreamSlice
+  ): AsyncGenerator<ComponentGroup> {
+    const pageId = streamSlice.pageId;
+    yield* this.statuspage.getComponentGroups(pageId);
+  }
+}

--- a/sources/statuspage-source/src/streams/components.ts
+++ b/sources/statuspage-source/src/streams/components.ts
@@ -1,0 +1,34 @@
+import {StreamKey, SyncMode} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {Component} from '../types';
+import {StatuspageStreamBase} from './common';
+
+interface StreamSlice {
+  pageId: string;
+}
+
+export class Components extends StatuspageStreamBase {
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/components.json');
+  }
+
+  get primaryKey(): StreamKey {
+    return 'id';
+  }
+
+  async *streamSlices(): AsyncGenerator<StreamSlice> {
+    for (const page of await this.statuspage.getPages(this.cfg.page_ids)) {
+      yield {pageId: page.id};
+    }
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: StreamSlice
+  ): AsyncGenerator<Component> {
+    const pageId = streamSlice.pageId;
+    yield* this.statuspage.getComponents(pageId);
+  }
+}

--- a/sources/statuspage-source/src/streams/index.ts
+++ b/sources/statuspage-source/src/streams/index.ts
@@ -1,5 +1,7 @@
+import {ComponentGroups} from './component_groups';
+import {Components} from './components';
 import {Incidents} from './incidents';
 import {Pages} from './pages';
 import {Users} from './users';
 
-export {Incidents, Pages, Users};
+export {ComponentGroups, Components, Incidents, Pages, Users};

--- a/sources/statuspage-source/src/types.ts
+++ b/sources/statuspage-source/src/types.ts
@@ -14,6 +14,17 @@ export interface Component {
   updated_at: string;
 }
 
+export interface ComponentGroup {
+  id: string;
+  page_id: string;
+  name: string;
+  description: string;
+  components: ReadonlyArray<string>;
+  position: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export declare enum IncidentImpact {
   Critical = 'critical',
   Major = 'major',

--- a/sources/statuspage-source/test/index.test.ts
+++ b/sources/statuspage-source/test/index.test.ts
@@ -9,6 +9,7 @@ import {VError} from 'verror';
 
 import * as sut from '../src/index';
 import {Statuspage} from '../src/statuspage';
+import {ComponentGroup} from '../src/types';
 
 const statusPageInstance = Statuspage.instance;
 
@@ -112,6 +113,77 @@ describe('index', () => {
     ]);
   });
 
+  test('streams - component groups, use full_refresh sync mode', async () => {
+    const fnComponentGroupsFunc = jest.fn();
+    const expectedData: ReadonlyArray<ComponentGroup> = readTestResourceFile(
+      'component_groups.json'
+    );
+    const sp = new Statuspage(
+      {
+        get: fnComponentGroupsFunc
+          .mockResolvedValueOnce({data: [expectedData[0]]})
+          .mockResolvedValueOnce({data: [expectedData[1]]})
+          .mockResolvedValueOnce({data: []}),
+      } as any,
+      new Date('1970-01-01T00:00:00-0000'),
+      logger,
+      3,
+      1
+    );
+    Statuspage.instance = jest.fn().mockReturnValue(sp);
+    const source = new sut.StatuspageSource(logger);
+    const streams = source.streams({...sourceConfig, page_size: 1});
+
+    const componentGroupsStream = streams[0];
+    const componentGroupsIter = componentGroupsStream.readRecords(
+      SyncMode.FULL_REFRESH,
+      null,
+      {pageId: 'page_id'}
+    );
+    const groups = [];
+    for await (const group of componentGroupsIter) {
+      groups.push(group);
+    }
+
+    expect(fnComponentGroupsFunc).toHaveBeenCalledTimes(3);
+    expect(groups).toStrictEqual(expectedData);
+  });
+
+  test('streams - components, use full_refresh sync mode', async () => {
+    const fnComponentsFunc = jest.fn();
+    const expectedData: ReadonlyArray<ComponentGroup> =
+      readTestResourceFile('components.json');
+    const sp = new Statuspage(
+      {
+        get: fnComponentsFunc
+          .mockResolvedValueOnce({data: [expectedData[0]]})
+          .mockResolvedValueOnce({data: [expectedData[1]]})
+          .mockResolvedValueOnce({data: []}),
+      } as any,
+      new Date('1970-01-01T00:00:00-0000'),
+      logger,
+      3,
+      1
+    );
+    Statuspage.instance = jest.fn().mockReturnValue(sp);
+    const source = new sut.StatuspageSource(logger);
+    const streams = source.streams({...sourceConfig, page_size: 1});
+
+    const componentsStream = streams[1];
+    const componentsIter = componentsStream.readRecords(
+      SyncMode.FULL_REFRESH,
+      null,
+      {pageId: 'page_id'}
+    );
+    const components = [];
+    for await (const group of componentsIter) {
+      components.push(group);
+    }
+
+    expect(fnComponentsFunc).toHaveBeenCalledTimes(3);
+    expect(components).toStrictEqual(expectedData);
+  });
+
   test('streams - incidents, use full_refresh sync mode', async () => {
     const fnIncidentsFunc = jest.fn();
     const inputIncidents: any[] = readTestResourceFile('incidents.json');
@@ -133,7 +205,7 @@ describe('index', () => {
     const source = new sut.StatuspageSource(logger);
     const streams = source.streams(sourceConfig);
 
-    const incidentsStream = streams[0];
+    const incidentsStream = streams[2];
     const incidentsIter = incidentsStream.readRecords(
       SyncMode.FULL_REFRESH,
       null,
@@ -165,7 +237,7 @@ describe('index', () => {
     const source = new sut.StatuspageSource(logger);
     const streams = source.streams(sourceConfig);
 
-    const pagesStream = streams[1];
+    const pagesStream = streams[3];
     const pagesIter = pagesStream.readRecords(SyncMode.FULL_REFRESH);
     const pages = [];
     for await (const page of pagesIter) {
@@ -191,7 +263,7 @@ describe('index', () => {
     const source = new sut.StatuspageSource(logger);
     const streams = source.streams(sourceConfig);
 
-    const usersStream = streams[2];
+    const usersStream = streams[4];
     const usersIter = usersStream.readRecords(SyncMode.FULL_REFRESH);
     const users = [];
     for await (const user of usersIter) {

--- a/sources/statuspage-source/test_files/component_groups.json
+++ b/sources/statuspage-source/test_files/component_groups.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "12z53jps5zzc",
+    "page_id": "string",
+    "name": "API Components",
+    "description": "string",
+    "components": [
+      "abc123",
+      "abc124"
+    ],
+    "position": "string",
+    "created_at": "2023-05-22T13:42:58Z",
+    "updated_at": "2023-05-22T13:42:58Z"
+  },
+  {
+    "id": "2n0aglk235ma",
+    "page_id": "string",
+    "name": "API Components",
+    "description": "string",
+    "components": [
+      "abc223",
+      "abc224"
+    ],
+    "position": "string",
+    "created_at": "2023-05-22T13:42:58Z",
+    "updated_at": "2023-05-22T13:42:58Z"
+  }
+]

--- a/sources/statuspage-source/test_files/components.json
+++ b/sources/statuspage-source/test_files/components.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "component1",
+    "page_id": "string",
+    "group_id": "string",
+    "created_at": "2023-05-22T13:42:58Z",
+    "updated_at": "2023-05-22T13:42:58Z",
+    "group": true,
+    "name": "string",
+    "description": "string",
+    "position": 0,
+    "status": "operational",
+    "showcase": true,
+    "only_show_if_degraded": true,
+    "automation_email": "string",
+    "start_date": "2023-05-22"
+  },
+  {
+    "id": "component2",
+    "page_id": "string",
+    "group_id": "string",
+    "created_at": "2023-05-22T13:42:58Z",
+    "updated_at": "2023-05-22T13:42:58Z",
+    "group": true,
+    "name": "string",
+    "description": "string",
+    "position": 0,
+    "status": "operational",
+    "showcase": true,
+    "only_show_if_degraded": true,
+    "automation_email": "string",
+    "start_date": "2023-05-22"
+  }
+]

--- a/sources/statuspage-source/test_files/full_configured_catalog.json
+++ b/sources/statuspage-source/test_files/full_configured_catalog.json
@@ -40,6 +40,40 @@
     },
     {
       "stream": {
+        "name": "components",
+        "json_schema": {},
+        "supported_sync_modes": [
+          "full_refresh"
+        ],
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "component_groups",
+        "json_schema": {},
+        "supported_sync_modes": [
+          "full_refresh"
+        ],
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          [
+            "id"
+          ]
+        ]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
         "name": "users",
         "json_schema": {},
         "supported_sync_modes": [


### PR DESCRIPTION
## Description

- Add components and component_groups streams to Statuspage source.
- Faros Destination sets compute_Application platform field for Statuspage components to `<component group name>/<statuspage page name>`.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
