### PR TITLE
FAI-8724 FAI-8855 Circle CI Handles Github- Gitlab formats when getting all projects with wildcard

### DIFF
--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -1,95 +1,100 @@
 {
-  "documentationUrl": "https://docs.faros.ai",
-  "connectionSpecification": {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "CircleCI Spec",
-    "type": "object",
-    "required": [
-      "token",
-      "project_names"
-    ],
-    "additionalProperties": true,
-    "properties": {
-      "token": {
-        "type": "string",
-        "title": "token",
-        "description": "CircleCI personal API token. See https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token",
-        "airbyte_secret": true
-      },
-      "project_names": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "title": "Project Names",
-        "description": "Project names should look like \"vcs-slug/org-name/repo-name\" or \"repo-name\" if slugs as repos is set to true. Only enter \"*\" for all projects."
-      },
-      "project_block_list": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "title": "Project Name Blocklist",
-        "description": "If project_names is \"*\", then enter a list of \"repo-name\" or \"vcs-slug/org-name/repo-name\""
-      },
-      "cutoff_days": {
-        "type": "integer",
-        "title": "Cutoff Days",
-        "default": 90,
-        "description": "Only fetch data updated after cutoff"
-      },
-      "reject_unauthorized": {
-        "type": "boolean",
-        "title": "Enforce Authorized Requests",
-        "default": true,
-        "description": "Enable certificate validation for the CircleCI server"
-      },
-      "slugs_as_repos": {
-        "type": "boolean",
-        "title": "Projects Listed as Repos",
-        "default": false,
-        "description": "List projects as \"repo-name\" instead of \"vcs-slug/org-name/repo-name\""
-      },
-      "url": {
-        "type": "string",
-        "title": "API URL",
-        "default": "https://circleci.com/api/v2",
-        "description": "CircleCI API URL"
-      },
-      "request_timeout": {
-        "type": "integer",
-        "title": "Request Timeout",
-        "description": "The max time in milliseconds to wait for a request to complete (0 - no timeout).",
-        "default": 60000
-      },
-      "max_retries": {
-        "type": "integer",
-        "title": "Max Number of Retries",
-        "description": "The max number of retries before giving up on retrying requests to CircleCI API",
-        "default": 3
-      },
-      "pull_blocklist_from_graph": {
-        "type": "boolean",
-        "title": "Pull Projects Blocklist from Faros Graph",
-        "default": false,
-        "description": "Should pull projects blocklist from Faros"
-      },
-      "faros_api_url": {
-        "type": "string",
-        "title": "Faros API URL",
-        "default": "https://prod.api.faros.ai",
-        "description": "Faros API URL"
-      },
-      "faros_api_key": {
-        "type": "string",
-        "title": "Faros API Key",
-        "description": "Faros API Key",
-        "airbyte_secret": true
-      },
-      "faros_graph_name": {
-        "type": "string",
-        "title": "Faros Graph"
-      }
+    "documentationUrl": "https://docs.faros.ai",
+    "connectionSpecification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CircleCI Spec",
+        "type": "object",
+        "required": [
+            "token",
+            "project_names"
+        ],
+        "additionalProperties": true,
+        "properties": {
+            "token": {
+                "type": "string",
+                "title": "token",
+                "description": "CircleCI personal API token. See https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token",
+                "airbyte_secret": true
+            },
+            "project_names": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "Project Names",
+                "description": "Project names should look like \"vcs-slug/org-name/repo-name\" or \"repo-name\" if slugs as repos is set to true. Only enter \"*\" for all projects."
+            },
+            "project_block_list": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "title": "Project Name Blocklist",
+                "description": "If project_names is \"*\", then enter a list of \"repo-name\" or \"vcs-slug/org-name/repo-name\""
+            },
+            "cutoff_days": {
+                "type": "integer",
+                "title": "Cutoff Days",
+                "default": 90,
+                "description": "Only fetch data updated after cutoff"
+            },
+            "reject_unauthorized": {
+                "type": "boolean",
+                "title": "Enforce Authorized Requests",
+                "default": true,
+                "description": "Enable certificate validation for the CircleCI server"
+            },
+            "slugs_as_repos": {
+                "type": "boolean",
+                "title": "Projects Listed as Repos",
+                "default": false,
+                "description": "List projects as \"repo-name\" instead of \"vcs-slug/org-name/repo-name\""
+            },
+            "url": {
+                "type": "string",
+                "title": "API URL",
+                "default": "https://circleci.com/api/v2",
+                "description": "CircleCI API URL"
+            },
+            "request_timeout": {
+                "type": "integer",
+                "title": "Request Timeout",
+                "description": "The max time in milliseconds to wait for a request to complete (0 - no timeout).",
+                "default": 120000
+            },
+            "max_retries": {
+                "type": "integer",
+                "title": "Max Number of Retries",
+                "description": "The max number of retries before giving up on retrying requests to CircleCI API",
+                "default": 3
+            },
+            "pull_blocklist_from_graph": {
+                "type": "boolean",
+                "title": "Pull Projects Blocklist from Faros Graph",
+                "default": false,
+                "description": "Should pull projects blocklist from Faros"
+            },
+            "faros_api_url": {
+                "type": "string",
+                "title": "Faros API URL",
+                "default": "https://prod.api.faros.ai",
+                "description": "Faros API URL"
+            },
+            "faros_api_key": {
+                "type": "string",
+                "title": "Faros API Key",
+                "description": "Faros API Key",
+                "airbyte_secret": true
+            },
+            "faros_graph_name": {
+                "type": "string",
+                "title": "Faros Graph"
+            },
+            "uses_github_or_gitlab": {
+                "type": "boolean",
+                "title": "Uses Github or Gitlab",
+                "description": "Does the project use Github or Gitlab"
+            }
+        }
     }
