### PR TITLE
FAI-8599: Fix serialization of timestamptz key

### DIFF
--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -80,6 +80,14 @@ exports[`graphql-client write batch upsert on_conflict update_columns bug 4`] = 
 
 exports[`graphql-client write batch upsert record with null primary key field 1`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"faros-ai\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt source uid } } }"`;
 
+exports[`graphql-client write batch upsert record with timestamptz primary key field 1`] = `"mutation { insert_vcs_User (objects: [{uid: \\"dbruno21\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_User_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 2`] = `"mutation { insert_vcs_Organization (objects: [{uid: \\"princode-ar\\", source: \\"GitHub\\"}], on_conflict: {constraint: vcs_Organization_pkey, update_columns: [source, uid]}) { returning { id refreshedAt source uid } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 3`] = `"mutation { insert_vcs_UserTool (objects: [{tool: {category: \\"GitHubCopilot\\", detail: \\"\\"}, userId: \\"65ecc2833915a71fb0157d2b0d3d9e2b0c6de441\\", organizationId: \\"d48dfb1908821e827f371cf370964d7131b69f4c\\"}], on_conflict: {constraint: vcs_UserTool_pkey, update_columns: [organizationId, tool, userId]}) { returning { id refreshedAt organizationId tool userId } } }"`;
+
+exports[`graphql-client write batch upsert record with timestamptz primary key field 4`] = `"mutation { insert_vcs_UserToolUsage (objects: [{usedAt: \\"2021-10-14T00:53:33-06:00\\", origin: \\"mytestsource\\", userToolId: \\"f1e4d99accb71ba8ac1b8a1204f84b8211909212\\"}], on_conflict: {constraint: vcs_UserToolUsage_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt usedAt userToolId } } }"`;
+
 exports[`graphql-client write batch upsert self-referent model 1`] = `"mutation { insert_org_Employee (objects: [{uid: \\"7\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [uid]}) { returning { id refreshedAt uid } } }"`;
 
 exports[`graphql-client write batch upsert self-referent model 2`] = `"mutation { insert_org_Employee (objects: [{uid: \\"9\\", origin: \\"mytestsource\\"}], on_conflict: {constraint: org_Employee_pkey, update_columns: [origin, refreshedAt]}) { returning { id refreshedAt uid } } }"`;

--- a/destinations/airbyte-faros-destination/test/resources/hasura-schema.json
+++ b/destinations/airbyte-faros-destination/test/resources/hasura-schema.json
@@ -26,6 +26,15 @@
     "vcs_User": [
       "source",
       "uid"
+    ],
+    "vcs_UserTool": [
+      "organizationId",
+      "tool",
+      "userId"
+    ],
+    "vcs_UserToolUsage": [
+      "usedAt",
+      "userToolId"
     ]
   },
   "scalars": {
@@ -120,6 +129,22 @@
       "source": "String",
       "type": "jsonb",
       "uid": "String"
+    },
+    "vcs_UserTool": {
+      "endedAt": "timestamptz",
+      "inactive": "Boolean",
+      "organizationId": "String",
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "startedAt": "timestamptz",
+      "tool": "jsonb",
+      "userId": "String"
+    },
+    "vcs_UserToolUsage": {
+      "origin": "String",
+      "refreshedAt": "timestamptz",
+      "usedAt": "timestamptz",
+      "userToolId": "String"
     }
   },
   "references": {
@@ -244,7 +269,41 @@
         "foreignKey": "repositoryId"
       }
     },
-    "vcs_User": {}
+    "vcs_User": {},
+    "vcs_UserTool": {
+      "organizationId": {
+        "field": "organization",
+        "model": "vcs_Organization",
+        "foreignKey": "organizationId"
+      },
+      "organization": {
+        "field": "organization",
+        "model": "vcs_Organization",
+        "foreignKey": "organizationId"
+      },
+      "userId": {
+        "field": "user",
+        "model": "vcs_User",
+        "foreignKey": "userId"
+      },
+      "user": {
+        "field": "user",
+        "model": "vcs_User",
+        "foreignKey": "userId"
+      }
+    },
+    "vcs_UserToolUsage": {
+      "userToolId": {
+        "field": "userTool",
+        "model": "vcs_UserTool",
+        "foreignKey": "userToolId"
+      },
+      "userTool": {
+        "field": "userTool",
+        "model": "vcs_UserTool",
+        "foreignKey": "userToolId"
+      }
+    }
   },
   "backReferences": {},
   "sortedModelDependencies": [
@@ -253,6 +312,8 @@
     "vcs_PullRequest",
     "vcs_Commit",
     "vcs_Repository",
+    "vcs_UserToolUsage",
+    "vcs_UserTool",
     "vcs_Organization",
     "vcs_User"
   ],
@@ -263,6 +324,8 @@
     "vcs_Commit",
     "vcs_Organization",
     "vcs_Repository",
-    "vcs_User"
+    "vcs_User",
+    "vcs_UserTool",
+    "vcs_UserToolUsage"
   ]
 }


### PR DESCRIPTION
## Description

Ensure that `timestamptz` primary keys are serialized consistently going into and out of the GraphQL database.   The batch upsert algorithm relies on serialization to compare and match keys of records in memory with those inserted into the GraphQL database.

In the case that led to this change, the primary key in the imported data used local timezone (e.g. `2021-10-14T00:53:33-06:00`) and the GraphQL database returned the same as UTC (e.g. `2021-10-14T06:53:33+00:00`).  The mismatch in timezones led to an assertion in the data processing.

We fixed this by enhancing the serialization logic to consider the type of the key field.  If we encounter a `timestamptz` field we normalize to epochs ensuring that timezones are irrelevant.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
