### PR TITLE
FAI-8191 - Add global source option to compress state

### DIFF
--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -50,7 +50,10 @@ export enum AirbyteTraceFailureType {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AirbyteConfig {}
+export interface AirbyteConfig {
+  compress_state?: boolean;
+  [k: string]: any;
+}
 
 export function parseAirbyteMessage(s: string): AirbyteMessage {
   try {

--- a/faros-airbyte-cdk/src/sources/state.ts
+++ b/faros-airbyte-cdk/src/sources/state.ts
@@ -1,0 +1,31 @@
+import {Dictionary} from 'ts-essentials';
+import VError from 'verror';
+import zlib from 'zlib';
+
+export interface CompressedState {
+  format: string;
+  data: string;
+}
+
+export class State {
+  static compress(state: Dictionary<any, string>): CompressedState {
+    const zipped = zlib.gzipSync(JSON.stringify(state)).toString('base64');
+    return {format: 'base64/gzip', data: zipped};
+  }
+
+  static decompress(
+    data?: Dictionary<any>
+  ): Dictionary<any> | null | undefined {
+    if (data?.format && data?.data) {
+      switch (data.format) {
+        case 'base64/gzip': {
+          const unzipped = zlib.gunzipSync(Buffer.from(data.data, 'base64'));
+          return JSON.parse(unzipped.toString());
+        }
+        default:
+          throw new VError('Unsupported state format: %s', data.format);
+      }
+    }
+    return data;
+  }
+}


### PR DESCRIPTION
## Description

I made this optional instead of enforced because this is a public cdk and usually people want uncompressed state for easier inspection/debugging/modifying.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
