### PR TITLE
fix: validate commit author is not empty

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/github/commits.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/commits.ts
@@ -24,10 +24,9 @@ export class Commits extends GitHubConverter {
 
     if (!repository) return res;
 
-    const author =
-      commit.author && Object.keys(commit.author).length != 0
-        ? {uid: commit.author.login, source}
-        : null;
+    const author = commit.author?.login
+      ? {uid: commit.author.login, source}
+      : null;
 
     res.push({
       model: 'vcs_Commit',

--- a/destinations/airbyte-faros-destination/src/converters/github/commits.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/commits.ts
@@ -24,7 +24,10 @@ export class Commits extends GitHubConverter {
 
     if (!repository) return res;
 
-    const author = commit.author ? {uid: commit.author.login, source} : null;
+    const author =
+      commit.author && Object.keys(commit.author).length != 0
+        ? {uid: commit.author.login, source}
+        : null;
 
     res.push({
       model: 'vcs_Commit',

--- a/destinations/airbyte-faros-destination/src/converters/github/pull_request_commits.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/pull_request_commits.ts
@@ -1,10 +1,10 @@
 import {AirbyteRecord} from 'faros-airbyte-cdk';
+import {Utils} from 'faros-js-client';
 
 import {RepoKey} from '../common/vcs';
 import {DestinationModel, DestinationRecord} from '../converter';
 import {GitHubCommon} from './common';
 import {GitHubConverter} from './common';
-import {Utils} from 'faros-js-client';
 
 export class PullRequestCommits extends GitHubConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
@@ -25,7 +25,10 @@ export class PullRequestCommits extends GitHubConverter {
 
     if (!repository) return [];
 
-    const author = prCommit.author ? {uid: prCommit.author.login, source} : null;
+    const author =
+      prCommit.author && Object.keys(prCommit.author).length != 0
+        ? {uid: prCommit.author.login, source}
+        : null;
 
     const commit = {
       uid: prCommit.sha,

--- a/destinations/airbyte-faros-destination/src/converters/github/pull_request_commits.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/pull_request_commits.ts
@@ -25,10 +25,9 @@ export class PullRequestCommits extends GitHubConverter {
 
     if (!repository) return [];
 
-    const author =
-      prCommit.author && Object.keys(prCommit.author).length != 0
-        ? {uid: prCommit.author.login, source}
-        : null;
+    const author = prCommit.author?.login
+      ? {uid: prCommit.author.login, source}
+      : null;
 
     const commit = {
       uid: prCommit.sha,

--- a/destinations/airbyte-faros-destination/src/converters/github/releases.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/releases.ts
@@ -24,10 +24,9 @@ export class Releases extends GitHubConverter {
 
     if (!repository) return res;
 
-    const author =
-      release.author && Object.keys(release.author).length != 0
-        ? {uid: release.author.login, source}
-        : null;
+    const author = release.author?.login
+      ? {uid: release.author.login, source}
+      : null;
 
     res.push({
       model: 'cicd_Release',

--- a/destinations/airbyte-faros-destination/src/converters/github/releases.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/releases.ts
@@ -24,7 +24,10 @@ export class Releases extends GitHubConverter {
 
     if (!repository) return res;
 
-    const author = release.author ? {uid: release.author.login, source} : null;
+    const author =
+      release.author && Object.keys(release.author).length != 0
+        ? {uid: release.author.login, source}
+        : null;
 
     res.push({
       model: 'cicd_Release',


### PR DESCRIPTION
## Description

Validate that `author` key on response from github api is not empty. This is caused when a un-named user is used as a commit author. The log error is :

` Failure reason: Failed to write vcs_Commit record with query 'mutation { insert_vcs_Commit_one (object: {uid: "COMMIT_SHA", sha: "COMMIT_SHA", message: "Release\n\n - 1.2.1", vcs_User: {data: {source: "GitHub"}, on_conflict: {constraint: vcs_User_pkey, update_columns: [source, uid]}}, createdAt: "2023-10-18T21:51:40.000Z", vcs_Repository: {data: {name: "my-repository", uid: "my-repository", vcs_Organization: {data: {uid: "my-org", source: "GitHub"}, on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}}}, on_conflict: {constraint: vcs_Repository_pkey, update_columns: [organization, uid]}}, origin: "github_source"}, on_conflict: {constraint: vcs_Commit_pkey, update_columns: [author, createdAt, message, origin, sha]}) { id refreshedAt } }': [{"extensions":{"path":"$.selectionSet.insert_vcs_Commit_one.args.object[0].vcs_User.data","code":"constraint-violation"},"message":"Not-NULL violation. null value in column \"uid\" of relation \"vcs_User\" violates not-null constraint"}]`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues


## Extra info

> Add any additional information
