### PR TITLE
FAI-6879 - StatusPage incidents should include startedAt

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/statuspage/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/statuspage/incidents.ts
@@ -44,7 +44,9 @@ export class Incidents extends StatuspageConverter {
 
     const incidentRef = {uid: incident.id, source};
     const createdAt = Utils.toDate(incident.created_at);
-    const startedAt = Utils.toDate(incident.started_at);
+    const startedAt = incident.started_at
+      ? Utils.toDate(incident.started_at)
+      : undefined;
 
     let acknowledgedAt = Utils.toDate(incident.created_at); // Statuspage doesn't have "triggered" semantic status
     const resolvedAt = incident.resolved_at

--- a/destinations/airbyte-faros-destination/src/converters/statuspage/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/statuspage/incidents.ts
@@ -1,7 +1,6 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-js-client';
 
-import {Common} from '../common/common';
 import {
   DestinationModel,
   DestinationRecord,
@@ -45,6 +44,7 @@ export class Incidents extends StatuspageConverter {
 
     const incidentRef = {uid: incident.id, source};
     const createdAt = Utils.toDate(incident.created_at);
+    const startedAt = Utils.toDate(incident.started_at);
 
     let acknowledgedAt = Utils.toDate(incident.created_at); // Statuspage doesn't have "triggered" semantic status
     const resolvedAt = incident.resolved_at
@@ -135,6 +135,7 @@ export class Incidents extends StatuspageConverter {
         description: incident.postmortem_body,
         url: incident.shortlink,
         createdAt,
+        startedAt,
         updatedAt,
         acknowledgedAt,
         resolvedAt,


### PR DESCRIPTION
## Description

`startedAt` was not being written for some reason. Uptime is calculated using `startedAt` and `resolvedAt` so without `startedAt`, uptime would always be 100%. 

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change