### PR TITLE
Fix loading of converter by using global replace

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/converter-registry.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter-registry.ts
@@ -36,7 +36,7 @@ export class ConverterRegistry {
     try {
       // Load the necessary module dynamically
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const converterDir = streamName.source.replace('_', '-');
+      const converterDir = streamName.source.replace(/_/g, '-');
       const mod = require(`./${converterDir}/${streamName.name}`);
 
       // Create converter instance by name

--- a/destinations/airbyte-faros-destination/test/converter-registry.test.ts
+++ b/destinations/airbyte-faros-destination/test/converter-registry.test.ts
@@ -153,9 +153,16 @@ describe('converter registry', () => {
   });
 
   test('loads a converter with underscore instead of dash', async () => {
-    const res = sut.getConverter(new StreamName('okta-faros', 'groups'));
-    expect(res).toBeDefined();
-    sut.getConverter(new StreamName('okta_faros', 'groups'));
-    expect(res).toBeDefined();
+    const streamNames = [
+      new StreamName('okta-faros', 'groups'),
+      new StreamName('okta_faros', 'groups'),
+      new StreamName('aws-cloudwatch-metrics', 'metrics'),
+      new StreamName('aws_cloudwatch_metrics', 'metrics'),
+    ];
+
+    streamNames.forEach((streamName) => {
+      const res = sut.getConverter(streamName);
+      expect(res).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
## Description

`'aws_cloudwatch_metrics'.replace('_', '-')` is `aws-cloudwatch_metrics`

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
