### PR TITLE
FAI-8579 - Added Files Source with S3 support

### DIFF
--- a/.github/workflows/skip-test-sources.txt
+++ b/.github/workflows/skip-test-sources.txt
@@ -9,6 +9,7 @@ datadog-source
 docker-source
 faros-graphdoctor-source
 faros-graphql-source
+files-source
 gitlab-ci-source
 googlecalendar-source
 harness-source

--- a/sources/files-source/bin/main
+++ b/sources/files-source/bin/main
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const {mainCommand} = require('../lib');
+
+mainCommand().parseAsync(process.argv);

--- a/sources/files-source/package.json
+++ b/sources/files-source/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "files-source",
+  "version": "0.0.1",
+  "description": "Files source",
+  "keywords": [
+    "airbyte",
+    "source",
+    "files"
+  ],
+  "homepage": "https://www.faros.ai",
+  "author": "Faros AI, Inc.",
+  "license": "Apache-2.0",
+  "files": [
+    "lib/",
+    "resources/"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "main": "./lib",
+  "scripts": {
+    "build": "tsc -p src",
+    "clean": "rm -rf lib node_modules out",
+    "fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts' && npm run lint -- --fix",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "prepare": "npm run build",
+    "test": "jest --verbose --color",
+    "test-cov": "jest --coverage --verbose --color",
+    "watch": "tsc -b -w src test"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.377.0",
+    "faros-airbyte-cdk": "0.0.1",
+    "verror": "^1.10.1"
+  },
+  "jest": {
+    "coverageDirectory": "out/coverage",
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "<rootDir>/test/"
+    ],
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testTimeout": 10000,
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "test/tsconfig.json"
+      }
+    }
+  }
+}

