### PR TITLE
FAI-5601 Add choice to use variable for airbyte secrets/multiline

### DIFF
--- a/faros-airbyte-cdk/src/help.ts
+++ b/faros-airbyte-cdk/src/help.ts
@@ -1,5 +1,5 @@
 import {ok} from 'assert';
-import _ from 'lodash';
+import _, {startsWith} from 'lodash';
 import {upperFirst} from 'lodash';
 import {table} from 'table';
 import {Dictionary} from 'ts-essentials';
@@ -317,6 +317,18 @@ async function promptLeaf(row: TableRow, tail = false) {
       idx++;
       choices.push({message: `example ${idx} (${example})`, value: example});
     }
+  }
+
+  if (row.airbyte_secret || row.multiline) {
+    const variableName = row.path
+      .split('.')
+      .filter((part) => part[0].match(/[a-z]/i))
+      .join('_')
+      .toUpperCase();
+    choices.push({
+      message: `Use environment variable ${variableName}`,
+      value: `\${${variableName}}`,
+    });
   }
 
   let choice = ' ';

--- a/faros-airbyte-cdk/src/help.ts
+++ b/faros-airbyte-cdk/src/help.ts
@@ -1,5 +1,5 @@
 import {ok} from 'assert';
-import _, {startsWith} from 'lodash';
+import _ from 'lodash';
 import {upperFirst} from 'lodash';
 import {table} from 'table';
 import {Dictionary} from 'ts-essentials';


### PR DESCRIPTION
## Description

Allows to use an exported variable instead of entering a password/multiline string.

![Screenshot 2023-08-10 at 2 21 57 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/8321854f-8485-4644-8ebf-ebc61ccbde11)
![Screenshot 2023-08-10 at 2 22 38 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/8a466203-fc93-47af-87c3-2a4ea78baff5)



## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
