### PR TITLE
Fix asana tasks converter

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
@@ -77,7 +77,7 @@ export class Tasks extends AsanaConverter {
         updatedAt: Utils.toDate(task.modified_at),
         statusChangedAt: Utils.toDate(task.modified_at),
         parent,
-        creator: task.assignee ? {uid: task.assignee, source} : null,
+        creator: task.assignee ? {uid: task.assignee.gid, source} : null,
       },
     });
 
@@ -116,7 +116,7 @@ export class Tasks extends AsanaConverter {
         model: 'tms_TaskAssignment',
         record: {
           task: taskKey,
-          assignee: {uid: task.assignee, source},
+          assignee: {uid: task.assignee.gid, source},
         },
       });
     }


### PR DESCRIPTION
## Description

`assignee` is an object with a `gid`, as we can see from the example source output record below:

```{"type":"RECORD","record":{"stream":"tasks","data":{"gid":"1205346703408262","assignee":{"gid":"7440298482110"},"completed":false,"completed_at":null,"completed_by":null,"created_at":"2023-08-24T15:52:00.014Z","custom_fields":[],"dependencies":[],"dependents":[],"due_at":null,"due_on":"2023-08-31","followers":[{"gid":"7440298482110"}],"hearted":false,"hearts":[],"html_notes":"<body></body>","is_rendered_as_separator":false,"liked":false,"likes":[],"memberships":[{"project":{"gid":"1205346703408259"},"section":{"gid":"1205346703408260"}}],"modified_at":"2023-08-24T15:52:17.456Z","name":"Task 1","notes":"","num_hearts":0,"num_likes":0,"num_subtasks":0,"parent":null,"permalink_url":"https://app.asana.com/0/1205346703408259/1205346703408262","projects":[{"gid":"1205346703408259"}],"resource_type":"task","start_on":null,"tags":[],"resource_subtype":"default_task","workspace":{"gid":"1205346833089989"}},"emitted_at":1692976377750}}```

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