--- a/sources/files-source/resources/schemas/files.json
+++ b/sources/files-source/resources/schemas/files.json
@@ -2,8 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "type": {
+      "type": "string"
+    },
     "fileName": {
       "type": "string"
+    },
+    "lastModified": {
+      "type": "number"
     },
     "content": {
       "type": "string"

--- a/sources/files-source/resources/schemas/files.json
+++ b/sources/files-source/resources/schemas/files.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "type": {
+    "filesSource": {
       "type": "string"
     },
     "fileName": {

--- a/sources/files-source/resources/schemas/files.json
+++ b/sources/files-source/resources/schemas/files.json
@@ -11,7 +11,7 @@
     "lastModified": {
       "type": "number"
     },
-    "content": {
+    "contents": {
       "type": "string"
     }
   }

--- a/sources/files-source/resources/schemas/files.json
+++ b/sources/files-source/resources/schemas/files.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "fileName": {
+      "type": "string"
+    },
+    "content": {
+      "type": "string"
+    }
+  }
+}

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -66,7 +66,7 @@
               },
               "aws_session_token": {
                 "order": 4,
-                "title": "AWS Session Token",
+                "title": "AWS Session Token (Optional)",
                 "description": "AWS Session Token",
                 "type": "string",
                 "airbyte_secret": true

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -1,0 +1,92 @@
+{
+  "documentationUrl": "https://docs.faros.ai",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Files Spec",
+    "type": "object",
+    "required": [
+      "files_source"
+    ],
+    "additionalProperties": true,
+    "properties": {
+      "files_source": {
+        "order": 1,
+        "title": "Files Source",
+        "description": "Only S3 supported",
+        "type": "object",
+        "oneOf": [
+          {
+            "order": 0,
+            "title": "S3",
+            "type": "object",
+            "required": [
+              "files_source",
+              "path",
+              "aws_region",
+              "aws_access_key_id",
+              "aws_secret_access_key"
+            ],
+            "properties": {
+              "files_source": {
+                "order": 0,
+                "type": "string",
+                "const": "S3"
+              },
+              "path": {
+                "order": 1,
+                "title": "Path",
+                "description": "Path to files in an S3 bucket",
+                "type": "string",
+                "examples": [
+                  "s3://my-bucket/path/to/files"
+                ]
+              },
+              "aws_region": {
+                "order": 2,
+                "title": "AWS Region",
+                "description": "AWS Region",
+                "type": "string",
+                "examples": [
+                  "us-east-1"
+                ]
+              },
+              "aws_access_key_id": {
+                "order": 2,
+                "title": "AWS Access Key Id",
+                "description": "AWS Access Key Id",
+                "type": "string",
+                "airbyte_secret": true
+              },
+              "aws_secret_access_key": {
+                "order": 3,
+                "title": "AWS Secret Access Key",
+                "description": "AWS Secret Access Key",
+                "type": "string",
+                "airbyte_secret": true
+              },
+              "aws_session_token": {
+                "order": 4,
+                "title": "AWS Session Token",
+                "description": "AWS Session Token",
+                "type": "string",
+                "airbyte_secret": true
+              }
+            }
+          }
+        ]
+      },
+      "stream_name": {
+        "order": 2,
+        "title": "Stream Name",
+        "description": "Name of the data stream",
+        "type": "string",
+        "default": "files",
+        "examples": [
+          "sales",
+          "customers",
+          "orders"
+        ]
+      }
+    }
+  }
+}

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -20,14 +20,14 @@
             "title": "S3",
             "type": "object",
             "required": [
-              "files_source",
+              "source_type",
               "path",
               "aws_region",
               "aws_access_key_id",
               "aws_secret_access_key"
             ],
             "properties": {
-              "files_source": {
+              "source_type": {
                 "order": 0,
                 "type": "string",
                 "const": "S3"
@@ -70,6 +70,17 @@
                 "description": "AWS Session Token",
                 "type": "string",
                 "airbyte_secret": true
+              },
+              "file_processing_strategy": {
+                "order": 5,
+                "type": "string",
+                "title": "File Processing Strategy",
+                "description": "Strategy to use for deciding whether to process or ignore files.",
+                "default": "PROCESS_ALL_FILES",
+                "enum": [
+                  "PROCESS_ALL_FILES",
+                  "IMMUTABLE_LEXICOGRAPHICAL_ORDER"
+                ]
               }
             }
           }

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -51,28 +51,28 @@
                 ]
               },
               "aws_access_key_id": {
-                "order": 2,
+                "order": 3,
                 "title": "AWS Access Key Id",
                 "description": "AWS Access Key Id (required IAM permissions: s3:ListBucket, s3:GetObject)",
                 "type": "string",
                 "airbyte_secret": true
               },
               "aws_secret_access_key": {
-                "order": 3,
+                "order": 4,
                 "title": "AWS Secret Access Key",
                 "description": "AWS Secret Access Key",
                 "type": "string",
                 "airbyte_secret": true
               },
               "aws_session_token": {
-                "order": 4,
+                "order": 5,
                 "title": "AWS Session Token (Optional)",
                 "description": "AWS Session Token",
                 "type": "string",
                 "airbyte_secret": true
               },
               "file_processing_strategy": {
-                "order": 5,
+                "order": 6,
                 "type": "string",
                 "title": "File Processing Strategy",
                 "description": "Strategy to use for deciding whether to process or ignore files.",

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -53,7 +53,7 @@
               "aws_access_key_id": {
                 "order": 2,
                 "title": "AWS Access Key Id",
-                "description": "AWS Access Key Id",
+                "description": "AWS Access Key Id (required IAM permissions: s3:ListBucket, s3:GetObject)",
                 "type": "string",
                 "airbyte_secret": true
               },

--- a/sources/files-source/src/files-reader.ts
+++ b/sources/files-source/src/files-reader.ts
@@ -22,7 +22,7 @@ type S3 = {
 };
 
 export interface OutputRecord {
-  type: string;
+  filesSource: string;
   fileName: string;
   lastModified: number;
   content: string;
@@ -145,7 +145,7 @@ export class S3Reader {
         );
         const content = await res.Body.transformToString();
         yield {
-          type: 'S3',
+          filesSource: 'S3',
           fileName: object.Key,
           lastModified: object.LastModified.getTime(),
           content,

--- a/sources/files-source/src/files-reader.ts
+++ b/sources/files-source/src/files-reader.ts
@@ -1,0 +1,102 @@
+import {
+  GetObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import {AirbyteConfig, AirbyteLogger} from 'faros-airbyte-cdk';
+import {VError} from 'verror';
+
+type S3 = {
+  type: 'S3';
+  path: string;
+  aws_region: string;
+  aws_access_key_id: string;
+  aws_secret_access_key: string;
+  aws_session_token?: string;
+};
+
+type FilesSource = S3;
+
+export interface FilesConfig extends AirbyteConfig {
+  readonly files_source: FilesSource;
+  readonly stream_name?: string;
+}
+
+export class FilesReader {
+  private static filesReader: FilesReader = null;
+
+  constructor(private readonly config: FilesConfig) {}
+
+  static async instance(
+    config: FilesConfig,
+    logger?: AirbyteLogger
+  ): Promise<FilesReader> {
+    if (FilesReader.filesReader) return FilesReader.filesReader;
+
+    switch (config.files_source?.type) {
+      case 'S3': {
+        if (
+          !config.files_source.path ||
+          !config.files_source.path.startsWith('s3://')
+        ) {
+          throw new VError(
+            'Please specify S3 bucket path in s3://bucket/path format'
+          );
+        }
+        if (!config.files_source.aws_region) {
+          throw new VError('Please specify AWS region');
+        }
+        if (!config.files_source.aws_access_key_id) {
+          throw new VError('Please specify AWS access key ID');
+        }
+        if (!config.files_source.aws_secret_access_key) {
+          throw new VError('Please specify AWS secret access key');
+        }
+        return new FilesReader(config);
+      }
+      default:
+        throw new VError('Please configure a files source');
+    }
+  }
+
+  async *readFiles(
+    logger?: AirbyteLogger
+  ): AsyncGenerator<{fileName: string; content: any}> {
+    const s3client = new S3Client({
+      region: this.config.files_source.aws_region,
+      credentials: {
+        accessKeyId: this.config.files_source.aws_access_key_id,
+        secretAccessKey: this.config.files_source.aws_secret_access_key,
+        sessionToken: this.config.files_source.aws_session_token,
+      },
+    });
+    const [bucketName, ...pathParts] = this.config.files_source.path
+      .replace('s3://', '')
+      .split('/');
+    const res = await s3client.send(
+      new ListObjectsV2Command({
+        Bucket: bucketName,
+        Prefix: pathParts.join('/'),
+      })
+    );
+    logger.info(JSON.stringify(res.Contents));
+
+    for (const object of res.Contents) {
+      if (object.Key.slice(-1) === '/') continue;
+      logger?.info(`Reading file: ${object.Key}`);
+
+      const res = await s3client.send(
+        new GetObjectCommand({Bucket: bucketName, Key: object.Key})
+      );
+      const asString = await res.Body.transformToString();
+      logger?.info(asString);
+      let content = null;
+      try {
+        content = JSON.parse(asString);
+      } catch (e) {
+        logger?.error(`File ${object.Key} is not a JSON file`);
+      }
+      yield {fileName: object.Key, content};
+    }
+  }
+}

--- a/sources/files-source/src/files-reader.ts
+++ b/sources/files-source/src/files-reader.ts
@@ -25,7 +25,7 @@ export interface OutputRecord {
   filesSource: string;
   fileName: string;
   lastModified: number;
-  content: string;
+  contents: string;
 }
 
 type FilesSource = S3;
@@ -143,12 +143,12 @@ export class S3Reader {
         const res = await this.s3Client.send(
           new GetObjectCommand({Bucket: this.bucketName, Key: object.Key})
         );
-        const content = await res.Body.transformToString();
+        const contents = await res.Body.transformToString('base64');
         yield {
           filesSource: 'S3',
           fileName: object.Key,
           lastModified: object.LastModified.getTime(),
-          content,
+          contents,
         };
       }
 

--- a/sources/files-source/src/index.ts
+++ b/sources/files-source/src/index.ts
@@ -26,7 +26,8 @@ export class FilesSource extends AirbyteSourceBase<FilesConfig> {
 
   async checkConnection(config: FilesConfig): Promise<[boolean, VError]> {
     try {
-      await FilesReader.instance(config, this.logger);
+      const filesReader = await FilesReader.instance(config, this.logger);
+      await filesReader.checkConnection();
     } catch (err: any) {
       return [false, err];
     }

--- a/sources/files-source/src/index.ts
+++ b/sources/files-source/src/index.ts
@@ -1,0 +1,39 @@
+import {Command} from 'commander';
+import {
+  AirbyteLogger,
+  AirbyteSourceBase,
+  AirbyteSourceRunner,
+  AirbyteSpec,
+  AirbyteStreamBase,
+} from 'faros-airbyte-cdk';
+import VError from 'verror';
+
+import {FilesConfig, FilesReader} from './files-reader';
+import {Files} from './streams';
+
+/** The main entry point. */
+export function mainCommand(): Command {
+  const logger = new AirbyteLogger();
+  const source = new FilesSource(logger);
+  return new AirbyteSourceRunner(logger, source).mainCommand();
+}
+
+export class FilesSource extends AirbyteSourceBase<FilesConfig> {
+  async spec(): Promise<AirbyteSpec> {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return new AirbyteSpec(require('../resources/spec.json'));
+  }
+
+  async checkConnection(config: FilesConfig): Promise<[boolean, VError]> {
+    try {
+      await FilesReader.instance(config, this.logger);
+    } catch (err: any) {
+      return [false, err];
+    }
+    return [true, undefined];
+  }
+
+  streams(config: FilesConfig): AirbyteStreamBase[] {
+    return [new Files(config, this.logger)];
+  }
+}

--- a/sources/files-source/src/streams/files.ts
+++ b/sources/files-source/src/streams/files.ts
@@ -1,0 +1,37 @@
+import {
+  AirbyteLogger,
+  AirbyteStreamBase,
+  StreamKey,
+  SyncMode,
+} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {FilesConfig, FilesReader} from '../files-reader';
+
+const DEFAULT_STREAM_NAME = 'files';
+
+export class Files extends AirbyteStreamBase {
+  constructor(
+    private readonly config: FilesConfig,
+    protected readonly logger: AirbyteLogger
+  ) {
+    super(logger);
+  }
+
+  get name(): string {
+    return this.config.stream_name || DEFAULT_STREAM_NAME;
+  }
+
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/files.json');
+  }
+
+  get primaryKey(): StreamKey {
+    return undefined;
+  }
+
+  async *readRecords(): AsyncGenerator<Dictionary<any, string>> {
+    const files = await FilesReader.instance(this.config, this.logger);
+    yield* files.readFiles(this.logger);
+  }
+}

--- a/sources/files-source/src/streams/index.ts
+++ b/sources/files-source/src/streams/index.ts
@@ -1,0 +1,3 @@
+import {Files} from './files';
+
+export {Files};

--- a/sources/files-source/src/tsconfig.json
+++ b/sources/files-source/src/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../.tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "../lib",
+    "experimentalDecorators": true
+  }
+}

--- a/sources/files-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/files-source/test/__snapshots__/index.test.ts.snap
@@ -5,8 +5,8 @@ exports[`index files full 1`] = `
   {
     "content": "{"id": 1, "name": "test"}",
     "fileName": "your-path/1.json",
+    "filesSource": "S3",
     "lastModified": 1701566283000,
-    "type": "S3",
   },
 ]
 `;

--- a/sources/files-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/files-source/test/__snapshots__/index.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`index files full 1`] = `
+[
+  {
+    "content": "{"id": 1, "name": "test"}",
+    "fileName": "your-path/1.json",
+    "lastModified": 1701566283000,
+    "type": "S3",
+  },
+]
+`;

--- a/sources/files-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/files-source/test/__snapshots__/index.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`index files full 1`] = `
 [
   {
-    "content": "{"id": 1, "name": "test"}",
+    "contents": "test",
     "fileName": "your-path/1.json",
     "filesSource": "S3",
     "lastModified": 1701566283000,

--- a/sources/files-source/test/index.test.ts
+++ b/sources/files-source/test/index.test.ts
@@ -50,7 +50,7 @@ describe('index', () => {
     testConnectionWithExpectedError(
       {
         files_source: {
-          type: 'S3',
+          source_type: 'S3',
           aws_region: 'your-aws-region',
           aws_access_key_id: 'your-access-key-id',
           aws_secret_access_key: 'your-secret-access-key',
@@ -63,7 +63,7 @@ describe('index', () => {
     testConnectionWithExpectedError(
       {
         files_source: {
-          type: 'S3',
+          source_type: 'S3',
           path: 'your-bucket/your-path',
           aws_region: 'your-aws-region',
           aws_access_key_id: 'your-access-key-id',
@@ -77,7 +77,7 @@ describe('index', () => {
     testConnectionWithExpectedError(
       {
         files_source: {
-          type: 'S3',
+          source_type: 'S3',
           path: 's3://your-bucket/your-path',
           aws_access_key_id: 'your-access-key-id',
           aws_secret_access_key: 'your-secret-access-key',
@@ -90,7 +90,7 @@ describe('index', () => {
     testConnectionWithExpectedError(
       {
         files_source: {
-          type: 'S3',
+          source_type: 'S3',
           path: 's3://your-bucket/your-path',
           aws_region: 'your-aws-region',
           aws_secret_access_key: 'your-secret-access-key',
@@ -103,7 +103,7 @@ describe('index', () => {
     testConnectionWithExpectedError(
       {
         files_source: {
-          type: 'S3',
+          source_type: 'S3',
           path: 's3://your-bucket/your-path',
           aws_region: 'your-aws-region',
           aws_access_key_id: 'your-access-key-id',

--- a/sources/files-source/test/index.test.ts
+++ b/sources/files-source/test/index.test.ts
@@ -163,7 +163,7 @@ describe('index', () => {
     const getObject = {
       Body: {
         transformToString: () => {
-          return '{"id": 1, "name": "test"}';
+          return 'test';
         },
       },
     };

--- a/sources/files-source/test/index.test.ts
+++ b/sources/files-source/test/index.test.ts
@@ -1,0 +1,115 @@
+import {AirbyteLogger, AirbyteLogLevel, AirbyteSpec} from 'faros-airbyte-cdk';
+import fs from 'fs-extra';
+import {VError} from 'verror';
+
+import {FilesReader} from '../src/files-reader';
+import * as sut from '../src/index';
+
+const files = FilesReader.instance;
+
+describe('index', () => {
+  const logger = new AirbyteLogger(
+    // Shush messages in tests, unless in debug
+    process.env.LOG_LEVEL === 'debug'
+      ? AirbyteLogLevel.DEBUG
+      : AirbyteLogLevel.INFO
+  );
+
+  beforeEach(() => {
+    FilesReader.instance = files;
+  });
+
+  function readResourceFile(fileName: string): any {
+    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
+  }
+
+  test('spec', async () => {
+    const source = new sut.FilesSource(logger);
+    await expect(source.spec()).resolves.toStrictEqual(
+      new AirbyteSpec(readResourceFile('spec.json'))
+    );
+  });
+
+  test('check connection', async () => {
+    const source = new sut.FilesSource(logger);
+
+    async function testConnectionWithExpectedError(
+      inputObject: any,
+      expectedErrorMessage: string
+    ): Promise<void> {
+      await expect(source.checkConnection(inputObject)).resolves.toStrictEqual([
+        false,
+        new VError(expectedErrorMessage),
+      ]);
+    }
+
+    // Test for default case
+    testConnectionWithExpectedError({}, 'Please configure a files source');
+
+    // Test for S3 case with missing path
+    testConnectionWithExpectedError(
+      {
+        files_source: {
+          type: 'S3',
+          aws_region: 'your-aws-region',
+          aws_access_key_id: 'your-access-key-id',
+          aws_secret_access_key: 'your-secret-access-key',
+        },
+      },
+      'Please specify S3 bucket path in s3://bucket/path format'
+    );
+
+    // Test for S3 case with path missing 's3://' prefix
+    testConnectionWithExpectedError(
+      {
+        files_source: {
+          type: 'S3',
+          path: 'your-bucket/your-path',
+          aws_region: 'your-aws-region',
+          aws_access_key_id: 'your-access-key-id',
+          aws_secret_access_key: 'your-secret-access-key',
+        },
+      },
+      'Please specify S3 bucket path in s3://bucket/path format'
+    );
+
+    // Test for S3 case with missing AWS region
+    testConnectionWithExpectedError(
+      {
+        files_source: {
+          type: 'S3',
+          path: 's3://your-bucket/your-path',
+          aws_access_key_id: 'your-access-key-id',
+          aws_secret_access_key: 'your-secret-access-key',
+        },
+      },
+      'Please specify AWS region'
+    );
+
+    // Test for S3 case with missing AWS access key ID
+    testConnectionWithExpectedError(
+      {
+        files_source: {
+          type: 'S3',
+          path: 's3://your-bucket/your-path',
+          aws_region: 'your-aws-region',
+          aws_secret_access_key: 'your-secret-access-key',
+        },
+      },
+      'Please specify AWS access key ID'
+    );
+
+    // Test for S3 case with missing AWS secret access key
+    testConnectionWithExpectedError(
+      {
+        files_source: {
+          type: 'S3',
+          path: 's3://your-bucket/your-path',
+          aws_region: 'your-aws-region',
+          aws_access_key_id: 'your-access-key-id',
+        },
+      },
+      'Please specify AWS secret access key'
+    );
+  });
+});

--- a/sources/files-source/test/tsconfig.json
+++ b/sources/files-source/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../.tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../out/test"
+  },
+  "references": [
+    {
+      "path": "../src"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- Added Files Source which can be used to read files. 
- Currently it supports reading JSON files from S3 given a path on a bucket, but could be extended to reading from other sources as well as supporting other file formats.
- Incremental sync support.
- Pagination handling when listing S3 objects

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
