### PR TITLE
FAI-7679 - Dedup jobs shared by workflows

### DIFF
--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -40,23 +40,23 @@ export class Tests extends CircleCIStreamBase {
       streamSlice.projectName,
       since
     )) {
-      const seenJobs = new Set<string>();
+      const seenJobs = new Set<number>();
       for (const workflow of pipeline.workflows ?? []) {
         for (const job of workflow.jobs ?? []) {
-          if (job.job_number === undefined) {
+          const jobNum = job.job_number;
+          if (jobNum === undefined) {
             this.logger.debug(
               `Job number for job [${job.id}] is undefined in project [${pipeline.project_slug}] - Skipping`
             );
             continue;
           }
-
-          if (seenJobs.has(job.id)) {
+          if (seenJobs.has(jobNum)) {
             this.logger.warn(
-              `Tests already seen for job [${job.job_number}] in project [${pipeline.project_slug}] - Skipping additional occurrence`
+              `Tests already seen for job [${jobNum}] in project [${pipeline.project_slug}] - Skipping additional occurrence`
             );
             continue;
           }
-          seenJobs.add(job.id);
+          seenJobs.add(jobNum);
 
           const tests = await this.circleCI.fetchTests(
             pipeline.project_slug,

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -40,24 +40,23 @@ export class Tests extends CircleCIStreamBase {
       streamSlice.projectName,
       since
     )) {
+      const seenJobs = new Set<string>();
       for (const workflow of pipeline.workflows ?? []) {
-        const seenJobs = new Set<number>();
-
         for (const job of workflow.jobs ?? []) {
-          const jobNum = job.job_number;
-          if (jobNum === undefined) {
+          if (job.job_number === undefined) {
             this.logger.debug(
               `Job number for job [${job.id}] is undefined in project [${pipeline.project_slug}] - Skipping`
             );
             continue;
           }
-          if (seenJobs.has(jobNum)) {
+
+          if (seenJobs.has(job.id)) {
             this.logger.warn(
-              `Tests already seen for job [${jobNum}] in project [${pipeline.project_slug}] - Skipping additional occurrence`
+              `Tests already seen for job [${job.job_number}] in project [${pipeline.project_slug}] - Skipping additional occurrence`
             );
             continue;
           }
-          seenJobs.add(jobNum);
+          seenJobs.add(job.id);
 
           const tests = await this.circleCI.fetchTests(
             pipeline.project_slug,


### PR DESCRIPTION
## Description

Figured it out the root cause finally. Jobs are at the pipeline level and workflows can share jobs if a workflow is executed from the failed step. It will point to the same jobs up to the point of the failure and then create new jobs for the remained.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change