-  }
 }

--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -1,95 +1,92 @@
 {
-    "documentationUrl": "https://docs.faros.ai",
-    "connectionSpecification": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CircleCI Spec",
-        "type": "object",
-        "required": [
-            "token",
-            "project_names"
-        ],
-        "additionalProperties": true,
-        "properties": {
-            "token": {
-                "type": "string",
-                "title": "token",
-                "description": "CircleCI personal API token. See https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token",
-                "airbyte_secret": true
-            },
-            "project_names": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                },
-                "title": "Project Names",
-                "description": "Project names should look like \"vcs-slug/org-name/repo-name\" or \"repo-name\" if slugs as repos is set to true. Only enter \"*\" for all projects."
-            },
-            "project_block_list": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                },
-                "title": "Project Name Blocklist",
-                "description": "If project_names is \"*\", then enter a list of \"repo-name\" or \"vcs-slug/org-name/repo-name\""
-            },
-            "cutoff_days": {
-                "type": "integer",
-                "title": "Cutoff Days",
-                "default": 90,
-                "description": "Only fetch data updated after cutoff"
-            },
-            "reject_unauthorized": {
-                "type": "boolean",
-                "title": "Enforce Authorized Requests",
-                "default": true,
-                "description": "Enable certificate validation for the CircleCI server"
-            },
-            "slugs_as_repos": {
-                "type": "boolean",
-                "title": "Projects Listed as Repos",
-                "default": false,
-                "description": "List projects as \"repo-name\" instead of \"vcs-slug/org-name/repo-name\""
-            },
-            "url": {
-                "type": "string",
-                "title": "API URL",
-                "default": "https://circleci.com/api/v2",
-                "description": "CircleCI API URL"
-            },
-            "request_timeout": {
-                "type": "integer",
-                "title": "Request Timeout",
-                "description": "The max time in milliseconds to wait for a request to complete (0 - no timeout).",
-                "default": 120000
-            },
-            "max_retries": {
-                "type": "integer",
-                "title": "Max Number of Retries",
-                "description": "The max number of retries before giving up on retrying requests to CircleCI API",
-                "default": 3
-            },
-            "pull_blocklist_from_graph": {
-                "type": "boolean",
-                "title": "Pull Projects Blocklist from Faros Graph",
-                "default": false,
-                "description": "Should pull projects blocklist from Faros"
-            },
-            "faros_api_url": {
-                "type": "string",
-                "title": "Faros API URL",
-                "default": "https://prod.api.faros.ai",
-                "description": "Faros API URL"
-            },
-            "faros_api_key": {
-                "type": "string",
-                "title": "Faros API Key",
-                "description": "Faros API Key",
-                "airbyte_secret": true
-            },
-            "faros_graph_name": {
-                "type": "string",
-                "title": "Faros Graph"
-            }
-        }
+  "documentationUrl": "https://docs.faros.ai",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "CircleCI Spec",
+    "type": "object",
+    "required": ["token", "project_names"],
+    "additionalProperties": true,
+    "properties": {
+      "token": {
+        "type": "string",
+        "title": "token",
+        "description": "CircleCI personal API token. See https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token",
+        "airbyte_secret": true
+      },
+      "project_names": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "title": "Project Names",
+        "description": "Project names should look like \"vcs-slug/org-name/repo-name\" or \"repo-name\" if slugs as repos is set to true. Only enter \"*\" for all projects."
+      },
+      "project_block_list": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "title": "Project Name Blocklist",
+        "description": "If project_names is \"*\", then enter a list of \"repo-name\" or \"vcs-slug/org-name/repo-name\""
+      },
+      "cutoff_days": {
+        "type": "integer",
+        "title": "Cutoff Days",
+        "default": 90,
+        "description": "Only fetch data updated after cutoff"
+      },
+      "reject_unauthorized": {
+        "type": "boolean",
+        "title": "Enforce Authorized Requests",
+        "default": true,
+        "description": "Enable certificate validation for the CircleCI server"
+      },
+      "slugs_as_repos": {
+        "type": "boolean",
+        "title": "Projects Listed as Repos",
+        "default": false,
+        "description": "List projects as \"repo-name\" instead of \"vcs-slug/org-name/repo-name\""
+      },
+      "url": {
+        "type": "string",
+        "title": "API URL",
+        "default": "https://circleci.com/api/v2",
+        "description": "CircleCI API URL"
+      },
+      "request_timeout": {
+        "type": "integer",
+        "title": "Request Timeout",
+        "description": "The max time in milliseconds to wait for a request to complete (0 - no timeout).",
+        "default": 120000
+      },
+      "max_retries": {
+        "type": "integer",
+        "title": "Max Number of Retries",
+        "description": "The max number of retries before giving up on retrying requests to CircleCI API",
+        "default": 3
+      },
+      "pull_blocklist_from_graph": {
+        "type": "boolean",
+        "title": "Pull Projects Blocklist from Faros Graph",
+        "default": false,
+        "description": "Should pull projects blocklist from Faros"
+      },
+      "faros_api_url": {
+        "type": "string",
+        "title": "Faros API URL",
+        "default": "https://prod.api.faros.ai",
+        "description": "Faros API URL"
+      },
+      "faros_api_key": {
+        "type": "string",
+        "title": "Faros API Key",
+        "description": "Faros API Key",
+        "airbyte_secret": true
+      },
+      "faros_graph_name": {
+        "type": "string",
+        "title": "Faros Graph"
+      }
     }
