### PR TITLE
Honor default Faros API URL

### DIFF
--- a/destinations/airbyte-faros-destination/resources/cloud.json
+++ b/destinations/airbyte-faros-destination/resources/cloud.json
@@ -2,8 +2,7 @@
   "type": "object",
   "title": "Cloud Edition",
   "required": [
-    "api_key",
-    "api_url"
+    "api_key"
   ],
   "properties": {
     "edition": {

--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -56,6 +56,7 @@ import {JSONataApplyMode, JSONataConverter} from './converters/jsonata';
 
 const PACKAGE_ROOT = path.join(__dirname, '..');
 const BASE_RESOURCES_DIR = path.join(PACKAGE_ROOT, 'resources');
+const DEFAULT_API_URL = 'https://prod.api.faros.ai';
 
 interface FarosDestinationState {
   readonly lastSynced: string;
@@ -184,16 +185,13 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
   }
 
   private async initCloud(config: DestinationConfig): Promise<void> {
-    if (!config.edition_configs.api_url) {
-      throw new VError('API url is not set');
-    }
     if (!config.edition_configs.api_key) {
       throw new VError('API key is not set');
     }
     const useGraphQLV2 = (config.edition_configs.graphql_api ?? 'v2') === 'v2';
     try {
       this.farosClientConfig = {
-        url: config.edition_configs.api_url,
+        url: config.edition_configs.api_url ?? DEFAULT_API_URL,
         apiKey: config.edition_configs.api_key,
         useGraphQLV2,
       };


### PR DESCRIPTION
## Description

`api_url` shouldn't be required since there's a default value in the spec

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
