### PR TITLE
Add agent field

### DIFF
--- a/sources/pagerduty-source/resources/schemas/incidentLogEntries.json
+++ b/sources/pagerduty-source/resources/schemas/incidentLogEntries.json
@@ -20,6 +20,26 @@
     "created_at": {
       "type": "string"
     },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "self": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        }
+      }
+    },
     "incident": {
       "type": "object",
       "properties": {

--- a/sources/pagerduty-source/src/pagerduty.ts
+++ b/sources/pagerduty-source/src/pagerduty.ts
@@ -72,6 +72,7 @@ export interface LogEntry extends PagerdutyObject {
   readonly incident: PagerdutyObject;
   readonly service: PagerdutyObject;
   readonly event_details?: Record<string, any>; // e.g. trigger events have "description" detail
+  readonly agent: PagerdutyObject;
 }
 
 export interface Incident extends PagerdutyObject {

--- a/sources/pagerduty-source/test/pagerduty.test.ts
+++ b/sources/pagerduty-source/test/pagerduty.test.ts
@@ -45,6 +45,13 @@ describe('Pagerduty', () => {
         self: 'self',
         html_url: 'url',
       },
+      agent: {
+        id: 'id',
+        type: 'Agent',
+        summary: 'Summary',
+        self: 'self',
+        html_url: 'url',
+      },
     };
 
     const response = pagination10000Response<LogEntry>(


### PR DESCRIPTION
## Description

The Agent field provides information about who made the respective log entry.
This PR adds that field to the data we ingest from the [Log Entries API
](https://developer.pagerduty.com/api-reference/c661e065403b5-list-log-entries)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

nil

## Migration notes

nil

## Extra info

nil
