### PR TITLE
Allow skipping connection check for Workday source

### DIFF
--- a/sources/workday-source/resources/spec.json
+++ b/sources/workday-source/resources/spec.json
@@ -108,6 +108,11 @@
                 "title": "Request Timeout",
                 "default": 60000,
                 "description": "The time allowed for a request to timeout (in milliseconds)."
+            },
+            "skipWorkerCheck": {
+                "type": "boolean",
+                "title": "Skip Worker Count Check",
+                "default": true
             }
         }
     }

--- a/sources/workday-source/src/index.ts
+++ b/sources/workday-source/src/index.ts
@@ -29,6 +29,7 @@ export interface WorkdayConfig extends AirbyteConfig {
   readonly limit?: number;
   readonly customReportName?: string;
   readonly timeout?: number;
+  readonly skipWorkerCheck?: boolean;
 }
 
 /** The main entry point. */

--- a/sources/workday-source/src/workday.ts
+++ b/sources/workday-source/src/workday.ts
@@ -32,7 +32,8 @@ export class Workday {
     private readonly api: AxiosInstance,
     private readonly limit: number,
     private readonly baseUrl: string,
-    private readonly tenant: string
+    private readonly tenant: string,
+    private readonly skipWorkerCheck: boolean
   ) {}
 
   static async instance(
@@ -81,7 +82,8 @@ export class Workday {
       api,
       cfg.limit ?? DEFAULT_PAGE_LIMIT,
       baseUrl.toString(),
-      cfg.tenant
+      cfg.tenant,
+      cfg.skipWorkerCheck ? cfg.skipWorkerCheck : true
     );
   }
 
@@ -113,12 +115,14 @@ export class Workday {
   }
 
   async checkConnection(): Promise<void> {
-    const res = [];
-    for await (const org of this.workers(1, 1)) {
-      res.push(org);
-    }
-    if (res.length <= 0) {
-      throw new VError('No workers were found');
+    if (this.skipWorkerCheck === false) {
+      const res = [];
+      for await (const org of this.workers(1, 1)) {
+        res.push(org);
+      }
+      if (res.length <= 0) {
+        throw new VError('No workers were found');
+      }
     }
   }
 

--- a/sources/workday-source/test/index.test.ts
+++ b/sources/workday-source/test/index.test.ts
@@ -19,7 +19,7 @@ function readTestResourceFile(fileName: string): any {
 }
 
 function getWorkdayInstance(logger, axios_instance, limit): Workday {
-  return new Workday(logger, axios_instance, limit, 'base-url', 'acme');
+  return new Workday(logger, axios_instance, limit, 'base-url', 'acme', true);
 }
 
 describe('index', () => {
@@ -194,7 +194,8 @@ describe('index', () => {
         } as any,
         0,
         'base-url',
-        'my_tenant'
+        'my_tenant',
+        true
       );
     });
 


### PR DESCRIPTION
We don't want to check for workers, so we have a skipWorkerCheck boolean.
