### PR TITLE
FAI-5603 Accept a spec from a given file path

### DIFF
--- a/faros-airbyte-cdk/src/destinations/destination-runner.ts
+++ b/faros-airbyte-cdk/src/destinations/destination-runner.ts
@@ -137,11 +137,17 @@ export class AirbyteDestinationRunner<
         '--json <path to json>',
         'Output the destination configuration as JSON'
       )
+      .option(
+        '--spec-file <path to spec>',
+        'Path to the spec file. If not provided, the spec will be fetched from the destination'
+      )
       .description(
         'Run a wizard command to prepare arguments for Airbyte Local CLI'
       )
       .action(async (opts) => {
-        const spec = await this.destination.spec();
+        const spec = opts.specFile
+          ? JSON.parse(fs.readFileSync(opts.specFile, 'utf8'))
+          : await this.destination.spec();
         const rows = traverseObject(
           spec.spec.connectionSpecification,
           opts.json

--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -146,11 +146,17 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
         '--json <path to json>',
         'Output the source configuration as JSON'
       )
+      .option(
+        '--spec-file <path to spec>',
+        'Path to the spec file. If not provided, the spec will be fetched from the source'
+      )
       .description(
         'Run a wizard command to prepare arguments for Airbyte Local CLI'
       )
       .action(async (opts) => {
-        const spec = await this.source.spec();
+        const spec = opts.specFile
+          ? JSON.parse(fs.readFileSync(opts.specFile, 'utf8'))
+          : await this.source.spec();
         const rows = traverseObject(
           spec.spec.connectionSpecification,
           opts.json


### PR DESCRIPTION
## Description

This will allow using the wizard with any airbyte connector, not just the ones developed with Faros CDK.
In the Airbyte local CLI we'll just need to output the non-Faros connectors' spec into a file and use any of the Faros connectors to run the wizard from that spec.

Example below runs the Faros destination wizard from an arbitrary Faros source.

![Screenshot 2023-06-13 at 3 30 41 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/6c77c669-7fbc-452c-895b-9f4ef0540549)



## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
