### PR TITLE
FAI-6462: Avoid or handle deadlocks for concurrent writes with Faros destination

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -39,7 +39,7 @@
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
     "faros-feeds-sdk": "^1.1.1",
-    "faros-js-client": "^0.2.37",
+    "faros-js-client": "^0.2.38",
     "fs-extra": "^11.1.0",
     "git-url-parse": "^13.0.0",
     "graphql": "^16.3.0",

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -2,8 +2,7 @@ import dateformat from 'date-format';
 import {AirbyteLogger} from 'faros-airbyte-cdk';
 import {Schema, SchemaLoader} from 'faros-js-client';
 import {EnumType, jsonToGraphQLQuery} from 'json-to-graphql-query';
-import _ from 'lodash';
-import {
+import _, {
   clone,
   difference,
   flatMap,
@@ -789,7 +788,8 @@ export class GraphQLClient {
         mutation: {
           [`insert_${model}`]: {
             __args: {
-              objects,
+              // sort objects to avoid deadlocks on concurrent inserts
+              objects: _.orderBy(objects, primaryKeys),
               on_conflict: onConflict,
             },
             returning: {

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -2,7 +2,7 @@ import dateformat from 'date-format';
 import {AirbyteLogger} from 'faros-airbyte-cdk';
 import {Schema, SchemaLoader} from 'faros-js-client';
 import {EnumType, jsonToGraphQLQuery} from 'json-to-graphql-query';
-import _, {
+import {
   clone,
   difference,
   flatMap,
@@ -13,6 +13,7 @@ import _, {
   isNil,
   keys,
   max,
+  orderBy,
   pick,
   reverse,
   set,
@@ -568,7 +569,7 @@ export class GraphQLClient {
         // }
         if (this.updateResetLimit) {
           for (const mutationRes of Object.values(res.data)) {
-            const refreshedAt = _.get(mutationRes, 'refreshedAt');
+            const refreshedAt = get(mutationRes, 'refreshedAt');
             if (refreshedAt) {
               const recordRefreshedAtMs = new Date(refreshedAt).getTime();
               this.resetLimitMillis = Math.min(
@@ -789,7 +790,7 @@ export class GraphQLClient {
           [`insert_${model}`]: {
             __args: {
               // sort objects to avoid deadlocks on concurrent inserts
-              objects: _.orderBy(objects, primaryKeys),
+              objects: orderBy(objects, primaryKeys),
               on_conflict: onConflict,
             },
             returning: {

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -6,7 +6,7 @@ exports[`graphql-client write batch updates update_columns bug 1`] = `"mutation 
 
 exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
 
-exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"metis\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;
+exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"metis\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;
 
 exports[`graphql-client write batch upsert basic end-to-end 3`] = `"mutation { insert_vcs_Branch (objects: [{name: \\"foo\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|metis|t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"main\\", origin: \\"mytestsource\\", repositoryId: \\"t1|gql-e2e-v2|hermes|t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Branch_pkey, update_columns: [origin]}) { returning { id refreshedAt name repositoryId } } }"`;
 
@@ -59,7 +59,7 @@ exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation 
 
 exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: \\"9\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [origin]}) { returning { id refreshedAt uid } } }"`;
 
-exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id refreshedAt uid } } }"`;
+exports[`graphql-client write batch upsert self-referent model 3`] = `"mutation { insert_org_Employee (objects: [{uid: \\"10\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|7\\"}, {uid: \\"7\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}, {uid: \\"8\\", origin: \\"mytestsource\\", managerId: \\"t1|gql-e2e-v2|9\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [managerId, origin]}) { returning { id refreshedAt uid } } }"`;
 
 exports[`graphql-client write batch upsert update as upsert 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"playg\\", source: \\"Bitbucket\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "date-format": "^4.0.6",
         "enquirer": "^2.3.6",
         "faros-feeds-sdk": "^1.1.1",
-        "faros-js-client": "^0.2.37",
+        "faros-js-client": "^0.2.38",
         "fast-redact": "^3.0.2",
         "fs-extra": "^11.1.0",
         "git-url-parse": "^13.0.0",
@@ -8234,9 +8234,9 @@
       }
     },
     "node_modules/faros-js-client": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.37.tgz",
-      "integrity": "sha512-Vz6b/vU1m09+Bz9VLvSGtuW2B0UI1+YUcqBAf/RfxyeprDRF31ol2LzUjQhPgfdds7CPx5MTy7O3viGVXyiw7w==",
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.38.tgz",
+      "integrity": "sha512-aOzEGEfakxP1ORNnUkCBcrAsurlHA5YQFLjXnnLEtvDaTTikOTk0PyPa03z5CkT3cMxA62rGBaaeu0tYxSr5Jg==",
       "dependencies": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",
@@ -23314,9 +23314,9 @@
       }
     },
     "faros-js-client": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.37.tgz",
-      "integrity": "sha512-Vz6b/vU1m09+Bz9VLvSGtuW2B0UI1+YUcqBAf/RfxyeprDRF31ol2LzUjQhPgfdds7CPx5MTy7O3viGVXyiw7w==",
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.38.tgz",
+      "integrity": "sha512-aOzEGEfakxP1ORNnUkCBcrAsurlHA5YQFLjXnnLEtvDaTTikOTk0PyPa03z5CkT3cMxA62rGBaaeu0tYxSr5Jg==",
       "requires": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",

--- a/sources/faros-graphql-source/package.json
+++ b/sources/faros-graphql-source/package.json
@@ -32,7 +32,7 @@
     "avsc": "5.7.7",
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
-    "faros-js-client": "^0.2.37",
+    "faros-js-client": "^0.2.38",
     "graphql": "^16.3.0",
     "verror": "^1.10.1"
   },


### PR DESCRIPTION
## Description
Changes to eliminate or handle deadlocks for concurrent writes via Faros destination
1. bump `faros-js-client` to get `HTTP 409` retry behavior for `graphql` endpoint
2. order objects within upsert batch to eliminate deadlocks for concurrent inserts

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
