### PR TITLE
CircleCI lowercase applied only to check if equal to blocklist

### DIFF
--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -157,9 +157,9 @@ export class CircleCI {
           this.logger.error(`Could not parse vcs url: "${projectVCSUrl}"`);
           continue;
         }
-        const vcsProvider = projectMatch[1].toLowerCase();
-        const orgId = projectMatch[2].toLowerCase();
-        const projectId = projectMatch[3].toLowerCase();
+        const vcsProvider = projectMatch[1];
+        const orgId = projectMatch[2];
+        const projectId = projectMatch[3];
 
         res.push(`${vcsProvider}/${orgId}/${projectId}`);
       }

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -81,7 +81,9 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
     }
 
     config.project_slugs = allProjectSlugs.filter(
-      (slug) => !projectSlugBlocklist.has(slug) && !excludedRepoSlugs?.has(slug)
+      (slug) =>
+        !projectSlugBlocklist.has(slug.toLowerCase()) &&
+        !excludedRepoSlugs?.has(slug.toLowerCase())
     );
 
     this.logger.info(`Will sync project slugs: ${config.project_slugs}`);


### PR DESCRIPTION
## Description
Project Slugs can't sync once converted to lowercase, so we only convert to lowercase to check against blocklist

## Type of change
- [X] Bug fix