+  }
 }

--- a/sources/circleci-source/resources/spec.json
+++ b/sources/circleci-source/resources/spec.json
@@ -89,11 +89,6 @@
             "faros_graph_name": {
                 "type": "string",
                 "title": "Faros Graph"
-            },
-            "uses_github_or_gitlab": {
-                "type": "boolean",
-                "title": "Uses Github or Gitlab",
-                "description": "Does the project use Github or Gitlab"
             }
         }
     }

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -68,10 +68,13 @@ export class CircleCI {
         'If wildcard is included in project names, do not include other project names'
       );
     }
-    if (
-      config.project_blocklist?.length > 0 &&
-      !config.project_names.includes('*')
-    ) {
+    const blocklist: string[] = config.project_blocklist
+      ? config.project_blocklist
+      : [];
+    const blocklist_is_empty = blocklist.length == 0;
+    const blocklist_is_nonempty = blocklist.length > 0;
+    const wildCardProjects = config.project_names.includes('*');
+    if (blocklist_is_nonempty && wildCardProjects) {
       throw new VError(
         'If blocklist contains values, project_names should only include wildcard "*".'
       );
@@ -84,12 +87,9 @@ export class CircleCI {
         `Config variable "slugs_as_repos" should be set as boolean, instead it is set as "${typeof config.slugs_as_repos}"`
       );
     }
-    const blocklist: string[] = config.project_blocklist
-      ? config.project_blocklist
-      : [];
 
     if (config.pull_blocklist_from_graph) {
-      if (blocklist.length > 0) {
+      if (blocklist_is_nonempty) {
         throw new VError(
           'If pull_blocklist_from_graph is true, project_blocklist should be empty.'
         );
@@ -103,7 +103,7 @@ export class CircleCI {
           'If pull_blocklist_from_graph is true, faros_api_url, faros_api_key, and faros_graph_name must be provided.'
         );
       }
-      if (!config.project_names.includes('*')) {
+      if (!wildCardProjects) {
         throw new VError(
           'If pull_blocklist_from_graph is true, project_names must include wildcard "*".'
         );

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -645,9 +645,10 @@ export class CircleCI {
     } else {
       config.uses_github_or_gitlab = false;
     }
-    logger.info(
-      `Finished running diagnostic. Uses github or gitlab: ${config.uses_github_or_gitlab}`
-    );
+    const git_log_message = config.uses_github_or_gitlab
+      ? 'Uses Github or Gitlab'
+      : 'Does not use Github or Gitlab';
+    logger.info(`Finished running diagnostic. ${git_log_message}.`);
     return config.uses_github_or_gitlab;
   }
 

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -71,7 +71,6 @@ export class CircleCI {
     const blocklist: string[] = config.project_blocklist
       ? config.project_blocklist
       : [];
-    const blocklist_is_empty = blocklist.length == 0;
     const blocklist_is_nonempty = blocklist.length > 0;
     const wildCardProjects = config.project_names.includes('*');
     if (blocklist_is_nonempty && wildCardProjects) {

--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -88,25 +88,11 @@ export class CircleCI {
     }
 
     if (config.pull_blocklist_from_graph) {
-      if (blocklist_is_nonempty) {
-        throw new VError(
-          'If pull_blocklist_from_graph is true, project_blocklist should be empty.'
-        );
-      }
-      if (
-        !config.faros_api_url ||
-        !config.faros_api_key ||
-        !config.faros_graph_name
-      ) {
-        throw new VError(
-          'If pull_blocklist_from_graph is true, faros_api_url, faros_api_key, and faros_graph_name must be provided.'
-        );
-      }
-      if (!wildCardProjects) {
-        throw new VError(
-          'If pull_blocklist_from_graph is true, project_names must include wildcard "*".'
-        );
-      }
+      CircleCI.validatePullingBlocklist(
+        config,
+        blocklist_is_nonempty,
+        wildCardProjects
+      );
     }
 
     const cutoffDays = config.cutoff_days ?? DEFAULT_CUTOFF_DAYS;
@@ -119,6 +105,33 @@ export class CircleCI {
       config.max_retries ?? DEFAULT_MAX_RETRIES
     );
     return CircleCI.circleCI;
+  }
+
+  static validatePullingBlocklist(
+    config,
+    blocklist_is_nonempty,
+    wildCardProjects
+  ): void {
+    // In this case blocklist is pulled from Faros' graph
+    if (blocklist_is_nonempty) {
+      throw new VError(
+        'If pull_blocklist_from_graph is true, project_blocklist should be empty.'
+      );
+    }
+    if (
+      !config.faros_api_url ||
+      !config.faros_api_key ||
+      !config.faros_graph_name
+    ) {
+      throw new VError(
+        'If pull_blocklist_from_graph is true, faros_api_url, faros_api_key, and faros_graph_name must be provided.'
+      );
+    }
+    if (!wildCardProjects) {
+      throw new VError(
+        'If pull_blocklist_from_graph is true, project_names must include wildcard "*".'
+      );
+    }
   }
 
   // used by ../index.ts

--- a/sources/circleci-source/src/circleci/typings.ts
+++ b/sources/circleci-source/src/circleci/typings.ts
@@ -92,3 +92,12 @@ export interface TestMetadata {
   name: string;
   classname: string;
 }
+
+export interface CircleCIOnReadInfo {
+  org_slug: string;
+  repoNamesToProjectIds: Map<string, string>;
+  repoNamesToOrgIds: Map<string, string>;
+  repoNames: string[];
+  orgIds: string[];
+  uses_github_or_gitlab: boolean;
+}

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -11,6 +11,7 @@ import {
 import VError from 'verror';
 
 import {CircleCI, CircleCIConfig} from './circleci/circleci';
+import {CircleCIOnReadInfo} from './circleci/typings';
 import {Pipelines, Projects, Tests} from './streams';
 
 /** The main entry point. */
@@ -46,38 +47,84 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
     catalog: AirbyteConfiguredCatalog;
     state?: AirbyteState;
   }> {
-    // Within this function we redefine what the project names are based on the config inputs.
-    // If they are providing the entire project names, we use that.
-    // If they want to pull all projects and use a blocklist to ignore certain projects,
-    // we pull all projects and then filter out the blocklist.
-    // We also want to be able to handle inputs that are given as repo names instead of project names.
-    // In that case, we need to be able to convert repo names into project names.
-    // In the case that they want to pull the blocklist from the graph, we assume slugs_as_repos is true.
-    // This is because the blocklist is pulled from the graph using the repo name, not the project name.
-    let blocklist: string[] = config.project_blocklist
-      ? config.project_blocklist
-      : [];
-    if (config.pull_blocklist_from_graph) {
-      blocklist = await CircleCI.pullProjectsBlocklistFromGraph(
-        config,
-        this.logger
+    // There are 4 booleans to consider:
+    // 1. slugs_as_repos
+    // 2. project_names includes *
+    // 3. project_blocklist is provided
+    // 4. Github/Gitlab is used for the project names
+    // We want to be able to handle all combinations of these booleans.
+
+    // First, we consider the simplest case - the user provides the entirety of the project names,
+    // and does not provide a block list. This is the noChangeCase.
+    // We do not need to do any processing on the project names in this case.
+    // We also do not need to do any processing on the blocklist in this case.
+
+    // In all the below cases, we need to get basic information from CircleCI, in which case
+    // we run the getBasicInfo function. This function gets the org slug, the repo names,
+    // the boolean 'github/gitlab usage', and the project ids, as well as organization ids.
+
+    // Second, we consider the special case where the user wants to pull all projects and
+    // pull a blocklist from the graph. Whenever the user wants to pull a blocklist from the graph,
+    // we use this special case.
+
+    // Third, we consider the case where the user wants to pull all projects and provides a block list
+    // of repo names to ignore.
+    // Fourth, we consider the case where the user wants to pull all projects and provides a block list
+    // of complete projects to ignore.
+
+    if (CircleCI.isNoChangeCase(config)) {
+      this.logger.info(
+        'No change applied to input project names: ' + config.project_names
       );
+      config.filtered_project_names = Array.from(config.project_names);
+      return {config, catalog, state};
     }
-    let filtered_project_names: string[] = [];
-    if (config.slugs_as_repos) {
-      filtered_project_names = await CircleCI.getFilteredProjectsFromRepoNames(
-        config,
-        this.logger,
-        blocklist
-      );
-    } else {
-      filtered_project_names = await CircleCI.getFilteredProjects(
-        config,
-        this.logger,
-        blocklist
-      );
+    const cci: CircleCIOnReadInfo = await CircleCI.getBasicInfo(
+      config,
+      this.logger
+    );
+
+    if (config.pull_blocklist_from_graph) {
+      config.filtered_project_names =
+        await CircleCI.getProjectsWhilePullingBlocklistFromGraph(
+          cci,
+          config,
+          this.logger
+        );
+      return {config, catalog, state};
     }
 
+    // Setting up blocklist
+    const blocklist: string[] = config.project_blocklist
+      ? config.project_blocklist
+      : [];
+    const wildCardProjects = config.project_names.includes('*');
+    let filtered_project_names: string[] = [];
+    if (wildCardProjects) {
+      if (config.slugs_as_repos) {
+        const filtered_repo_names = CircleCI.filterOnBlocklist(
+          cci.repoNames,
+          blocklist,
+          this.logger
+        );
+        filtered_project_names = CircleCI.getCompleteProjectNamesFromRepoNames(
+          this.logger,
+          filtered_repo_names,
+          cci
+        );
+      } else {
+        const projectNames = CircleCI.getCompleteProjectNamesFromRepoNames(
+          this.logger,
+          cci.repoNames,
+          cci
+        );
+        filtered_project_names = CircleCI.filterOnBlocklist(
+          projectNames,
+          blocklist,
+          this.logger
+        );
+      }
+    }
     config.filtered_project_names = filtered_project_names;
     return {config, catalog, state};
   }

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -124,6 +124,18 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
           this.logger
         );
       }
+    } else {
+      if (config.slugs_as_repos) {
+        filtered_project_names = CircleCI.getCompleteProjectNamesFromRepoNames(
+          this.logger,
+          config.project_names,
+          cci
+        );
+      } else {
+        throw new Error(
+          'Input config case not covered. Please contact support.'
+        );
+      }
     }
     config.filtered_project_names = filtered_project_names;
     return {config, catalog, state};

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -124,18 +124,14 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
           this.logger
         );
       }
+    } else if (config.slugs_as_repos) {
+      filtered_project_names = CircleCI.getCompleteProjectNamesFromRepoNames(
+        this.logger,
+        config.project_names,
+        cci
+      );
     } else {
-      if (config.slugs_as_repos) {
-        filtered_project_names = CircleCI.getCompleteProjectNamesFromRepoNames(
-          this.logger,
-          config.project_names,
-          cci
-        );
-      } else {
-        throw new Error(
-          'Input config case not covered. Please contact support.'
-        );
-      }
+      throw new Error('Input config case not covered. Please contact support.');
     }
     config.filtered_project_names = filtered_project_names;
     return {config, catalog, state};

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -46,6 +46,14 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
     catalog: AirbyteConfiguredCatalog;
     state?: AirbyteState;
   }> {
+    // Within this function we redefine what the project names are based on the config inputs.
+    // If they are providing the entire project names, we use that.
+    // If they want to pull all projects and use a blocklist to ignore certain projects,
+    // we pull all projects and then filter out the blocklist.
+    // We also want to be able to handle inputs that are given as repo names instead of project names.
+    // In that case, we need to be able to convert repo names into project names.
+    // In the case that they want to pull the blocklist from the graph, we assume slugs_as_repos is true.
+    // This is because the blocklist is pulled from the graph using the repo name, not the project name.
     let blocklist: string[] = config.project_blocklist
       ? config.project_blocklist
       : [];


### PR DESCRIPTION
## Description
Reading at this URL, we see that Circle CI have two different formats for their project names.
This PR adds support for that case:
https://circleci.com/docs/api/v2/index.html#operation/getProjectBySlug

Also adding documentation and simplified logic for reading the "OnBeforeRead" function.
Documentation in this file:
sources/circleci-source/src/index.ts
under the function 'OnBeforeRead'


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

