### PR TITLE
FAI-6360 - Option to delete records that are referenced by other records when resetting models

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -307,7 +307,8 @@ export class GraphQLClient {
 
   async resetData(
     origin: string,
-    models: ReadonlyArray<string>
+    models: ReadonlyArray<string>,
+    keepReferencedRecords: boolean
   ): Promise<void> {
     this.checkSchema();
 
@@ -327,14 +328,16 @@ export class GraphQLClient {
       const deleteConditions = {
         origin: {_eq: origin},
         refreshedAt: {_lt: minRefreshedAt},
-        _not: {
+      };
+      if (keepReferencedRecords) {
+        deleteConditions['_not'] = {
           _or: this.schema.backReferences[model].map((br) => {
             return {
               [br.field]: {},
             };
           }),
-        },
-      };
+        };
+      }
       const mutation = {
         [`delete_${model}`]: {
           __args: {

--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -488,7 +488,8 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
           async () =>
             await graphQLClient.resetData(
               origin,
-              Array.from(streamContext.resetModels)
+              Array.from(streamContext.resetModels),
+              this.edition === Edition.COMMUNITY
             )
         )) {
           await graphQLClient.flush();


### PR DESCRIPTION
## Description

Current behavior is Airbyte connectors do not delete records that are referenced by other existing records when resetting non-incremental models or during a full sync. This was because the related model reset logic was developed with Faros CE as the only use case, and the model tables in Faros CE have foreign key relationships that do not allow deletions of records that are being referenced by records from other tables.

In Faros SaaS, we do allow such deletions, similar to our old phantom behavior. Airbyte connectors running in SaaS should be updated to delete model records that are referenced by other records. The referencing records will still maintain their references to the phantoms.

I tested this by running the Statuspage connector on a Faros graph in SaaS, and then marked generated compute_Applications A1 and A2 as Included via the Faros Applications page. After executing a model reset, all of the Statuspage records were deleted, and the Faros Applications page showed no compute_Applications. The subsequent sync repopulated all the records, and compute_Applications A1 and A2 were automatically remarked as Included by the existing ownership records that were previously generated by the Faros Applications page.

This realigns our connector behavior with our V1 logic. Example use case:
Our Jira connector lists `tms_Project` as a non-incremental model. When a Jira project is renamed, the existing `tms_Project` record should be deleted from the graph, even if other records reference it.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
