### PR TITLE
FAI-6878: add request compression to faros-js-client

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -39,7 +39,7 @@
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
     "faros-feeds-sdk": "^1.1.1",
-    "faros-js-client": "^0.2.40",
+    "faros-js-client": "^0.2.41",
     "fs-extra": "^11.1.0",
     "git-url-parse": "^13.0.0",
     "graphql": "^16.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "date-format": "^4.0.6",
         "enquirer": "^2.3.6",
         "faros-feeds-sdk": "^1.1.1",
-        "faros-js-client": "^0.2.40",
+        "faros-js-client": "^0.2.41",
         "fast-redact": "^3.0.2",
         "fs-extra": "^11.1.0",
         "git-url-parse": "^13.0.0",
@@ -8381,9 +8381,9 @@
       }
     },
     "node_modules/faros-js-client": {
-      "version": "0.2.40",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.40.tgz",
-      "integrity": "sha512-2kEKb2LVfUltdE525n8X7zsUiRh9+GqNqwcznEPlmfdtL5QtGw038QI2t4FLmi/2gJY4QLR9/PHwUT8tqFfJgg==",
+      "version": "0.2.41",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.41.tgz",
+      "integrity": "sha512-FAzPPQprhJReHcfWo/XlyLiKzikloT0o7eamzTaOG5Z5tEt574tCdIMBiE/wqBbKrF3o4qGm3/vSDCbvCB9Hrw==",
       "dependencies": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",
@@ -23611,9 +23611,9 @@
       }
     },
     "faros-js-client": {
-      "version": "0.2.40",
-      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.40.tgz",
-      "integrity": "sha512-2kEKb2LVfUltdE525n8X7zsUiRh9+GqNqwcznEPlmfdtL5QtGw038QI2t4FLmi/2gJY4QLR9/PHwUT8tqFfJgg==",
+      "version": "0.2.41",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.2.41.tgz",
+      "integrity": "sha512-FAzPPQprhJReHcfWo/XlyLiKzikloT0o7eamzTaOG5Z5tEt574tCdIMBiE/wqBbKrF3o4qGm3/vSDCbvCB9Hrw==",
       "requires": {
         "axios": "^0.21.4",
         "axios-retry": "^3.2.5",

--- a/sources/faros-graphql-source/package.json
+++ b/sources/faros-graphql-source/package.json
@@ -32,7 +32,7 @@
     "avsc": "5.7.7",
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
-    "faros-js-client": "^0.2.40",
+    "faros-js-client": "^0.2.41",
     "graphql": "^16.3.0",
     "verror": "^1.10.1"
   },


### PR DESCRIPTION


## Description

Bump client to get unlimited request/response sizes

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

