### PR TITLE
Allow configuring Customer.io API url

### DIFF
--- a/sources/customer-io-source/resources/spec.json
+++ b/sources/customer-io-source/resources/spec.json
@@ -13,6 +13,13 @@
         "description": "App API Key for Customer.io API authentication",
         "airbyte_secret": true
       },
+      "api_url": {
+        "type": "string",
+        "title": "API URL",
+        "description": "Customer.io API URL. Use https://api.customer.io/v1 for US, and https://api-eu.customer.io/v1 for EU.",
+        "default": "https://api.customer.io/v1",
+        "examples": ["https://api.customer.io/v1", "https://api-eu.customer.io/v1"]
+      },
       "cutoff_days": {
         "type": "integer",
         "title": "Cutoff Days",

--- a/sources/customer-io-source/src/customer-io/customer-io.ts
+++ b/sources/customer-io-source/src/customer-io/customer-io.ts
@@ -14,6 +14,7 @@ const CUSTOMER_IO_API_URL = 'https://api.customer.io/v1';
 
 export interface CustomerIOConfig {
   app_api_key: string;
+  api_url?: string;
   readonly cutoff_days: number;
 }
 
@@ -35,7 +36,7 @@ export class CustomerIO {
     return new CustomerIO(
       axiosInstance ??
         axios.create({
-          baseURL: CUSTOMER_IO_API_URL,
+          baseURL: config.api_url ?? CUSTOMER_IO_API_URL,
           timeout: 30000,
           responseType: 'json',
           headers: {Authorization: `Bearer ${config.app_api_key}`},


### PR DESCRIPTION
## Description

Allow configuring Customer.io API url

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

https://github.com/faros-ai/airbyte-connectors/issues/1118