### PR TITLE
[FAI-8458] [FAI-8704]  For Circle CI, adding option to pull repo names from Faros Graph

### DIFF
--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -77,7 +77,7 @@
       "faros_api_url": {
         "type": "string",
         "title": "Faros API URL",
-        "default": "https://api.faros.ai",
+        "default": "https://prod.api.faros.ai",
         "description": "Faros API URL for pulling data from Faros graph"
       },
       "faros_api_token": {

--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -83,7 +83,7 @@
       "faros_api_key": {
         "type": "string",
         "title": "Faros API Key",
-        "description": "Faros API Token for pulling data from Faros"
+        "description": "Faros API Key"
       },
       "faros_graph_name": {
         "type": "string",

--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -70,25 +70,24 @@
       },
       "pull_block_list_from_graph": {
         "type": "boolean",
-        "title": "Pull Block List from Faros Graph",
+        "title": "Pull Projects Blocklist from Faros Graph",
         "default": false,
-        "description": "Boolean flag whether block list from Faros graph"
+        "description": "Should pull projects blocklist from Faros"
       },
       "faros_api_url": {
         "type": "string",
         "title": "Faros API URL",
         "default": "https://prod.api.faros.ai",
-        "description": "Faros API URL for pulling data from Faros graph"
+        "description": "Faros API URL"
       },
-      "faros_api_token": {
+      "faros_api_key": {
         "type": "string",
-        "title": "Faros API Token",
-        "description": "Faros API Token for pulling data from Faros graph"
+        "title": "Faros API Key",
+        "description": "Faros API Token for pulling data from Faros"
       },
       "faros_graph_name": {
         "type": "string",
-        "title": "Faros Graph",
-        "description": "Faros Graph name for pulling data from Faros graph"
+        "title": "Faros Graph"
       }
     }
   }

--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -67,6 +67,28 @@
         "title": "Max Number of Retries",
         "description": "The max number of retries before giving up on retrying requests to CircleCI API",
         "default": 3
