### PR TITLE
[FAI-6768] Add destination packaging test to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,13 @@ jobs:
               ./scripts/source-acceptance-test.sh $source
             fi
           done
+      - name: Destination packaging test
+        run: |
+          cd destinations/airbyte-faros-destination && \
+          cat package.json | jq --arg V "${{ env.TAG_VERSION }}" '(.dependencies."faros-airbyte-cdk",.dependencies."faros-airbyte-common") = $V' > package.tmp && \
+          mv package.tmp package.json && \
+          npm i && \
+          npm version ${{ env.TAG_VERSION }}
 
       - name: Stop Jenkins server
         if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }} # Skip PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,6 @@ jobs:
               ./scripts/source-acceptance-test.sh $source
             fi
           done
-      - name: Destination packaging test
-        run: |
-          cd destinations/airbyte-faros-destination && npm i
 
       - name: Stop Jenkins server
         if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }} # Skip PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,7 @@ jobs:
           done
       - name: Destination packaging test
         run: |
-          cd destinations/airbyte-faros-destination && \
-          cat package.json | jq --arg V "${{ env.TAG_VERSION }}" '(.dependencies."faros-airbyte-cdk",.dependencies."faros-airbyte-common") = $V' > package.tmp && \
-          mv package.tmp package.json && \
-          npm i && \
-          npm version ${{ env.TAG_VERSION }}
+          cd destinations/airbyte-faros-destination && npm i
 
       - name: Stop Jenkins server
         if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }} # Skip PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,5 +121,49 @@ jobs:
 
       - name: Test
         env:
-          NODE_OPTIONS: "--max-old-space-size=4096"
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: lerna run test-cov
+
+  test-packaging:
+    if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch' }} # Only on PRs
+    name: Test packaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FORCE_COLOR: true
+      HUSKY_SKIP_INSTALL: 1
+      HUSKY_SKIP_HOOKS: 1
+      HUSKY: 0
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm install -g lerna @lerna/legacy-package-management && lerna bootstrap --hoist
+
+      - name: Test Airbyte CDK package
+        run: |
+          cd faros-airbyte-cdk && \
+          npm i && \
+          npm version 0.1.0 && \
+          npm publish --dry-run
+
+      - name: Test Airbyte Common package
+        run: |
+          cd faros-airbyte-common && \
+          npm i && \
+          npm version 0.1.0 && \
+          npm publish --dry-run
+
+      - name: Test Faros Destination package
+        run: |
+          cd destinations/airbyte-faros-destination && \
+          npm i && \
+          npm version 0.1.0 && \
+          npm publish --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,19 +148,16 @@ jobs:
         run: |
           cd faros-airbyte-cdk && \
           npm i && \
-          npm version 0.0.1 && \
           npm publish --dry-run
 
       - name: Test Airbyte Common package
         run: |
           cd faros-airbyte-common && \
           npm i && \
-          npm version 0.0.1 && \
           npm publish --dry-run
 
       - name: Test Faros Destination package
         run: |
           cd destinations/airbyte-faros-destination && \
           npm i && \
-          npm version 0.0.1 && \
           npm publish --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
 
   test-packaging:
     if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch' }} # Only on PRs
-    name: Test packaging
+    name: Packaging Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,19 +148,19 @@ jobs:
         run: |
           cd faros-airbyte-cdk && \
           npm i && \
-          npm version 0.1.0 && \
+          npm version 0.0.1 && \
           npm publish --dry-run
 
       - name: Test Airbyte Common package
         run: |
           cd faros-airbyte-common && \
           npm i && \
-          npm version 0.1.0 && \
+          npm version 0.0.1 && \
           npm publish --dry-run
 
       - name: Test Faros Destination package
         run: |
           cd destinations/airbyte-faros-destination && \
           npm i && \
-          npm version 0.1.0 && \
+          npm version 0.0.1 && \
           npm publish --dry-run


### PR DESCRIPTION
## Description
Issues like the one which happened when we bumped Commander package which [had to be reverted](https://github.com/faros-ai/airbyte-connectors/pull/1063) might be able to be caught before merging by attempting the destination packaging within our CI workflow
