### PR TITLE
[FAI-2451] Replacing CustomReports with Customreports

### DIFF
--- a/sources/workday-source/src/index.ts
+++ b/sources/workday-source/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'faros-airbyte-cdk';
 import VError from 'verror';
 
-import {CustomReports, OrgCharts, Orgs, People, Workers} from './streams';
+import {Customreports, OrgCharts, Orgs, People, Workers} from './streams';
 import {Workday} from './workday';
 
 export interface TokenCredentials {
@@ -59,7 +59,7 @@ export class WorkdaySource extends AirbyteSourceBase<WorkdayConfig> {
       new Orgs(config, this.logger),
       new People(config, this.logger),
       new Workers(config, this.logger),
-      new CustomReports(config, this.logger),
+      new Customreports(config, this.logger),
     ];
   }
 }

--- a/sources/workday-source/src/streams/customreports.ts
+++ b/sources/workday-source/src/streams/customreports.ts
@@ -4,7 +4,7 @@ import {Dictionary} from 'ts-essentials';
 import {WorkdayConfig} from '..';
 import {Workday} from '../workday';
 
-export class CustomReports extends AirbyteStreamBase {
+export class Customreports extends AirbyteStreamBase {
   constructor(
     private readonly cfg: WorkdayConfig,
     protected readonly logger: AirbyteLogger

--- a/sources/workday-source/src/streams/index.ts
+++ b/sources/workday-source/src/streams/index.ts
@@ -1,7 +1,7 @@
-import {CustomReports} from './customreports';
+import {Customreports} from './customreports';
 import {OrgCharts} from './orgcharts';
 import {Orgs} from './orgs';
 import {People} from './people';
 import {Workers} from './workers';
 
-export {People, Orgs, OrgCharts, Workers, CustomReports};
+export {People, Orgs, OrgCharts, Workers, Customreports};

--- a/sources/workday-source/test/index.test.ts
+++ b/sources/workday-source/test/index.test.ts
@@ -183,14 +183,14 @@ describe('index', () => {
     expect(items).toStrictEqual([...expected.data, ...expected.data]);
   });
   test('streams - customReports', async () => {
-    const fnCustomReports = jest.fn();
+    const fnCustomreports = jest.fn();
     const expected = readTestResourceFile('customreports.json');
 
     Workday.instance = jest.fn().mockImplementation(() => {
       return new Workday(
         logger,
         {
-          get: fnCustomReports.mockResolvedValue({data: expected}),
+          get: fnCustomreports.mockResolvedValue({data: expected}),
         } as any,
         0,
         'base-url',
@@ -205,7 +205,7 @@ describe('index', () => {
     for await (const item of iter) {
       items.push(item);
     }
-    expect(fnCustomReports).toHaveBeenCalledTimes(1);
+    expect(fnCustomreports).toHaveBeenCalledTimes(1);
     expect(items).toStrictEqual(expected.Report_Entry);
   });
 });


### PR DESCRIPTION
## Description
Stream name "customreports" was failing, so we changed the class name from "CustomReports" to "Customreports".
This made the fix. Thanks to @cjwooo for the tip.

## Type of change
- [ X] Bug fix
- [ ] New feature
- [ ] Breaking change