+      },
+      "pull_block_list_from_graph": {
+        "type": "boolean",
+        "title": "Pull Block List from Faros Graph",
+        "default": false,
+        "description": "Boolean flag whether block list from Faros graph"
+      },
+      "faros_api_url": {
+        "type": "string",
+        "title": "Faros API URL",
+        "default": "https://api.faros.ai",
+        "description": "Faros API URL for pulling data from Faros graph"
+      },
+      "faros_api_token": {
+        "type": "string",
+        "title": "Faros API Token",
+        "description": "Faros API Token for pulling data from Faros graph"
+      },
+      "faros_graph_name": {
+        "type": "string",
+        "title": "Faros Graph",
+        "description": "Faros Graph name for pulling data from Faros graph"
       }
     }
   }

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -180,7 +180,7 @@ export class CircleCI {
       !config.faros_graph_name
     ) {
       throw new Error(
-        `Faros API URL, Faros API Key, and Faros Graph Name are required to pull blocked projects from Faros`
+        `Faros API URL, Faros API Key, and Faros Graph Name are required to pull blocklist of projects from Faros`
       );
     }
     if (!config.slugs_as_repos) {

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -168,7 +168,7 @@ export class CircleCI {
     return project_names;
   }
 
-  static async pullBlockedProjectsFromGraph(
+  static async pullProjectsBlocklistFromGraph(
     config: CircleCIConfig,
     logger: AirbyteLogger
   ): Promise<string[]> {

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -186,14 +186,24 @@ export class CircleCI {
       baseURL: config.faros_api_url,
       headers: {
         accept: 'application/json',
-        'Circle-Token': config.token,
+        contentType: 'application/json',
+        authorization: config.faros_api_token,
+        'x-faros-graph-version': 'v2',
+        graph: config.faros_graph_name,
       },
       httpsAgent: new https.Agent({rejectUnauthorized: true}),
       timeout: config.request_timeout ?? DEFAULT_REQUEST_TIMEOUT,
-      // CircleCI responses can be very large hence the infinity
       maxContentLength: Infinity,
       maxBodyLength: Infinity,
     });
+    const query: string =
+      'query BlockedRepos { vcs_Repository { included name } }';
+    const result = await axiosV2Instance.post(
+      `/graphs/${config.faros_graph_name}/graphql`,
+      {query}
+    );
+    logger.info(`Blocked repos result: ${JSON.stringify(result.data)}`);
+    throw new Error(`Not implemented yet`);
     return [];
   }
 

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -20,7 +20,7 @@ const DEFAULT_REQUEST_TIMEOUT = 60000;
 export interface CircleCIConfig {
   readonly token: string;
   readonly project_names: ReadonlyArray<string>;
-  readonly project_block_list?: ReadonlyArray<string>;
+  readonly project_block_list?: string[];
   // Applying project_block_list to project_names results in filtered_project_names
   filtered_project_names?: string[];
   readonly reject_unauthorized: boolean;

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -213,16 +213,13 @@ export class CircleCI {
     };
     const fc = new FarosClient(fcConfig);
     const result = await fc.gql(config.faros_graph_name, query, {after: ''});
-    if (!result) {
+    if (!result?.vcs_Repository) {
       throw new Error(
         `Could not get result from calling Faros GraphQL on graph ${config.faros_graph_name} with query ${query}.`
       );
     }
     const all_ignored_repo_infos = [];
     let crt_ignored_repo_infos = result.vcs_Repository;
-    if (!crt_ignored_repo_infos) {
-      throw new Error(`Failed to get ignored repos from '/graphql' endpoint.`);
-    }
     all_ignored_repo_infos.push(...crt_ignored_repo_infos);
     let nCalls: number = 1;
     while (crt_ignored_repo_infos.length == limit) {
@@ -232,7 +229,7 @@ export class CircleCI {
       const result = await fc.gql(config.faros_graph_name, query, {
         after: last_repo_id,
       });
-      if (!result || !result.vcs_Repository) {
+      if (!result?.vcs_Repository) {
         throw new Error(
           `Could not get result from calling Faros GraphQL on graph ${config.faros_graph_name} with query ${query}.`
         );
@@ -253,9 +250,9 @@ export class CircleCI {
     for (const ignored_repo_info of all_ignored_repo_infos) {
       updated_blocklist.push(ignored_repo_info.name);
     }
-    logger.info(`Updated block list: ${JSON.stringify(updated_blocklist)}`);
+    logger.debug(`Updated block list: ${JSON.stringify(updated_blocklist)}`);
     logger.info(
-      `Finished pulling blocked projects from Faros' graph. Got ${updated_blocklist.length} blocked projects.`
+      `Finished pulling ${updated_blocklist.length} blocked projects from Faros' graph`
     );
     return updated_blocklist;
   }

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -20,7 +20,7 @@ const DEFAULT_REQUEST_TIMEOUT = 60000;
 export interface CircleCIConfig {
   readonly token: string;
   readonly project_names: ReadonlyArray<string>;
-  readonly project_block_list?: string[];
+  readonly project_block_list?: ReadonlyArray<string>;
   // Applying project_block_list to project_names results in filtered_project_names
   filtered_project_names?: string[];
   readonly reject_unauthorized: boolean;

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -180,7 +180,7 @@ export class CircleCI {
       !config.faros_graph_name
     ) {
       throw new Error(
-        `Faros API URL, Faros API Token, and Faros Graph Name are required to pull blocked projects from Faros`
+        `Faros API URL, Faros API Key, and Faros Graph Name are required to pull blocked projects from Faros`
       );
     }
     if (!config.slugs_as_repos) {

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -211,12 +211,17 @@ export class CircleCI {
     if (!ignored_repo_infos) {
       throw new Error(`Failed to get ignored repos from '/graphql' endpoint.`);
     }
-    logger.info(`Ignored repo infos: ${JSON.stringify(ignored_repo_infos)}`);
+    logger.debug(`Ignored repo infos: ${JSON.stringify(ignored_repo_infos)}`);
     const updated_block_list: string[] = [];
     for (const ignored_repo_info of ignored_repo_infos) {
       updated_block_list.push(ignored_repo_info.name);
     }
-    logger.info(`Updated block list: ${JSON.stringify(updated_block_list)}`);
+    logger.debug(`Updated block list: ${JSON.stringify(updated_block_list)}`);
+    if (updated_block_list.length == 1000) {
+      throw new Error(
+        "Block list reached graphql's max limit of 1000. Please reach out to Faros for support."
+      );
+    }
     return updated_block_list;
   }
 

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -194,7 +194,7 @@ export class CircleCI {
       );
     }
     logger.info('Pulling blocklist of projects from Faros');
-    const limit = 1000;
+    const limit = 100;
     const query: string = `query BlockedRepos($after: String) {
       vcs_Repository(
         limit: ${limit} 
@@ -221,7 +221,6 @@ export class CircleCI {
     const all_ignored_repo_infos = [];
     let crt_ignored_repo_infos = result.vcs_Repository;
     all_ignored_repo_infos.push(...crt_ignored_repo_infos);
-    let nCalls: number = 1;
     while (crt_ignored_repo_infos.length == limit) {
       const last_repo_info =
         crt_ignored_repo_infos[crt_ignored_repo_infos.length - 1];
@@ -236,12 +235,6 @@ export class CircleCI {
       }
       crt_ignored_repo_infos = result.vcs_Repository;
       all_ignored_repo_infos.push(...crt_ignored_repo_infos);
-      nCalls += 1;
-      if (nCalls > 100) {
-        throw new Error(
-          `Too many calls to Faros GraphQL to get blocked projects.`
-        );
-      }
     }
     logger.debug(
       `Ignored repo infos: ${JSON.stringify(all_ignored_repo_infos)}`

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -190,7 +190,7 @@ export class CircleCI {
     }
     if (!config.project_names.includes('*')) {
       throw new Error(
-        `When pulling blocked repos from Faros, project_names must include wildcard "*"`
+        `When pulling blocklist of projects from Faros, project_names must include wildcard "*"`
       );
     }
     logger.info('Pulling blocklist of projects from Faros');

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -185,7 +185,7 @@ export class CircleCI {
     }
     if (!config.slugs_as_repos) {
       throw new Error(
-        `When pulling blocked repos from Faros, slugs_as_repos must be set to true`
+        `When pulling blocklist projects from Faros, slugs_as_repos must be set to true`
       );
     }
     if (!config.project_names.includes('*')) {

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -182,6 +182,17 @@ export class CircleCI {
         `Faros API URL, Faros API Token, and Faros Graph Name are required to pull blocked projects from graph`
       );
     }
+    if (!config.slugs_as_repos) {
+      throw new Error(
+        `When pulling blocked repos from Faros graph, slugs_as_repos must be set to true`
+      );
+    }
+    if (!config.project_names.includes('*')) {
+      throw new Error(
+        `When pulling blocked repos from Faros graph, project_names must include wildcard "*"`
+      );
+    }
+    logger.info("Pulling blocked projects from Faros' graph");
     const axiosV2Instance = axios.create({
       baseURL: config.faros_api_url,
       headers: {
@@ -197,7 +208,7 @@ export class CircleCI {
       maxBodyLength: Infinity,
     });
     const query: string =
-      'query BlockedRepos { vcs_Repository(where: {farosOptions: {inclusionCategory: {_eq: "Excluded"}}}) { name  farosOptions { inclusionCategory } } }';
+      'query BlockedRepos { vcs_Repository(where: {farosOptions: {inclusionCategory: {_eq: "Excluded"}}}) { name } }';
     const result = await axiosV2Instance.post(
       `/graphs/${config.faros_graph_name}/graphql`,
       {query}
@@ -222,6 +233,9 @@ export class CircleCI {
         "Block list reached graphql's max limit of 1000. Please reach out to Faros for support."
       );
     }
+    logger.info(
+      `Finished pulling blocked projects from Faros' graph. Got ${updated_block_list.length} blocked projects.`
+    );
     return updated_block_list;
   }
 

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -193,7 +193,7 @@ export class CircleCI {
         `When pulling blocked repos from Faros, project_names must include wildcard "*"`
       );
     }
-    logger.info('Pulling blocked projects from Faros');
+    logger.info('Pulling blocklist of projects from Faros');
     const query: string =
       'query BlockedRepos { vcs_Repository(where: {farosOptions: {inclusionCategory: {_eq: "Excluded"}}}) { name } }';
     const fcConfig: FarosClientConfig = {

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -50,7 +50,7 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
       ? config.project_blocklist
       : [];
     if (config.pull_blocklist_from_graph) {
-      blocklist = await CircleCI.pullBlockedProjectsFromGraph(
+      blocklist = await CircleCI.pullProjectsBlocklistFromGraph(
         config,
         this.logger
       );

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -46,11 +46,11 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
     catalog: AirbyteConfiguredCatalog;
     state?: AirbyteState;
   }> {
-    let block_list: string[] = config.project_block_list
-      ? config.project_block_list
+    let blocklist: string[] = config.project_blocklist
+      ? config.project_blocklist
       : [];
-    if (config.pull_block_list_from_graph) {
-      block_list = await CircleCI.pullBlockedProjectsFromGraph(
+    if (config.pull_blocklist_from_graph) {
+      blocklist = await CircleCI.pullBlockedProjectsFromGraph(
         config,
         this.logger
       );
@@ -60,13 +60,13 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
       filtered_project_names = await CircleCI.getFilteredProjectsFromRepoNames(
         config,
         this.logger,
-        block_list
+        blocklist
       );
     } else {
       filtered_project_names = await CircleCI.getFilteredProjects(
         config,
         this.logger,
-        block_list
+        blocklist
       );
     }
 

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -46,16 +46,27 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
     catalog: AirbyteConfiguredCatalog;
     state?: AirbyteState;
   }> {
+    let block_list: string[] = config.project_block_list
+      ? config.project_block_list
+      : [];
+    if (config.pull_block_list_from_graph) {
+      block_list = await CircleCI.pullBlockedProjectsFromGraph(
+        config,
+        this.logger
+      );
+    }
     let filtered_project_names: string[] = [];
     if (config.slugs_as_repos) {
       filtered_project_names = await CircleCI.getFilteredProjectsFromRepoNames(
         config,
-        this.logger
+        this.logger,
+        block_list
       );
     } else {
       filtered_project_names = await CircleCI.getFilteredProjects(
         config,
-        this.logger
+        this.logger,
+        block_list
       );
     }
 

--- a/sources/circleci-source/test/index.test.ts
+++ b/sources/circleci-source/test/index.test.ts
@@ -38,7 +38,7 @@ describe('index', () => {
   const sourceConfig: CircleCIConfig = {
     token: '',
     project_names: ['test-project'],
-    project_block_list: [],
+    project_blocklist: [],
     slugs_as_repos: true,
     cutoff_days: 90,
     reject_unauthorized: true,


### PR DESCRIPTION
## Description
Allowing Faros users to get their ignored repos from the Faros Graph by setting input vars to the configs:
"pull_blocked_repos"
"faros_api_key"
"faros_api_url"
"graph"

## Type of change
- [X] New feature

