### PR TITLE
FAI-7679 - CircleCI test double counting fix

### DIFF
--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -41,7 +41,18 @@ export class Tests extends CircleCIStreamBase {
       since
     )) {
       for (const workflow of pipeline.workflows ?? []) {
+        const seenJobs = new Set<number>();
+
         for (const job of workflow.jobs ?? []) {
+          const jobNum = job.job_number;
+          if (seenJobs.has(jobNum)) {
+            this.logger.warn(
+              `Tests for job [${jobNum}] in project [${pipeline.project_slug}] has already been seen. Skipping second occurrence.`
+            );
+            continue;
+          }
+          seenJobs.add(jobNum);
+
           const tests = await this.circleCI.fetchTests(
             pipeline.project_slug,
             job.job_number

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -47,7 +47,7 @@ export class Tests extends CircleCIStreamBase {
           const jobNum = job.job_number;
           if (seenJobs.has(jobNum)) {
             this.logger.warn(
-              `Tests for job [${jobNum}] in project [${pipeline.project_slug}] has already been seen. Skipping second occurrence.`
+              `Tests for job [${jobNum}] in project [${pipeline.project_slug}] have already been seen. Skipping second occurrence.`
             );
             continue;
           }


### PR DESCRIPTION
## Description

There is a scenario where we are double counting tests for jobs that are rebuilt. We should only pull the tests for a given job number once.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change