### PR TITLE
Fix enum default

### DIFF
--- a/faros-airbyte-cdk/src/help.ts
+++ b/faros-airbyte-cdk/src/help.ts
@@ -338,7 +338,7 @@ async function promptLeaf(row: TableRow, tail = false) {
         if (row.default === choice) {
           choices.push({
             message: `${row.default} (default)`,
-            value: `Used default (${row.default}).`,
+            value: 'Used default.',
           });
         } else {
           choices.push({


### PR DESCRIPTION
## Description

The value [here](https://github.com/faros-ai/airbyte-connectors/blob/07516a04471d68bec9be1a3d343ed8b2398920f4/faros-airbyte-cdk/src/help.ts#L341) doesn't match the value in the switch [here](https://github.com/faros-ai/airbyte-connectors/blob/07516a04471d68bec9be1a3d343ed8b2398920f4/faros-airbyte-cdk/src/help.ts#L371)

As a result, we don't use the default value of an enum, but instead the string `Used default <some default>.`

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
