### PR TITLE
Add request_timeout to the CircleCI spec

### DIFF
--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -6,8 +6,7 @@
     "type": "object",
     "required": [
       "token",
-      "project_names",
-      "cutoff_days"
+      "project_names"
     ],
     "additionalProperties": true,
     "properties": {
@@ -42,6 +41,12 @@
         "title": "API URL",
         "default": "https://circleci.com/api/v2",
         "description": "CircleCI API URL"
+      },
+      "request_timeout": {
+        "type": "integer",
+        "title": "Request Timeout",
+        "description": "The max time in milliseconds to wait for a request to complete (0 - no timeout).",
+        "default": 60000
       },
       "max_retries": {
         "type": "integer",

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -15,13 +15,15 @@ import {Job, Pipeline, Project, TestMetadata, Workflow} from './typings';
 const DEFAULT_API_URL = 'https://circleci.com/api/v2';
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_CUTOFF_DAYS = 90;
+const DEFAULT_REQUEST_TIMEOUT = 60000;
 
 export interface CircleCIConfig {
   readonly token: string;
   readonly project_names: ReadonlyArray<string>;
   readonly reject_unauthorized: boolean;
-  readonly cutoff_days: number;
+  readonly cutoff_days?: number;
   readonly url?: string;
+  readonly request_timeout?: number;
   readonly max_retries?: number;
 }
 
@@ -58,7 +60,7 @@ export class CircleCI {
           'Circle-Token': config.token,
         },
         httpsAgent: new https.Agent({rejectUnauthorized}),
-        timeout: 60000, // default is `0` (no timeout)
+        timeout: config.request_timeout ?? DEFAULT_REQUEST_TIMEOUT,
         // CircleCI responses can be are very large hence the infinity
         maxContentLength: Infinity,
         maxBodyLength: Infinity,


### PR DESCRIPTION
## Description

Also, removed `cutoff_days` from required fields, since it has a default.

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
