### PR TITLE
FAI-6714: ensure upserts update nil values and relations

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -736,7 +736,7 @@ export class GraphQLClient {
     // error on flush
     if (has(object, 'uid') && isNil(object['uid'])) {
       throw new VError(
-        'cannot upsert null uid for model %s with keys %s',
+        'cannot upsert null or undefined uid for model %s with keys %s',
         model,
         JSON.stringify(pick(record, this.schema.primaryKeys[model]))
       );

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -4,6 +4,8 @@ exports[`graphql-client basic batch mutation 1`] = `"mutation { m0: insert_vcs_M
 
 exports[`graphql-client write batch updates update_columns bug 1`] = `"mutation { m0: insert_tms_Task_one (object: {uid: \\"9\\", source: \\"jira\\", origin: \\"mytestsource\\"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [origin]}) { id refreshedAt } m1: insert_tms_Task_one (object: {uid: \\"7\\", source: \\"jira\\", origin: \\"mytestsource\\"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [origin]}) { id refreshedAt } m2: insert_tms_Task_one (object: {uid: \\"7\\", tms_Task: {data: {uid: \\"9\\", source: \\"jira\\"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [refreshedAt]}}, source: \\"jira\\", origin: \\"mytestsource\\"}, on_conflict: {constraint: tms_Task_pkey, update_columns: [origin, parent]}) { id refreshedAt } }"`;
 
+exports[`graphql-client write batch upsert allow upsert null values 1`] = `"mutation { insert_vcs_Commit (objects: [{sha: \\"c2\\", authorId: null, message: null, origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Commit_pkey, update_columns: [authorId, message, origin, refreshedAt]}) { returning { id refreshedAt repositoryId sha } } }"`;
+
 exports[`graphql-client write batch upsert basic end-to-end 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
 
 exports[`graphql-client write batch upsert basic end-to-end 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}, {name: \\"metis\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;
@@ -46,8 +48,6 @@ Array [
 `;
 
 exports[`graphql-client write batch upsert nil uid 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"u1\\", origin: \\"mytestsource\\"}, {uid: \\"u2\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt source uid } } }"`;
-
-exports[`graphql-client write batch upsert null fields bug 1`] = `"mutation { insert_vcs_Commit (objects: [{sha: \\"c2\\", authorId: null, message: null, origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Commit_pkey, update_columns: [authorId, message, origin, refreshedAt]}) { returning { id refreshedAt repositoryId sha } } }"`;
 
 exports[`graphql-client write batch upsert on_conflict update_columns bug 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
 

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -45,6 +45,10 @@ Array [
 ]
 `;
 
+exports[`graphql-client write batch upsert nil uid 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"u1\\", origin: \\"mytestsource\\"}, {uid: \\"u2\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert null fields bug 1`] = `"mutation { insert_vcs_Commit (objects: [{sha: \\"c2\\", authorId: null, message: null, origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Commit_pkey, update_columns: [authorId, message, origin, refreshedAt]}) { returning { id refreshedAt repositoryId sha } } }"`;
+
 exports[`graphql-client write batch upsert on_conflict update_columns bug 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
 
 exports[`graphql-client write batch upsert on_conflict update_columns bug 2`] = `"mutation { insert_vcs_Repository (objects: [{name: \\"hermes\\", organizationId: \\"t1|gql-e2e-v2|GitHub|faros-ai\\"}], on_conflict: {constraint: vcs_Repository_pkey, update_columns: [name, organizationId]}) { returning { id refreshedAt name organizationId } } }"`;

--- a/destinations/airbyte-faros-destination/test/graphql-client.test.ts
+++ b/destinations/airbyte-faros-destination/test/graphql-client.test.ts
@@ -641,7 +641,7 @@ describe('graphql-client write batch upsert', () => {
     await client.flush();
     expect(queries).toEqual(responses.length);
   });
-  test('null fields bug', async () => {
+  test('allow upsert null values', async () => {
     const responses = [
       JSON.parse(`
         {
@@ -732,7 +732,7 @@ describe('graphql-client write batch upsert', () => {
     await expect(
       client.writeRecord('vcs_Organization', {uid: null}, 'mytestsource')
     ).rejects.toThrow(
-      'cannot upsert null uid for model vcs_Organization with keys {"uid":null}'
+      'cannot upsert null or undefined uid for model vcs_Organization with keys {"uid":null}'
     );
     await client.writeRecord('vcs_Organization', {uid: 'u2'}, 'mytestsource');
     await client.flush();


### PR DESCRIPTION
## Description

Allow upserts of `nil` (i.e. null and undefined) values and relations.  Also, validate the `uid` fields are non-null while processing records.  This prevents a later db constraint violation that results in a full batch being discarded.

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
