### PR TITLE
[FAI-8170] Azure Repos principalName Fix

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/models.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/models.ts
@@ -192,7 +192,7 @@ interface UserLink {
 export interface User {
   subjectKind: string;
   domain: string;
-  principalName: string;
+  principalName?: string;
   mailAddress: string;
   origin: string;
   originId: string;

--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/users.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/users.ts
@@ -11,10 +11,8 @@ export class Users extends AzureReposConverter {
   ];
 
   private checkUserItemValidity(userItem: User): boolean {
-    if (!userItem.principalName) {
-      return false;
-    }
-    return true;
+    // Add checks to record in this function
+    return !!userItem.principalName;
   }
 
   async convert(

--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/users.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/users.ts
@@ -10,12 +10,22 @@ export class Users extends AzureReposConverter {
     'vcs_User',
   ];
 
+  private checkUserItemValidity(userItem: User): boolean {
+    if (!userItem.principalName) {
+      return false;
+    }
+    return true;
+  }
+
   async convert(
     record: AirbyteRecord
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const source = this.streamName.source;
     const userItem = record.record.data as User;
     const res: DestinationRecord[] = [];
+    if (!this.checkUserItemValidity(userItem)) {
+      return res;
+    }
     const organizationName = this.getOrganizationFromUrl(
       userItem._links.self.href
     );
@@ -31,7 +41,6 @@ export class Users extends AzureReposConverter {
         user: {uid: userItem.principalName, source},
       },
     });
-
     res.push({
       model: 'vcs_User',
       record: {


### PR DESCRIPTION
## Description

If principalName is missing, we write User Records with empty uid.
This fix ensures principalName is included in order to properly write records.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

