### PR TITLE
Update package-lock.json and fix acceptance tests

### DIFF
--- a/.github/workflows/skip-test-sources.txt
+++ b/.github/workflows/skip-test-sources.txt
@@ -2,7 +2,6 @@ agileaccelerator-source
 azure-repos-source
 azure-workitems-source
 azurepipeline-source
-azureactivedirectory-source
 bamboohr-source
 bitbucket-server-source
 datadog-source

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,56 @@
   "packages": {
     "": {
       "name": "root",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.9",
+        "@atlassian/bitbucket-server": "^0.0.6",
+        "@datadog/datadog-api-client": "1.3.0",
+        "@gitbeaker/node": "^35.6.0",
+        "@pagerduty/pdjs": "^2.2.4",
+        "@snyk/docker-registry-v2-client": "^2.6.1",
+        "analytics-node": "^6.0.0",
+        "avsc": "5.7.7",
+        "axios": "^0.26.0",
+        "axios-mock-adapter": "^1.20.0",
+        "axios-retry": "^3.3.1",
+        "bitbucket": "^2.7.0",
+        "bottleneck": "^2.19.5",
+        "clubhouse-lib": "^0.13.0",
+        "commander": "^9.3.0",
+        "condoit": "^2.1.0",
+        "date-format": "^4.0.6",
+        "enquirer": "^2.3.6",
+        "faros-feeds-sdk": "^1.1.1",
+        "faros-js-client": "^0.2.41",
+        "fast-redact": "^3.0.2",
+        "fs-extra": "^11.1.0",
+        "git-url-parse": "^13.0.0",
+        "googleapis": "^108.0.0",
+        "graphql": "^16.3.0",
+        "graphql-request": "^5.0.0",
+        "is-retry-allowed": "^2.2.0",
+        "jenkins": "^0.28.1",
+        "json-schema-traverse": "^1.0.0",
+        "json-to-graphql-query": "^2.2.0",
+        "jsonata": "^1.8.5",
+        "jsonwebtoken": "^9.0.0",
+        "lodash": "^4.17.21",
+        "luxon": "^3.2.1",
+        "nock": "^13.1.0",
+        "object-sizeof": "^1.6.1",
+        "parse-diff": "^0.11.1",
+        "parse-link-header": "^2.0.0",
+        "pino": "^8.5.0",
+        "table": "^6.8.1",
+        "toposort": "^2.0.2",
+        "traverse": "^0.6.6",
+        "turndown": "^7.1.1",
+        "typescript-memoize": "^1.1.0",
+        "uuid": "^9.0.0",
+        "verror": "^1.10.1",
+        "victorops-api-client": "^1.0.2",
+        "zod": "^3.20.6"
+      },
       "devDependencies": {
         "@types/analytics-node": "^3.1.8",
         "@types/eslint": "^8.44.0",
@@ -238,14 +288,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.382.0.tgz",
-      "integrity": "sha512-K95GKLtpYdvWZvV7RYOMLevjLmpIKoTWdRFEUaMhtD5UBHLPoPM+1dTTNhyYwe/FX3gemAck+QXCw9V094Bz9A==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.385.0.tgz",
+      "integrity": "sha512-fimiDkwB78M55hUBYMXohAm1v28RPH5y+aVK8ZfzzrXlT3BaRcNWxa0iklniCNqWvF/Ycs4za5M3uoUNbcYuXw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.382.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
+        "@aws-sdk/client-sts": "3.385.0",
+        "@aws-sdk/credential-provider-node": "3.385.0",
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
@@ -326,6 +376,127 @@
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
+      "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.382.0",
+        "@aws-sdk/middleware-host-header": "3.379.1",
+        "@aws-sdk/middleware-logger": "3.378.0",
+        "@aws-sdk/middleware-recursion-detection": "3.378.0",
+        "@aws-sdk/middleware-sdk-sts": "3.379.1",
+        "@aws-sdk/middleware-signing": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.382.0",
+        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.382.0",
+        "@aws-sdk/util-user-agent-browser": "3.378.0",
+        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@smithy/config-resolver": "^2.0.1",
+        "@smithy/fetch-http-handler": "^2.0.1",
+        "@smithy/hash-node": "^2.0.1",
+        "@smithy/invalid-dependency": "^2.0.1",
+        "@smithy/middleware-content-length": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.1",
+        "@smithy/middleware-retry": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.1",
+        "@smithy/node-http-handler": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/smithy-client": "^2.0.1",
+        "@smithy/types": "^2.0.2",
+        "@smithy/url-parser": "^2.0.1",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.1",
+        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
+      "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.378.0",
+        "@aws-sdk/credential-provider-process": "3.378.0",
+        "@aws-sdk/credential-provider-sso": "3.382.0",
+        "@aws-sdk/credential-provider-web-identity": "3.378.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
+      "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.378.0",
+        "@aws-sdk/credential-provider-ini": "3.382.0",
+        "@aws-sdk/credential-provider-process": "3.378.0",
+        "@aws-sdk/credential-provider-sso": "3.382.0",
+        "@aws-sdk/credential-provider-web-identity": "3.378.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
+      "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.382.0",
+        "@aws-sdk/token-providers": "3.382.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
+      "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.382.0",
+        "@aws-sdk/types": "3.378.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -419,13 +590,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
-      "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.385.0.tgz",
+      "integrity": "sha512-VdSDwICW2cBttbdj1izu6VYflJbZZKu3/FSaJGuGu8SgTvRsa56g6E5xfbUfR/SCstuETObKLusSfQZ6yxUnzA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
+        "@aws-sdk/credential-provider-node": "3.385.0",
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
@@ -480,13 +651,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
-      "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.385.0.tgz",
+      "integrity": "sha512-WBIR5GdfUzCGzynQYX/TuCXw3KJCkHBk6bVAsO1YmfR68XKVAxWmJPKovlK/rR6LIuV+iwUMNludO+SkmG0efg==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.378.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
+        "@aws-sdk/credential-provider-sso": "3.385.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -500,14 +671,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
-      "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.385.0.tgz",
+      "integrity": "sha512-Lk8uu6jm/8OkbLX4Qnss8o5bnt0yQa0Tb7Azbh5/5otju5kStVAD2E+zMGrMP++NriGyZV87crduh0J8l4JUTA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-ini": "3.382.0",
+        "@aws-sdk/credential-provider-ini": "3.385.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
+        "@aws-sdk/credential-provider-sso": "3.385.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -536,12 +707,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
-      "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.385.0.tgz",
+      "integrity": "sha512-ETFnS+4ZKTAgT8boVpIpRuXA9wWGpNqOcI1RXtjsaIgQ9s8uNn2JPa8l71gZh861mzBC8Hadp1EpNu+43w4lkg==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.382.0",
-        "@aws-sdk/token-providers": "3.382.0",
+        "@aws-sdk/token-providers": "3.385.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -669,11 +840,10 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
-      "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.385.0.tgz",
+      "integrity": "sha512-2A2Y7/bU5EaxQwLwLy7ojs+Wy5VOBkIlGPH7ZcpPaoQ1Hscwn3Wvx/DZmOvbyYfZ1CbIFutoHJlVxh6KZldUDw==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.382.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -13572,9 +13742,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.2.tgz",
-      "integrity": "sha512-zKu9aWeSWTy1JgvxIpZveJKKsAr4+6uNMZ0Vf0KRwzl/UNZA3XjHiIl/0WwqLMkDwuHuDkT5xAgPA2jpKq4whA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+      "integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -16381,7 +16551,8 @@
       }
     },
     "@apidevtools/json-schema-ref-parser": {
-      "version": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
       "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
@@ -16391,7 +16562,8 @@
       }
     },
     "@atlassian/bitbucket-server": {
-      "version": "https://registry.npmjs.org/@atlassian/bitbucket-server/-/bitbucket-server-0.0.6.tgz",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@atlassian/bitbucket-server/-/bitbucket-server-0.0.6.tgz",
       "integrity": "sha512-92EpKlSPw0ZZXiS4Qt+1DKuDxSIntL2j8Q0CWc8o/nUNOJAW/D9szIgcef5VPTbVslHeb2C3gBSMNnETdykdmQ==",
       "requires": {
         "before-after-hook": "^1.1.0",
@@ -16551,14 +16723,14 @@
       }
     },
     "@aws-sdk/client-kms": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.382.0.tgz",
