### PR TITLE
Fix mutating original range start value for statuspage

### DIFF
--- a/sources/statuspage-source/src/statuspage.ts
+++ b/sources/statuspage-source/src/statuspage.ts
@@ -221,9 +221,9 @@ export class Statuspage {
       return `${year}-${month}-${day}`;
     };
 
-    const rangeStart = this.getComponentUptimeRangeStart(
-      componentStartDate,
-      rangeEndDate
+    // Instantiate new date object to avoid mutating the original.
+    const rangeStart = new Date(
+      this.getComponentUptimeRangeStart(componentStartDate, rangeEndDate)
     );
 
     // Use start of day to avoid partial days.


### PR DESCRIPTION
## Description

- Fix the `rangeStart` mutating the original value since Date is an object so returning a reference by instantiating a new Date object

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
