### PR TITLE
Fix handling of required array field

### DIFF
--- a/faros-airbyte-cdk/src/help.ts
+++ b/faros-airbyte-cdk/src/help.ts
@@ -295,7 +295,7 @@ async function promptLeaf(row: TableRow, tail = false) {
   if (row.constValue !== undefined) {
     return row.constValue;
   }
-  if (!row.required) {
+  if (!row.required || tail) {
     choices.push({
       // If `tail` is true, this means we're prompting for the second or later element of an array.
       message: tail ? 'Done' : 'Skip this section',


### PR DESCRIPTION
## Description

Fix bug where, if an array field is marked required, we never show an option (`Done`) to stop entering values

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
