### PR TITLE
FAI-7679 - CircleCI should ignore undefined run numbers

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/circleci/models.ts
+++ b/destinations/airbyte-faros-destination/src/converters/circleci/models.ts
@@ -77,6 +77,7 @@ export interface TestMetadata {
   project_slug: string;
   workflow_id: string;
   workflow_name: string;
+  job_id: string;
   job_number: number;
   job_started_at: Date;
   job_stopped_at: Date;

--- a/destinations/airbyte-faros-destination/src/converters/circleci/tests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/circleci/tests.ts
@@ -37,10 +37,10 @@ export class Tests extends CircleCIConverter {
     const test = record.record.data as TestMetadata;
     const res: DestinationRecord[] = [];
 
-    const testSuiteUid = `${test.pipeline_id}__${test.workflow_name}_${test.classname}`;
+    const testSuiteUid = `${test.pipeline_id}__${test.workflow_name}__${test.classname}`;
     const testCaseUid = `${testSuiteUid}__${test.name}`;
-    const testCaseResultUid = `${testCaseUid}__${test.job_number}`;
-    const testExecutionUid = `${testSuiteUid}__${test.job_number}`;
+    const testCaseResultUid = `${testCaseUid}__${test.job_id}`;
+    const testExecutionUid = `${testSuiteUid}__${test.job_id}`;
 
     // Write test case & test suite association only once
     if (!this.skipWritingTestCases && !this.testCases.has(testCaseUid)) {

--- a/sources/circleci-source/src/circleci/typings.ts
+++ b/sources/circleci-source/src/circleci/typings.ts
@@ -80,6 +80,7 @@ export interface TestMetadata {
   project_slug: string;
   workflow_id: string;
   workflow_name: string;
+  job_id: string;
   job_number: number;
   job_started_at: string;
   job_stopped_at: string;

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -71,6 +71,7 @@ export class Tests extends CircleCIStreamBase {
               project_slug: pipeline.project_slug,
               workflow_id: workflow.id,
               workflow_name: workflow.name,
+              job_id: job.id,
               job_number: job.job_number,
               job_started_at: job.started_at,
               job_stopped_at: job.stopped_at,

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -45,9 +45,15 @@ export class Tests extends CircleCIStreamBase {
 
         for (const job of workflow.jobs ?? []) {
           const jobNum = job.job_number;
+          if (jobNum === undefined) {
+            this.logger.debug(
+              `Job number for job [${job.id}] is undefined in project [${pipeline.project_slug}] - Skipping`
+            );
+            continue;
+          }
           if (seenJobs.has(jobNum)) {
             this.logger.warn(
-              `Tests for job [${jobNum}] in project [${pipeline.project_slug}] have already been seen. Skipping second occurrence.`
+              `Tests already seen for job [${jobNum}] in project [${pipeline.project_slug}] - Skipping additional occurrence`
             );
             continue;
           }

--- a/sources/circleci-source/test_files/tests.json
+++ b/sources/circleci-source/test_files/tests.json
@@ -25,6 +25,7 @@
     "project_slug": "gh/CircleCI-Public/api-preview-docs",
     "workflow_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
     "workflow_name": "build-and-test",
+    "job_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
     "job_number": 0,
     "job_started_at": "2019-08-24T14:15:22Z",
     "job_stopped_at": "2019-08-24T14:15:22Z"
@@ -55,6 +56,7 @@
     "project_slug": "gh/CircleCI-Public/api-preview-docs",
     "workflow_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
     "workflow_name": "build-and-test",
+    "job_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
     "job_number": 0,
     "job_started_at": "2019-08-24T14:15:22Z",
     "job_stopped_at": "2019-08-24T14:15:22Z"


### PR DESCRIPTION
## Description

The CircleCI connector incorrectly double counts tests when a run is rebuilt. I suspect that the `job_number` is not unique enough and is reused for the reruns. `job_id` should be unique enough. I also added logic to ignore a job's tests when `job_number` is undefined. There are some control jobs that don't have job numbers, for example an approval step.

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
