### PR TITLE
remove toLower function when insert teamMembership relation

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/github/team_memberships.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/team_memberships.ts
@@ -22,7 +22,7 @@ export class TeamMemberships extends GitHubConverter {
       source,
     };
     const user = {
-      uid: toLower(membership.username),
+      uid: membership.username,
       source,
     };
 


### PR DESCRIPTION
## Description

Remove toLower funtion when insert user on team_membership stream, because this does not match with user when is created on stream user, on stream commit, on stream pull_request, and many other. 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
