### PR TITLE
Statuspage: Skip components with showcase disabled

### DIFF
--- a/sources/statuspage-source/src/streams/component_uptime.ts
+++ b/sources/statuspage-source/src/streams/component_uptime.ts
@@ -34,6 +34,9 @@ export class ComponentUptimes extends StatuspageStreamBase {
     }
     for (const page of await this.statuspage.getPages(this.cfg.page_ids)) {
       for await (const component of this.statuspage.getComponents(page.id)) {
+        if (!component.showcase) {
+          continue;
+        }
         yield {
           pageId: page.id,
           componentId: component.id,


### PR DESCRIPTION
## Description

- Status page uptimes should skip uptimes not enabled

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
