### PR TITLE
Statuspage source should factor component start date when fetching

### DIFF
--- a/sources/statuspage-source/src/statuspage.ts
+++ b/sources/statuspage-source/src/statuspage.ts
@@ -210,6 +210,7 @@ export class Statuspage {
   async *getComponentUptime(
     pageId: string,
     componentId: string,
+    componentStartDate: Date,
     rangeEndDate?: Date
   ): AsyncGenerator<ComponentUptime> {
     const path = `/pages/${pageId}/components/${componentId}/uptime`;
@@ -220,13 +221,11 @@ export class Statuspage {
       return `${year}-${month}-${day}`;
     };
 
-    // Can only get uptimes for the last 90 days.
-    const maxRangeStart = new Date();
-    maxRangeStart.setDate(maxRangeStart.getDate() - 90);
-    const maxCutoff =
-      this.startDate > maxRangeStart ? this.startDate : maxRangeStart;
+    const rangeStart = this.getComponentUptimeRangeStart(
+      componentStartDate,
+      rangeEndDate
+    );
 
-    const rangeStart = rangeEndDate > maxCutoff ? rangeEndDate : maxCutoff;
     // Use start of day to avoid partial days.
     const currentDate = new Date(getFormattedDate(new Date()));
 
@@ -244,5 +243,25 @@ export class Statuspage {
 
       rangeStart.setDate(rangeStart.getDate() + 1);
     }
+  }
+
+  private getComponentUptimeRangeStart(
+    componentStartDate: Date,
+    rangeEndDate: Date
+  ): Date {
+    // Can only get uptimes for the last 90 days.
+    const maxStartDate = new Date();
+    maxStartDate.setDate(maxStartDate.getDate() - 90);
+
+    // If the component was created after the max range start,
+    // use the component start date.
+    const startDate =
+      componentStartDate > maxStartDate ? componentStartDate : maxStartDate;
+
+    // If a defined cutoff date is after start date use that.
+    const cutoff = this.startDate > startDate ? this.startDate : startDate;
+
+    // Use range end date is defined and is after the cutoff date,
+    return rangeEndDate > cutoff ? rangeEndDate : cutoff;
   }
 }

--- a/sources/statuspage-source/src/streams/component_uptime.ts
+++ b/sources/statuspage-source/src/streams/component_uptime.ts
@@ -7,6 +7,7 @@ import {StatuspageStreamBase} from './common';
 interface StreamSlice {
   pageId: string;
   componentId: string;
+  startDate: string;
 }
 
 type ComponentUptimeState = Dictionary<Dictionary<{rangeEnd?: string}>>;
@@ -33,7 +34,11 @@ export class ComponentUptimes extends StatuspageStreamBase {
     }
     for (const page of await this.statuspage.getPages(this.cfg.page_ids)) {
       for await (const component of this.statuspage.getComponents(page.id)) {
-        yield {pageId: page.id, componentId: component.id};
+        yield {
+          pageId: page.id,
+          componentId: component.id,
+          startDate: component.start_date,
+        };
       }
     }
   }
@@ -55,6 +60,7 @@ export class ComponentUptimes extends StatuspageStreamBase {
     yield* this.statuspage.getComponentUptime(
       pageId,
       componentId,
+      new Date(streamSlice.startDate),
       rangeEndDate
     );
   }


### PR DESCRIPTION
## Description

- Statuspage source should factor in component start date when fetching otherwise it fails with 422 for an invalid range_start

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
