### PR TITLE
Truncate comment in `vcs_PullRequestComment` records to 1000 chars

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/commits.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/commits.ts
@@ -2,7 +2,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-js-client';
 
 import {DestinationModel, DestinationRecord} from '../converter';
-import {AzureReposConverter} from './common';
+import {AzureReposConverter, MAX_DESCRIPTION_LENGTH} from './common';
 import {Commit} from './models';
 
 export class Commits extends AzureReposConverter {
@@ -34,7 +34,7 @@ export class Commits extends AzureReposConverter {
       record: {
         sha: commitItem.commitId,
         uid: commitItem.commitId,
-        message: commitItem.comment,
+        message: commitItem.comment?.substring(0, MAX_DESCRIPTION_LENGTH),
         htmlUrl: commitItem.remoteUrl,
         createdAt: Utils.toDate(commitItem.committer?.date),
         author: {uid: commitItem.author?.email, source},

--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/common.ts
@@ -9,6 +9,8 @@ import {
   PullRequestStateCategory,
 } from './models';
 
+export const MAX_DESCRIPTION_LENGTH = 1000;
+
 export type ApplicationMapping = Record<
   string,
   {name: string; platform?: string}

--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/pull_requests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/pull_requests.ts
@@ -2,7 +2,7 @@ import {AirbyteRecord} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-js-client';
 
 import {DestinationModel, DestinationRecord} from '../converter';
-import {AzureReposConverter} from './common';
+import {AzureReposConverter, MAX_DESCRIPTION_LENGTH} from './common';
 import {PullRequest} from './models';
 
 export class PullRequests extends AzureReposConverter {
@@ -43,7 +43,7 @@ export class PullRequests extends AzureReposConverter {
           record: {
             number: comment.id,
             uid: comment.id.toString(),
-            comment: comment.content,
+            comment: comment.content?.substring(0, MAX_DESCRIPTION_LENGTH),
             createdAt: Utils.toDate(comment.publishedDate),
             updatedAt: Utils.toDate(comment.lastUpdatedDate),
             author: {uid: comment.author.uniqueName, source},

--- a/destinations/airbyte-faros-destination/src/converters/bitbucket-server/pull_request_activities.ts
+++ b/destinations/airbyte-faros-destination/src/converters/bitbucket-server/pull_request_activities.ts
@@ -7,6 +7,7 @@ import {
 } from 'faros-airbyte-common/bitbucket-server';
 import {Utils} from 'faros-js-client';
 
+import {MAX_DESCRIPTION_LENGTH} from '../azure-repos/common';
 import {DestinationModel, DestinationRecord} from '../converter';
 import {BitbucketServerConverter} from './common';
 
@@ -42,7 +43,10 @@ export class PullRequestActivities extends BitbucketServerConverter {
           number: id,
           uid: id.toString(),
           pullRequest,
-          comment: activity.comment.text,
+          comment: activity?.comment?.text?.substring(
+            0,
+            MAX_DESCRIPTION_LENGTH
+          ),
           createdAt: Utils.toDate(activity.comment.createdDate),
           updatedAt: Utils.toDate(activity.comment.updatedDate),
           author,

--- a/destinations/airbyte-faros-destination/src/converters/bitbucket/pull_request_activities.ts
+++ b/destinations/airbyte-faros-destination/src/converters/bitbucket/pull_request_activities.ts
@@ -91,7 +91,10 @@ export class PullRequestActivities extends BitbucketConverter {
         record: {
           number: id,
           uid: id.toString(),
-          comment: change?.content?.raw,
+          comment: change?.content?.raw?.substring(
+            0,
+            BitbucketCommon.MAX_DESCRIPTION_LENGTH
+          ),
           createdAt: Utils.toDate(change?.created_on),
           updatedAt: Utils.toDate(change?.updated_on),
           author: reviewer,

--- a/destinations/airbyte-faros-destination/src/converters/github/review_comments.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/review_comments.ts
@@ -34,7 +34,10 @@ export class ReviewComments extends GitHubConverter {
         record: {
           number: comment.id,
           uid: comment.id.toString(),
-          comment: comment.body,
+          comment: comment?.body?.substring(
+            0,
+            GitHubCommon.MAX_DESCRIPTION_LENGTH
+          ),
           createdAt: Utils.toDate(comment.created_at),
           updatedAt: Utils.toDate(comment.updated_at),
           author,


### PR DESCRIPTION
## Description

Avoid writing very long comment messages into the graph.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues
The actual error:
```
index row requires 9352 bytes maximum size is 8191
```
reported in https://github.com/faros-ai/faros-community-edition/issues/312