### PR TITLE
FAI-6879: Enable option to disable syncing uptimes for components

### DIFF
--- a/.github/workflows/skip-test-sources.txt
+++ b/.github/workflows/skip-test-sources.txt
@@ -2,6 +2,7 @@ agileaccelerator-source
 azure-repos-source
 azure-workitems-source
 azurepipeline-source
+azureactivedirectory-source
 bamboohr-source
 bitbucket-server-source
 datadog-source

--- a/destinations/airbyte-faros-destination/src/converters/statuspage/component_uptimes.ts
+++ b/destinations/airbyte-faros-destination/src/converters/statuspage/component_uptimes.ts
@@ -35,7 +35,7 @@ export class ComponentUptimes extends StatuspageConverter {
     } as Component;
     const application = this.computeApplication(ctx, component);
     // Generate uid from uptime page_id, component id, range_start, and range_end
-    const uid = `${uptime.page_id}:${uptime.id}:${uptime.range_start}-${uptime.range_end}}`;
+    const uid = `${uptime.page_id}:${uptime.id}:${uptime.range_start}-${uptime.range_end}`;
     return [
       {
         model: 'ims_ApplicationUptime',

--- a/sources/statuspage-source/resources/spec.json
+++ b/sources/statuspage-source/resources/spec.json
@@ -48,6 +48,12 @@
         "title": "Max Number of Retries",
         "description": "The max number of retries before giving up on retrying requests to Statuspage API",
         "default": 3
+      },
+      "fetch_component_uptime": {
+        "type": "boolean",
+        "title": "Fetch Component Uptimes",
+        "description": "Fetch the uptime of each component",
+        "default": false
       }
     }
   }

--- a/sources/statuspage-source/src/statuspage.ts
+++ b/sources/statuspage-source/src/statuspage.ts
@@ -24,6 +24,7 @@ export interface StatuspageConfig {
   readonly page_ids?: ReadonlyArray<string>;
   readonly max_retries?: number;
   readonly page_size?: number;
+  readonly fetch_component_uptime?: boolean;
 }
 
 export class Statuspage {
@@ -219,8 +220,13 @@ export class Statuspage {
       return `${year}-${month}-${day}`;
     };
 
-    const rangeStart =
-      rangeEndDate > this.startDate ? rangeEndDate : this.startDate;
+    // Can only get uptimes for the last 90 days.
+    const maxRangeStart = new Date();
+    maxRangeStart.setDate(maxRangeStart.getDate() - 90);
+    const maxCutoff =
+      this.startDate > maxRangeStart ? this.startDate : maxRangeStart;
+
+    const rangeStart = rangeEndDate > maxCutoff ? rangeEndDate : maxCutoff;
     // Use start of day to avoid partial days.
     const currentDate = new Date(getFormattedDate(new Date()));
 

--- a/sources/statuspage-source/src/streams/component_uptime.ts
+++ b/sources/statuspage-source/src/streams/component_uptime.ts
@@ -26,7 +26,7 @@ export class ComponentUptimes extends StatuspageStreamBase {
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
     if (!this.cfg.fetch_component_uptime) {
-      this.logger.info(
+      this.logger.debug(
         'Fetching component uptime is disabled. Skipping fetching component uptimes.'
       );
       return;

--- a/sources/statuspage-source/src/streams/component_uptime.ts
+++ b/sources/statuspage-source/src/streams/component_uptime.ts
@@ -25,6 +25,12 @@ export class ComponentUptimes extends StatuspageStreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
+    if (!this.cfg.fetch_component_uptime) {
+      this.logger.info(
+        'Fetching component uptime is disabled. Skipping fetching component uptimes.'
+      );
+      return;
+    }
     for (const page of await this.statuspage.getPages(this.cfg.page_ids)) {
       for await (const component of this.statuspage.getComponents(page.id)) {
         yield {pageId: page.id, componentId: component.id};


### PR DESCRIPTION
## Description

- Enable the option to disable syncing uptimes for components
- Ensure we only try to fetch a max of 90 days
- Fix uptime UID

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
