### PR TITLE
Refactor converters tests to call assertProcessedAndWrittenModels

### DIFF
--- a/destinations/airbyte-faros-destination/test/converters/agileaccelerator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/agileaccelerator.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/agileaccelerator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/agileaccelerator.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {agileacceleratorAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('agileaccelerator', () => {
   const logger = testLogger();
@@ -54,29 +55,6 @@ describe('agileaccelerator', () => {
       tms_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/asana.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/asana.test.ts
@@ -16,6 +16,7 @@ import {Users} from '../../src/converters/asana/users';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {asanaAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('asana', () => {
   const logger = testLogger();
@@ -68,30 +69,7 @@ describe('asana', () => {
       tms_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 
   describe('tasks', () => {

--- a/destinations/airbyte-faros-destination/test/converters/asana.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/asana.test.ts
@@ -1,7 +1,5 @@
 import {
-  AirbyteLog,
   AirbyteLogger,
-  AirbyteLogLevel,
   AirbyteRecord,
 } from 'faros-airbyte-cdk';
 import _ from 'lodash';

--- a/destinations/airbyte-faros-destination/test/converters/azure-repos.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azure-repos.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/azure-repos.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azure-repos.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {azurereposAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('azure-repos', () => {
   const logger = testLogger();
@@ -62,28 +63,6 @@ describe('azure-repos', () => {
       vcs_User: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/azureactivedirectory.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azureactivedirectory.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/azureactivedirectory.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azureactivedirectory.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {CLI, read} from './../cli';
 import {azureactivedirectoryAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('azureactivedirectory', () => {
   const logger = testLogger();
@@ -57,28 +58,6 @@ describe('azureactivedirectory', () => {
       org_TeamMembership: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {CLI, read} from './../cli';
 import {azurepipelineAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('azurepipeline', () => {
   const logger = testLogger();
@@ -57,28 +58,6 @@ describe('azurepipeline', () => {
       cicd_Release: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/backlog.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/backlog.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/backlog.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/backlog.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {backlogAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('backlog', () => {
   const logger = testLogger();
@@ -61,28 +62,6 @@ describe('backlog', () => {
       tms_User: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {bamboohrAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('bamboohr', () => {
   const logger = testLogger();
@@ -68,28 +69,6 @@ describe('bamboohr', () => {
       org_TeamMembership: 110,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/bitbucket-server.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bitbucket-server.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/bitbucket-server.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bitbucket-server.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {bitbucketServerAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('bitbucket-server', () => {
   const logger = testLogger();
@@ -68,29 +69,6 @@ describe('bitbucket-server', () => {
       vcs_User: 4,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/bitbucket.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bitbucket.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/bitbucket.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bitbucket.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {bitbucketAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('bitbucket', () => {
   const logger = testLogger();
@@ -82,29 +83,6 @@ describe('bitbucket', () => {
       vcs_User: 33,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/buildkite.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/buildkite.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/buildkite.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/buildkite.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {CLI, read} from './../cli';
 import {buildkiteAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('buildkite', () => {
   const logger = testLogger();
@@ -56,28 +57,6 @@ describe('buildkite', () => {
       cicd_Pipeline: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/circleci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/circleci.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/circleci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/circleci.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {circleciAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('circleci', () => {
   const logger = testLogger();
@@ -68,28 +69,6 @@ describe('circleci', () => {
       qa_TestSuiteTestCaseAssociation: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/clickup.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/clickup.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/clickup.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/clickup.test.ts
@@ -9,6 +9,7 @@ import {
   testLogger,
 } from '../testing-tools';
 import {clickupAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('clickup', () => {
   const logger = testLogger();
@@ -73,29 +74,6 @@ describe('clickup', () => {
       tms_User: 3,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/datadog.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/datadog.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {datadogAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('datadog', () => {
   const logger = testLogger();
@@ -77,30 +78,7 @@ describe('datadog', () => {
       ims_User: 14,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    const { processedTotal, writtenTotal } = await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
 
     const recordedRequests = await segmentMock.getSeenRequests();
     expect(recordedRequests.length).toBe(1);

--- a/destinations/airbyte-faros-destination/test/converters/datadog.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/datadog.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/docker.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/docker.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/docker.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/docker.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {dockerAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('docker', () => {
   const logger = testLogger();
@@ -60,28 +61,6 @@ describe('docker', () => {
       cicd_Repository: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import {readFileSync} from 'fs';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';

--- a/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/faros_feeds.test.ts
@@ -6,6 +6,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {farosFeedsAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('faros_feeds', () => {
   const logger = testLogger();
@@ -71,28 +72,6 @@ describe('faros_feeds', () => {
       vcs_User: 217,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/firehydrant.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/firehydrant.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/firehydrant.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/firehydrant.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {firehydrantAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('firehydrant', () => {
   const logger = testLogger();
@@ -75,30 +76,7 @@ describe('firehydrant', () => {
       tms_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    const { processedTotal, writtenTotal } = await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
 
     const recordedRequests = await segmentMock.getSeenRequests();
     expect(recordedRequests.length).toBe(1);

--- a/destinations/airbyte-faros-destination/test/converters/github.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/github.test.ts
@@ -18,6 +18,7 @@ import {
   testLogger,
 } from '../testing-tools';
 import {githubAllStreamsLog, githubLog, githubPGRawLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('github', () => {
   const logger = testLogger();
@@ -316,29 +317,6 @@ describe('github', () => {
       vcs_User: 195,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {gitlabCiAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('gitlab-ci', () => {
   const logger = testLogger();
@@ -58,29 +59,6 @@ describe('gitlab-ci', () => {
       cicd_Pipeline: 8,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab.test.ts
@@ -10,6 +10,7 @@ import {
   testLogger,
 } from '../testing-tools';
 import {gitlabAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('gitlab', () => {
   const logger = testLogger();
@@ -148,29 +149,6 @@ describe('gitlab', () => {
       vcs_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/googlecalendar.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/googlecalendar.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/googlecalendar.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/googlecalendar.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {googlecalendarAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('googlecalendar', () => {
   const logger = testLogger();
@@ -79,29 +80,6 @@ describe('googlecalendar', () => {
       geo_Location: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/harness.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/harness.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/harness.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/harness.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {harnessAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('harness', () => {
   const logger = testLogger();
@@ -52,29 +53,6 @@ describe('harness', () => {
       compute_Application: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/hygieia.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/hygieia.test.ts
@@ -9,6 +9,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {hygieiaAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('hygieia', () => {
   const logger = testLogger();
@@ -55,29 +56,6 @@ describe('hygieia', () => {
       cicd_Pipeline: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/jenkins.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jenkins.test.ts
@@ -7,6 +7,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {jenkinsAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('jenkins', () => {
   const logger = testLogger();
@@ -48,30 +49,7 @@ describe('jenkins', () => {
       .fromPairs()
       .value();
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    const { processedTotal, writtenTotal } = await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   }
 
   test('process records from all streams', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/jenkins.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jenkins.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 import {Dictionary} from 'ts-essentials';

--- a/destinations/airbyte-faros-destination/test/converters/jira.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jira.test.ts
@@ -12,6 +12,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {jiraAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('jira', () => {
   const logger = testLogger();
@@ -109,29 +110,6 @@ describe('jira', () => {
       tms_User: 29,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/notion.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/notion.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/notion.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/notion.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, sourceSpecificTempConfig, testLogger} from '../testing-tools';
 import {notionAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('notion', () => {
   const logger = testLogger();
@@ -86,29 +87,6 @@ describe('notion', () => {
       tms_User: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/octopus.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/octopus.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/octopus.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/octopus.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {octopusAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('octopus', () => {
   const logger = testLogger();
@@ -59,28 +60,6 @@ describe('octopus', () => {
       cicd_Release: 6,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/okta.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/okta.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {oktaAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('okta', () => {
   const logger = testLogger();
@@ -67,30 +68,7 @@ describe('okta', () => {
       org_TeamMembership: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    const { processedTotal, writtenTotal } = await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
 
     const recordedRequests = await segmentMock.getSeenRequests();
     expect(recordedRequests.length).toBe(1);

--- a/destinations/airbyte-faros-destination/test/converters/okta.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/okta.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/opsgenie.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/opsgenie.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/opsgenie.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/opsgenie.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {opsgenieAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('opsgenie', () => {
   const logger = testLogger();
@@ -74,30 +75,7 @@ describe('opsgenie', () => {
       tms_User: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    const { processedTotal, writtenTotal } = await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
 
     const recordedRequests = await segmentMock.getSeenRequests();
     expect(recordedRequests.length).toBe(1);

--- a/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
@@ -9,6 +9,7 @@ import {
   testLogger,
 } from '../testing-tools';
 import {pagerdutyAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('pagerduty', () => {
   const logger = testLogger();
@@ -76,29 +77,6 @@ describe('pagerduty', () => {
       org_ApplicationOwnership: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {phabricatorAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('phabricator', () => {
   const logger = testLogger();
@@ -70,29 +71,6 @@ describe('phabricator', () => {
       vcs_User: 4,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/semaphoreci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/semaphoreci.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/semaphoreci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/semaphoreci.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig} from '../testing-tools';
 import {semaphoreciAllStreamLogs} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('semaphoreci', () => {
   const mockttp = getLocal({debug: false, recordTraffic: false});
@@ -53,28 +54,6 @@ describe('semaphoreci', () => {
       cicd_Repository: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/servicenow.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/servicenow.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal, MockedEndpoint} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/servicenow.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/servicenow.test.ts
@@ -7,6 +7,7 @@ import {Incidents} from '../../src/converters/servicenow/incidents';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {servicenowAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('servicenow', () => {
   const logger = testLogger();
@@ -72,30 +73,7 @@ describe('servicenow', () => {
       ims_User: 2,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    const { processedTotal, writtenTotal } = await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
 
     const recordedRequests = await segmentMock.getSeenRequests();
     expect(recordedRequests.length).toBe(1);

--- a/destinations/airbyte-faros-destination/test/converters/shortcut.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/shortcut.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/shortcut.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/shortcut.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {shortcutAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('shortcut', () => {
   const logger = testLogger();
@@ -65,28 +66,6 @@ describe('shortcut', () => {
       tms_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/squadcast.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/squadcast.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/squadcast.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/squadcast.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {squadcastAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('squadcast', () => {
   const logger = testLogger();
@@ -59,29 +60,6 @@ describe('squadcast', () => {
       ims_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {statuspageAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('statuspage', () => {
   const logger = testLogger();
@@ -60,29 +61,6 @@ describe('statuspage', () => {
       ims_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/testrails.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/testrails.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/testrails.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/testrails.test.ts
@@ -6,6 +6,7 @@ import {Edition, InvalidRecordStrategy} from '../../src';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {testrailsAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('testrails', () => {
   const logger = testLogger();
@@ -64,28 +65,6 @@ describe('testrails', () => {
       qa_TestSuiteTestCaseAssociation: 4,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/utils.ts
+++ b/destinations/airbyte-faros-destination/test/converters/utils.ts
@@ -1,7 +1,7 @@
-import {CLI, read} from "../cli";
-import _ from "lodash";
-import {AirbyteLog, AirbyteLogLevel} from "faros-airbyte-cdk";
-import {Dictionary} from "ts-essentials";
+import {CLI, read} from '../cli';
+import _ from 'lodash';
+import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
 
 
 type ProcessedAndWrittenModels = {

--- a/destinations/airbyte-faros-destination/test/converters/utils.ts
+++ b/destinations/airbyte-faros-destination/test/converters/utils.ts
@@ -1,0 +1,38 @@
+import {CLI, read} from "../cli";
+import _ from "lodash";
+import {AirbyteLog, AirbyteLogLevel} from "faros-airbyte-cdk";
+import {Dictionary} from "ts-essentials";
+
+
+type ProcessedAndWrittenModels = {
+  processedTotal: number;
+  writtenTotal: number;
+}
+/** Function to assert records written and processed from stream */
+export async function assertProcessedAndWrittenModels<T>(processedByStream: Dictionary<number>, writtenByModel: Dictionary<number>, stdout: string, processed: Dictionary<T>, cli: CLI): Promise<ProcessedAndWrittenModels> {
+  const processedTotal = _(processedByStream).values().sum();
+  const writtenTotal = _(writtenByModel).values().sum();
+  expect(stdout).toMatch(`Processed ${processedTotal} records`);
+  expect(stdout).toMatch(`Would write ${writtenTotal} records`);
+  expect(stdout).toMatch('Errored 0 records');
+  expect(stdout).toMatch('Skipped 0 records');
+  expect(stdout).toMatch(
+    JSON.stringify(
+      AirbyteLog.make(
+        AirbyteLogLevel.INFO,
+        `Processed records by stream: ${JSON.stringify(processed)}`
+      )
+    )
+  );
+  expect(stdout).toMatch(
+    JSON.stringify(
+      AirbyteLog.make(
+        AirbyteLogLevel.INFO,
+        `Would write records by model: ${JSON.stringify(writtenByModel)}`
+      )
+    )
+  );
+  expect(await read(cli.stderr)).toBe('');
+  expect(await cli.wait()).toBe(0);
+  return { processedTotal, writtenTotal };
+}

--- a/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
@@ -1,4 +1,3 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 

--- a/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
@@ -5,6 +5,7 @@ import {getLocal} from 'mockttp';
 import {CLI, read} from '../cli';
 import {initMockttp, tempConfig, testLogger} from '../testing-tools';
 import {victoropsAllStreamsLog} from './data';
+import {assertProcessedAndWrittenModels} from "./utils";
 
 describe('victorops', () => {
   const logger = testLogger();
@@ -59,29 +60,6 @@ describe('victorops', () => {
       ims_User: 1,
     };
 
-    const processedTotal = _(processedByStream).values().sum();
-    const writtenTotal = _(writtenByModel).values().sum();
-    expect(stdout).toMatch(`Processed ${processedTotal} records`);
-    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-    expect(stdout).toMatch('Errored 0 records');
-    expect(stdout).toMatch('Skipped 0 records');
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Processed records by stream: ${JSON.stringify(processed)}`
-        )
-      )
-    );
-    expect(stdout).toMatch(
-      JSON.stringify(
-        AirbyteLog.make(
-          AirbyteLogLevel.INFO,
-          `Would write records by model: ${JSON.stringify(writtenByModel)}`
-        )
-      )
-    );
-    expect(await read(cli.stderr)).toBe('');
-    expect(await cli.wait()).toBe(0);
+    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
   });
 });


### PR DESCRIPTION
## Description

Refactor all converters tests to call assertProcessedAndWrittenModels util function to do the written, processed and stdout expects.
Main goal is to reduce code duplication between tests, that was warned in [this](https://github.com/faros-ai/airbyte-connectors/pull/1170#pullrequestreview-1682115009) PR by Sonarcloud check.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
