### PR TITLE
FAI-8225 | added org_EmployeeTool to model names

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/faros-feeds/model_names.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-feeds/model_names.ts
@@ -68,6 +68,7 @@ export const ALL_MODEL_NAMES = [
   'org_BoardOwnership',
   'org_Department',
   'org_Employee',
+  'org_EmployeeTool',
   'org_PipelineOwnership',
   'org_ProjectOwnership',
   'org_RepositoryOwnership',


### PR DESCRIPTION
## Description

- Added org_EmployeeTool to model names
  - records will start to be written with https://github.com/faros-ai/feeds/pull/1958

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
