### PR TITLE
FAI-6560: handle nil/empty array literals properly

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -210,6 +210,20 @@ function addLevel(u: Upsert): [Upsert, number][] {
   return result;
 }
 
+export function toPostgresArrayLiteral(value: any[]): string {
+  return `{${value
+    .map((s) => {
+      if (typeof s === 'string') {
+        return `"${s}"`;
+      }
+      if (isNil(s)) {
+        return 'NULL';
+      }
+      return s;
+    })
+    .join(',')}}`;
+}
+
 /**
  * Client for writing records as GraphQL mutations.  The client supports 3
  * kinds of writes: Upserts, Updates and Deletes.
@@ -827,7 +841,7 @@ export class GraphQLClient {
         );
       }
       // format array value as postgres literal
-      return `{${value.join(',')}}`;
+      return toPostgresArrayLiteral(value);
     } else if (typeof value === 'object' || Array.isArray(value)) {
       return traverse(value).map(function (this, val) {
         if (val instanceof Date) {

--- a/destinations/airbyte-faros-destination/test/graphql-client.test.ts
+++ b/destinations/airbyte-faros-destination/test/graphql-client.test.ts
@@ -11,6 +11,7 @@ import {
   serialize,
   strictPick,
   toLevels,
+  toPostgresArrayLiteral,
   Upsert,
   UpsertBuffer,
 } from '../src/common/graphql-client';
@@ -887,5 +888,22 @@ describe('groupByKeys', () => {
   });
   test('2 groups of mix', async () => {
     await expectGroupByKeys([u0a, u1a, u1b]);
+  });
+});
+
+describe('toPostgresArrayLiteral', () => {
+  test('strings', async () => {
+    expect(toPostgresArrayLiteral(['a', 'b', 'c'])).toEqual(`{"a","b","c"}`);
+    expect(toPostgresArrayLiteral(['a', '', 'c'])).toEqual(`{"a","","c"}`);
+    expect(toPostgresArrayLiteral(['a', null, 'c'])).toEqual(`{"a",NULL,"c"}`);
+    expect(toPostgresArrayLiteral(['a', undefined, 'c'])).toEqual(
+      `{"a",NULL,"c"}`
+    );
+  });
+  test('numbers', async () => {
+    expect(toPostgresArrayLiteral([1, 2, 3])).toEqual(`{1,2,3}`);
+    expect(toPostgresArrayLiteral([1, null, 3])).toEqual(`{1,NULL,3}`);
+    expect(toPostgresArrayLiteral([1, undefined, 3])).toEqual(`{1,NULL,3}`);
+    expect(toPostgresArrayLiteral([1, 0, 3])).toEqual(`{1,0,3}`);
   });
 });


### PR DESCRIPTION
## Description

Fix handling of empty string by quoting strings and translating `nil` to `NULL`.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