-      "integrity": "sha512-K95GKLtpYdvWZvV7RYOMLevjLmpIKoTWdRFEUaMhtD5UBHLPoPM+1dTTNhyYwe/FX3gemAck+QXCw9V094Bz9A==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.385.0.tgz",
+      "integrity": "sha512-fimiDkwB78M55hUBYMXohAm1v28RPH5y+aVK8ZfzzrXlT3BaRcNWxa0iklniCNqWvF/Ycs4za5M3uoUNbcYuXw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.382.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
+        "@aws-sdk/client-sts": "3.385.0",
+        "@aws-sdk/credential-provider-node": "3.385.0",
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
@@ -16637,6 +16809,114 @@
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sts": {
+          "version": "3.382.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
+          "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/credential-provider-node": "3.382.0",
+            "@aws-sdk/middleware-host-header": "3.379.1",
+            "@aws-sdk/middleware-logger": "3.378.0",
+            "@aws-sdk/middleware-recursion-detection": "3.378.0",
+            "@aws-sdk/middleware-sdk-sts": "3.379.1",
+            "@aws-sdk/middleware-signing": "3.379.1",
+            "@aws-sdk/middleware-user-agent": "3.382.0",
+            "@aws-sdk/types": "3.378.0",
+            "@aws-sdk/util-endpoints": "3.382.0",
+            "@aws-sdk/util-user-agent-browser": "3.378.0",
+            "@aws-sdk/util-user-agent-node": "3.378.0",
+            "@smithy/config-resolver": "^2.0.1",
+            "@smithy/fetch-http-handler": "^2.0.1",
+            "@smithy/hash-node": "^2.0.1",
+            "@smithy/invalid-dependency": "^2.0.1",
+            "@smithy/middleware-content-length": "^2.0.1",
+            "@smithy/middleware-endpoint": "^2.0.1",
+            "@smithy/middleware-retry": "^2.0.1",
+            "@smithy/middleware-serde": "^2.0.1",
+            "@smithy/middleware-stack": "^2.0.0",
+            "@smithy/node-config-provider": "^2.0.1",
+            "@smithy/node-http-handler": "^2.0.1",
+            "@smithy/protocol-http": "^2.0.1",
+            "@smithy/smithy-client": "^2.0.1",
+            "@smithy/types": "^2.0.2",
+            "@smithy/url-parser": "^2.0.1",
+            "@smithy/util-base64": "^2.0.0",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.0.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.1",
+            "@smithy/util-defaults-mode-node": "^2.0.1",
+            "@smithy/util-retry": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.382.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
+          "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.378.0",
+            "@aws-sdk/credential-provider-process": "3.378.0",
+            "@aws-sdk/credential-provider-sso": "3.382.0",
+            "@aws-sdk/credential-provider-web-identity": "3.378.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.382.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
+          "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.378.0",
+            "@aws-sdk/credential-provider-ini": "3.382.0",
+            "@aws-sdk/credential-provider-process": "3.378.0",
+            "@aws-sdk/credential-provider-sso": "3.382.0",
+            "@aws-sdk/credential-provider-web-identity": "3.378.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.382.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
+          "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.382.0",
+            "@aws-sdk/token-providers": "3.382.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.382.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
+          "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.382.0",
+            "@aws-sdk/types": "3.378.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.0",
+            "@smithy/types": "^2.0.2",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -16720,13 +17000,13 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
-      "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.385.0.tgz",
+      "integrity": "sha512-VdSDwICW2cBttbdj1izu6VYflJbZZKu3/FSaJGuGu8SgTvRsa56g6E5xfbUfR/SCstuETObKLusSfQZ6yxUnzA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
+        "@aws-sdk/credential-provider-node": "3.385.0",
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
@@ -16775,13 +17055,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
-      "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.385.0.tgz",
+      "integrity": "sha512-WBIR5GdfUzCGzynQYX/TuCXw3KJCkHBk6bVAsO1YmfR68XKVAxWmJPKovlK/rR6LIuV+iwUMNludO+SkmG0efg==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.378.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
+        "@aws-sdk/credential-provider-sso": "3.385.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -16792,14 +17072,14 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
-      "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.385.0.tgz",
+      "integrity": "sha512-Lk8uu6jm/8OkbLX4Qnss8o5bnt0yQa0Tb7Azbh5/5otju5kStVAD2E+zMGrMP++NriGyZV87crduh0J8l4JUTA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-ini": "3.382.0",
+        "@aws-sdk/credential-provider-ini": "3.385.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
+        "@aws-sdk/credential-provider-sso": "3.385.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -16822,12 +17102,12 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
-      "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.385.0.tgz",
+      "integrity": "sha512-ETFnS+4ZKTAgT8boVpIpRuXA9wWGpNqOcI1RXtjsaIgQ9s8uNn2JPa8l71gZh861mzBC8Hadp1EpNu+43w4lkg==",
       "requires": {
         "@aws-sdk/client-sso": "3.382.0",
-        "@aws-sdk/token-providers": "3.382.0",
+        "@aws-sdk/token-providers": "3.385.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -16928,11 +17208,10 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
-      "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+      "version": "3.385.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.385.0.tgz",
+      "integrity": "sha512-2A2Y7/bU5EaxQwLwLy7ojs+Wy5VOBkIlGPH7ZcpPaoQ1Hscwn3Wvx/DZmOvbyYfZ1CbIFutoHJlVxh6KZldUDw==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.382.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -17481,7 +17760,8 @@
       }
     },
     "@datadog/datadog-api-client": {
-      "version": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.3.0.tgz",
       "integrity": "sha512-PR0VooKg5PZq4ItqGHDC0LUcG0vxQLhD9q8H7bjkAG1rw05OMLrS9hKVX4GqvY7aMpJGeC5Xnn/WdQLiysNa7A==",
       "requires": {
         "@types/buffer-from": "^1.1.0",
@@ -17573,7 +17853,8 @@
       }
     },
     "@gitbeaker/node": {
-      "version": "https://registry.npmjs.org/@gitbeaker/node/-/node-35.8.1.tgz",
+      "version": "35.8.1",
+      "resolved": "https://registry.npmjs.org/@gitbeaker/node/-/node-35.8.1.tgz",
       "integrity": "sha512-g6rX853y61qNhzq9cWtxIEoe2KDeFBtXAeWMGWJnc3nz3WRump2pIICvJqw/yobLZqmTNt+ea6w3/n92Mnbn3g==",
       "requires": {
         "@gitbeaker/core": "^35.8.1",
@@ -19528,7 +19809,8 @@
       }
     },
     "@pagerduty/pdjs": {
-      "version": "https://registry.npmjs.org/@pagerduty/pdjs/-/pdjs-2.2.4.tgz",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@pagerduty/pdjs/-/pdjs-2.2.4.tgz",
       "integrity": "sha512-MMZvxos7PJnGJ8z3ijsu/gsMQLIfO8peeigKCjUDmviXk8FIaZZjX0X889NIKuFDhGirYbJVwGTaDYCEw4baLg==",
       "requires": {
         "browser-or-node": "^2.0.0",
@@ -19987,7 +20269,8 @@
       }
     },
     "@snyk/docker-registry-v2-client": {
-      "version": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.10.1.tgz",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.10.1.tgz",
       "integrity": "sha512-+mk983F/on2lL/W9bThRsCUU+56AyGY6TSZQQgKAaVbsyv3BrS6iln6J5NEWMd6WW4/+RdsV+qlMWdGwSUsCVg==",
       "requires": {
         "needle": "^3.2.0",
@@ -20612,7 +20895,8 @@
       }
     },
     "analytics-node": {
-      "version": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
       "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
       "requires": {
         "@segment/loosely-validate-event": "^2.0.0",
@@ -20816,7 +21100,8 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "avsc": {
-      "version": "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz",
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz",
       "integrity": "sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ=="
     },
     "axios": {
@@ -20828,7 +21113,8 @@
       }
     },
     "axios-mock-adapter": {
-      "version": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
       "integrity": "sha512-5NI1V/VK+8+JeTF8niqOowuysA4b8mGzdlMN/QnTnoXbYh4HZSNiopsDclN2g/m85+G++IrEtUdZaQ3GnaMsSA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
@@ -20986,7 +21272,8 @@
       }
     },
     "bitbucket": {
-      "version": "https://registry.npmjs.org/bitbucket/-/bitbucket-2.11.0.tgz",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bitbucket/-/bitbucket-2.11.0.tgz",
       "integrity": "sha512-YoUekxzBybCnwbh+9IzKE0sEWIp/nz1JId+yGc5qXFCFN1cZnUCDSesWYQokG1NvXXNE4oPdRezhwgyjBhIckg==",
       "requires": {
         "before-after-hook": "^2.1.0",
@@ -21061,7 +21348,8 @@
       }
     },
     "bottleneck": {
-      "version": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "bowser": {
@@ -21475,7 +21763,8 @@
       }
     },
     "clubhouse-lib": {
-      "version": "https://registry.npmjs.org/clubhouse-lib/-/clubhouse-lib-0.13.0.tgz",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/clubhouse-lib/-/clubhouse-lib-0.13.0.tgz",
       "integrity": "sha512-rFaZ1fod0Cb6g0juxW4OFC6n1y4hgECj8y4Ozgce5jX4vn5O2HUbK2dms/ahC92P/1/1ouQ8LAIDJXPCUl1Ezg==",
       "requires": {
         "cross-fetch": "^3.1.4",
@@ -21608,7 +21897,8 @@
       }
     },
     "condoit": {
-      "version": "https://registry.npmjs.org/condoit/-/condoit-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/condoit/-/condoit-2.1.0.tgz",
       "integrity": "sha512-jRaTbGuF3lj+RQ8hPMNMvhBcsDJpXVYNWMgtx6GCLdpDuRHE74gx8G4jUQfRHATjv2OaRANf/6gBNm5uTj7ZhA==",
       "requires": {
         "axios": "^0.21.4",
@@ -21892,7 +22182,8 @@
       "dev": true
     },
     "date-format": {
-      "version": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
       "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg=="
     },
     "dateformat": {
@@ -22666,7 +22957,8 @@
       "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
     },
     "faros-feeds-sdk": {
-      "version": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-1.1.7.tgz",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/faros-feeds-sdk/-/faros-feeds-sdk-1.1.7.tgz",
       "integrity": "sha512-awlu71LlddmBtTRoSMGfc8xavOOAJ/w7F6PsbwrW1KGxSmIoFTvtkNVaSKCB10IOPZD2hu5b01tg7wQ+9OGHVw==",
       "requires": {
         "@avro/common-types": "^0.2.0",
@@ -23419,7 +23711,8 @@
       }
     },
     "googleapis": {
-      "version": "https://registry.npmjs.org/googleapis/-/googleapis-108.0.1.tgz",
+      "version": "108.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-108.0.1.tgz",
       "integrity": "sha512-NKYTMfQH1xVl38Efj4UAwYq/9j+vc/iaqULfG3dSBK4vQHhsYKgKN6agMrgzlWo3NA8ivwb/0bToxZxnhxj7Bg==",
       "requires": {
         "google-auth-library": "^8.0.2",
@@ -23495,7 +23788,8 @@
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-request": {
-      "version": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.2.0.tgz",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.2.0.tgz",
       "integrity": "sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -24170,7 +24464,8 @@
       }
     },
     "jenkins": {
-      "version": "https://registry.npmjs.org/jenkins/-/jenkins-0.28.1.tgz",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/jenkins/-/jenkins-0.28.1.tgz",
       "integrity": "sha512-gcC4QUrP4VzdqOMHoVzh36XlJprxJkI2HGLQSY7w84KoCTVNDcR/8O00tYyXp9vrZOx4wl5zCXLVKMgH2IoyJQ==",
       "requires": {
         "papi": "^0.29.0"
@@ -24770,7 +25065,8 @@
       "dev": true
     },
     "jsonata": {
-      "version": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
       "integrity": "sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA=="
     },
     "jsonc-parser": {
@@ -24805,7 +25101,8 @@
       }
     },
     "jsonwebtoken": {
-      "version": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
       "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
       "requires": {
         "jws": "^3.2.2",
@@ -25941,7 +26238,8 @@
       "dev": true
     },
     "nock": {
-      "version": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
       "integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
       "requires": {
         "debug": "^4.1.0",
@@ -26490,7 +26788,8 @@
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
     "object-sizeof": {
-      "version": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.6.3.tgz",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.6.3.tgz",
       "integrity": "sha512-LGtilAKuDGKCcvu1Xg3UvAhAeJJlFmblo3faltmOQ80xrGwAHxnauIXucalKdTEksHp/Pq9tZGz1hfyEmjFJPQ==",
       "requires": {
         "buffer": "^5.6.0"
@@ -26825,7 +27124,8 @@
       }
     },
     "parse-diff": {
-      "version": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.11.1.tgz",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.11.1.tgz",
       "integrity": "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA=="
     },
     "parse-json": {
@@ -26943,9 +27243,9 @@
       "dev": true
     },
     "pino": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.2.tgz",
-      "integrity": "sha512-zKu9aWeSWTy1JgvxIpZveJKKsAr4+6uNMZ0Vf0KRwzl/UNZA3XjHiIl/0WwqLMkDwuHuDkT5xAgPA2jpKq4whA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+      "integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -28209,7 +28509,8 @@
       "dev": true
     },
     "table": {
-      "version": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
       "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "requires": {
         "ajv": "^8.0.1",
@@ -28404,7 +28705,8 @@
       }
     },
     "traverse": {
-      "version": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "treeverse": {
@@ -28510,7 +28812,8 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "turndown": {
-      "version": "https://registry.npmjs.org/turndown/-/turndown-7.1.2.tgz",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.2.tgz",
       "integrity": "sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==",
       "requires": {
         "domino": "^2.1.6"
@@ -28764,7 +29067,8 @@
       }
     },
     "victorops-api-client": {
-      "version": "https://registry.npmjs.org/victorops-api-client/-/victorops-api-client-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/victorops-api-client/-/victorops-api-client-1.0.2.tgz",
       "integrity": "sha512-5FzBpkCDYgLkFVl8TkgBsSb5TrAU0EdlRWKOg+yicWhwukb/8d9IBuRd9lcOiNcnNlIszVdTYZ1eFP1LxYiYxQ==",
       "requires": {
         "axios": "^0.21.1",
@@ -29045,7 +29349,8 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zod": {
-      "version": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     },
     "zstd-codec": {

--- a/sources/agileaccelerator-source/acceptance-test-config.yml
+++ b/sources/agileaccelerator-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: agileaccelerator-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        works: [ "cutoff" ]
+        works: ['cutoff']

--- a/sources/azure-repos-source/acceptance-test-config.yml
+++ b/sources/azure-repos-source/acceptance-test-config.yml
@@ -1,18 +1,19 @@
 connector_image: azure-repos-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/azure-workitems-source/acceptance-test-config.yml
+++ b/sources/azure-workitems-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: azure-workitems-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        tasks: [ "cutoff" ]
+        tasks: ['cutoff']

--- a/sources/azureactivedirectory-source/acceptance-test-config.yml
+++ b/sources/azureactivedirectory-source/acceptance-test-config.yml
@@ -1,18 +1,19 @@
 connector_image: azureactivedirectory-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/azurepipeline-source/acceptance-test-config.yml
+++ b/sources/azurepipeline-source/acceptance-test-config.yml
@@ -1,25 +1,26 @@
 connector_image: azurepipeline-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        builds: ["lastQueueTime"]
-        releases: ["lastCreatedOn"]
+        builds: ['lastQueueTime']
+        releases: ['lastCreatedOn']

--- a/sources/backlog-source/acceptance-test-config.yml
+++ b/sources/backlog-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: backlog-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        issues: ["lastUpdatedAt"]
+        issues: ['lastUpdatedAt']

--- a/sources/bamboohr-source/acceptance-test-config.yml
+++ b/sources/bamboohr-source/acceptance-test-config.yml
@@ -1,18 +1,19 @@
 connector_image: bamboohr-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/bitbucket-server-source/acceptance-test-config.yml
+++ b/sources/bitbucket-server-source/acceptance-test-config.yml
@@ -1,27 +1,28 @@
 connector_image: bitbucket-server-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        commits: ["PLAYG/repo1", "lastCommitterTimestamp"]
-        pull_request_activities: ["PLAYG/repo1", "lastUpdatedDate"]
-        pull_request_diffs: ["PLAYG/repo1", "lastUpdatedDate"]
-        pull_requests: ["PLAYG/repo1", "lastUpdatedDate"]
+        commits: ['PLAYG/repo1', 'lastCommitterTimestamp']
+        pull_request_activities: ['PLAYG/repo1', 'lastUpdatedDate']
+        pull_request_diffs: ['PLAYG/repo1', 'lastUpdatedDate']
+        pull_requests: ['PLAYG/repo1', 'lastUpdatedDate']

--- a/sources/bitbucket-source/acceptance-test-config.yml
+++ b/sources/bitbucket-source/acceptance-test-config.yml
@@ -1,29 +1,30 @@
 connector_image: bitbucket-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
       empty_streams:
         - bitbucket_branches
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        commits: ["RomanKyrnis/geekhub2019", "cutoff"]
-        issues: ["RomanKyrnis/geekhub2019", "cutoff"]
-        pull_request_activities: ["RomanKyrnis/geekhub2019", "cutoff"]
-        pull_requests: ["RomanKyrnis/geekhub2019", "cutoff"]
+        commits: ['RomanKyrnis/geekhub2019', 'cutoff']
+        issues: ['RomanKyrnis/geekhub2019', 'cutoff']
+        pull_request_activities: ['RomanKyrnis/geekhub2019', 'cutoff']
+        pull_requests: ['RomanKyrnis/geekhub2019', 'cutoff']

--- a/sources/buildkite-source/acceptance-test-config.yml
+++ b/sources/buildkite-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: buildkite-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        builds: ["lastCreatedAt"]
+        builds: ['lastCreatedAt']

--- a/sources/circleci-source/acceptance-test-config.yml
+++ b/sources/circleci-source/acceptance-test-config.yml
@@ -13,6 +13,7 @@ tests:
   basic_read:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/clickup-source/acceptance-test-config.yml
+++ b/sources/clickup-source/acceptance-test-config.yml
@@ -1,29 +1,30 @@
 connector_image: clickup-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
-      empty_streams: ["status_histories"]
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      empty_streams: ['status_histories']
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
       ignored_fields:
-        status_histories: ["current_status", "status_history"]
-        workspaces: ["members"]
+        status_histories: ['current_status', 'status_history']
+        workspaces: ['members']
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        status_histories: ["900900062157", "lastUpdatedDate"]
-        tasks: ["900900062157", "lastUpdatedDate"]
+        status_histories: ['900900062157', 'lastUpdatedDate']
+        tasks: ['900900062157', 'lastUpdatedDate']

--- a/sources/customer-io-source/acceptance-test-config.yml
+++ b/sources/customer-io-source/acceptance-test-config.yml
@@ -13,10 +13,10 @@ tests:
   basic_read:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'
-      expect_trace_message_on_failure: false
   incremental:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/incremental_configured_catalog.json'

--- a/sources/customer-io-source/acceptance-test-config.yml
+++ b/sources/customer-io-source/acceptance-test-config.yml
@@ -1,26 +1,27 @@
 connector_image: customer-io-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        campaigns: [ "cutoff" ]
-        campaign_actions: [ "cutoff" ]
-        newsletters: [ "cutoff" ]
+        campaigns: ['cutoff']
+        campaign_actions: ['cutoff']
+        newsletters: ['cutoff']

--- a/sources/datadog-source/acceptance-test-config.yml
+++ b/sources/datadog-source/acceptance-test-config.yml
@@ -1,26 +1,27 @@
 connector_image: datadog-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incidents: [ "lastModified" ]
-        metrics: [ "timestamp" ]
-        users: [ "lastModifiedAt" ]
+        incidents: ['lastModified']
+        metrics: ['timestamp']
+        users: ['lastModifiedAt']

--- a/sources/docker-source/acceptance-test-config.yml
+++ b/sources/docker-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: docker-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        tags: [ "lastCreatedAt" ]
+        tags: ['lastCreatedAt']

--- a/sources/example-source/acceptance-test-config.yml
+++ b/sources/example-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: example-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        builds: [ "cutoff" ]
+        builds: ['cutoff']

--- a/sources/firehydrant-source/acceptance-test-config.yml
+++ b/sources/firehydrant-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: firehydrant-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incidents: ["lastCreatedAt"]
+        incidents: ['lastCreatedAt']

--- a/sources/gitlab-ci-source/acceptance-test-config.yml
+++ b/sources/gitlab-ci-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: gitlab-ci-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        pipelines: [ "cutoff" ]
+        pipelines: ['cutoff']

--- a/sources/googlecalendar-source/acceptance-test-config.yml
+++ b/sources/googlecalendar-source/acceptance-test-config.yml
@@ -1,28 +1,29 @@
 connector_image: googlecalendar-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
       ignored_fields:
         events:
           - nextSyncToken
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        calendars: [ "lastSyncToken" ]
-        events: [ "lastSyncToken" ]
+        calendars: ['lastSyncToken']
+        events: ['lastSyncToken']

--- a/sources/harness-source/acceptance-test-config.yml
+++ b/sources/harness-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: harness-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        executions: [ "lastEndedAt" ]
+        executions: ['lastEndedAt']

--- a/sources/jenkins-source/acceptance-test-config.yml
+++ b/sources/jenkins-source/acceptance-test-config.yml
@@ -1,25 +1,26 @@
 connector_image: jenkins-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        builds: [ "newJobsLastCompletedBuilds", "Faros-test-job" ]
-        jobs: ["url"]
+        builds: ['newJobsLastCompletedBuilds', 'Faros-test-job']
+        jobs: ['url']

--- a/sources/octopus-source/acceptance-test-config.yml
+++ b/sources/octopus-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: example-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        builds: [ "cutoff" ]
+        builds: ['cutoff']

--- a/sources/okta-source/acceptance-test-config.yml
+++ b/sources/okta-source/acceptance-test-config.yml
@@ -1,18 +1,19 @@
 connector_image: okta-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/opsgenie-source/acceptance-test-config.yml
+++ b/sources/opsgenie-source/acceptance-test-config.yml
@@ -13,6 +13,7 @@ tests:
     basic_read:
         - config_path: "secrets/config.json"
           configured_catalog_path: "test_files/full_configured_catalog.json"
+      expect_trace_message_on_failure: false
     full_refresh:
         - config_path: "secrets/config.json"
           configured_catalog_path: "test_files/full_configured_catalog.json"

--- a/sources/pagerduty-source/acceptance-test-config.yml
+++ b/sources/pagerduty-source/acceptance-test-config.yml
@@ -1,26 +1,27 @@
 connector_image: pagerduty-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
-      empty_streams: ["priorities_resource", "teams"]
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      empty_streams: ['priorities_resource', 'teams']
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incident_log_entries: [ "lastSynced" ]
-        incidents: [ "lastSynced" ]
+        incident_log_entries: ['lastSynced']
+        incidents: ['lastSynced']

--- a/sources/phabricator-source/acceptance-test-config.yml
+++ b/sources/phabricator-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: phabricator-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        builds: [ "cutoff" ]
+        builds: ['cutoff']

--- a/sources/semaphoreci-source/acceptance-test-config.yml
+++ b/sources/semaphoreci-source/acceptance-test-config.yml
@@ -13,6 +13,7 @@ tests:
   basic_read:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/servicenow-source/acceptance-test-config.yml
+++ b/sources/servicenow-source/acceptance-test-config.yml
@@ -1,25 +1,26 @@
 connector_image: servicenow-source
 tests:
   spec:
-    - config_path: "test_files/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'test_files/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "test_files/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'test_files/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "test_files/config.json"
+    - config_path: 'test_files/config.json'
   basic_read:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "test_files/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'test_files/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incidents: [ "sys_updated_on" ]
-        users: [ "sys_updated_on" ]
+        incidents: ['sys_updated_on']
+        users: ['sys_updated_on']

--- a/sources/shortcut-source/acceptance-test-config.yml
+++ b/sources/shortcut-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: shortcut-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        iterations: ["lastUpdatedAt"]
+        iterations: ['lastUpdatedAt']

--- a/sources/squadcast-source/acceptance-test-config.yml
+++ b/sources/squadcast-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: squadcast-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incidents: [ "lastUpdatedAt" ]
+        incidents: ['lastUpdatedAt']

--- a/sources/statuspage-source/acceptance-test-config.yml
+++ b/sources/statuspage-source/acceptance-test-config.yml
@@ -1,25 +1,26 @@
 connector_image: statuspage-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incidents: [ "mz1ms2kfwq1s", "lastUpdatedAt" ]
-        component_uptimes: [ "mz1ms2kfwq1s", "n0d3k22k3trw", "rangeEnd" ]
+        incidents: ['mz1ms2kfwq1s', 'lastUpdatedAt']
+        component_uptimes: ['mz1ms2kfwq1s', 'n0d3k22k3trw', 'rangeEnd']

--- a/sources/statuspage-source/acceptance-test-config.yml
+++ b/sources/statuspage-source/acceptance-test-config.yml
@@ -14,6 +14,8 @@ tests:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'
       expect_trace_message_on_failure: false
+      empty_streams:
+        - component_uptimes
   full_refresh:
     - config_path: 'secrets/config.json'
       configured_catalog_path: 'test_files/full_configured_catalog.json'

--- a/sources/statuspage-source/resources/schemas/component_uptime.json
+++ b/sources/statuspage-source/resources/schemas/component_uptime.json
@@ -19,11 +19,9 @@
     },
     "warnings": {
       "type": "array",
-      "items": [
-        {
-          "type": "string"
-        }
-      ]
+      "items": {
+        "type": "string"
+      }
     },
     "id": {
       "type": "string"

--- a/sources/victorops-source/acceptance-test-config.yml
+++ b/sources/victorops-source/acceptance-test-config.yml
@@ -1,24 +1,25 @@
 connector_image: victorops-source
 tests:
   spec:
-    - config_path: "secrets/config.json"
-      spec_path: "resources/spec.json"
+    - config_path: 'secrets/config.json'
+      spec_path: 'resources/spec.json'
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "test_files/invalid_config.json"
-      status: "failed"
+    - config_path: 'secrets/config.json'
+      status: 'succeed'
+    - config_path: 'test_files/invalid_config.json'
+      status: 'failed'
   discovery:
-    - config_path: "secrets/config.json"
+    - config_path: 'secrets/config.json'
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
+      expect_trace_message_on_failure: false
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/full_configured_catalog.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/full_configured_catalog.json'
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "test_files/incremental_configured_catalog.json"
-      future_state_path: "test_files/abnormal_state.json"
+    - config_path: 'secrets/config.json'
+      configured_catalog_path: 'test_files/incremental_configured_catalog.json'
+      future_state_path: 'test_files/abnormal_state.json'
       cursor_paths:
-        incidents: [ "cutoff" ]
+        incidents: ['cutoff']


### PR DESCRIPTION
## Description

My VS Code auto-changed all the double quotes to single quotes in the acceptance-test-config.yml files, but the actual change was adding `expect_trace_message_on_failure: false`. This particular test assertion has been flaky in the past. For me specifically, I could never get this assertion to pass locally, but it was passing on GHA up until now. Since we should migrate our acceptance-test-config.ymls to use Airbyte's new format anyways, I'm disabling this assertion until we do so.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
