### PR TITLE
Skip 'lerna version' command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ ARG version
 RUN test -n "$version" || (echo "'version' argument is not set, e.g --build-arg version=x.y.z" && false)
 ENV CONNECTOR_VERSION $version
 
-RUN cp package-lock.json .package-lock.json.tmp \
-    && lerna version $CONNECTOR_VERSION -y --no-git-tag-version --no-push --ignore-scripts --exact \
-    && mv .package-lock.json.tmp package-lock.json
+#RUN cp package-lock.json .package-lock.json.tmp \
+    #&& lerna version $CONNECTOR_VERSION -y --no-git-tag-version --no-push --ignore-scripts --exact \
+    #&& mv .package-lock.json.tmp package-lock.json
 RUN apk del .gyp
 
 ARG path


### PR DESCRIPTION
## Description

I don't know why this command is failing now in the docker build, and I want to unblock the connector acceptance tests and the release workflow now.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
