### PR TITLE
FAI-8918 Support query groups

### DIFF
--- a/sources/aws-cloudwatch-metrics-source/resources/spec.json
+++ b/sources/aws-cloudwatch-metrics-source/resources/spec.json
@@ -7,7 +7,7 @@
     "required": [
       "aws_region",
       "credentials",
-      "queries"
+      "query_groups"
     ],
     "additionalProperties": false,
     "properties": {
@@ -50,30 +50,35 @@
           }
         }
       },
-      "queries": {
+      "query_groups": {
         "order": 2,
         "type": "array",
         "items": {
           "type": "object",
-          "required": ["name", "query"],
+          "required": ["name", "queries"],
           "properties": {
             "name": {
               "order": 0,
               "type": "string",
-              "title": "Query Name",
-              "description": "A unique name for the query."
+              "title": "Query Group Name",
+              "description": "A unique name for the query group."
             },
-            "query": {
+            "queries": {
               "order": 1,
-              "type": "string",
-              "title": "Query",
-              "description": "The CloudWatch query in JSON format.",
-              "multiline": true
+              "type": "array",
+              "items": {
+                "type": "string",
+                "title": "Query",
+                "description": "The CloudWatch query in JSON format.",
+                "multiline": true
+              },
+              "title": "Queries",
+              "description": "An array of queries to execute against CloudWatch."
             }
           }
         },
-        "title": "Queries",
-        "description": "An array of named queries to execute against CloudWatch."
+        "title": "Query Groups",
+        "description": "An array of query groups to execute against CloudWatch."
       },
       "page_size": {
         "order": 3,

--- a/sources/aws-cloudwatch-metrics-source/src/streams/metrics.ts
+++ b/sources/aws-cloudwatch-metrics-source/src/streams/metrics.ts
@@ -13,7 +13,7 @@ import {
   Config,
   DataPoint,
   MIN_DATE,
-  NamedQuery,
+  QueryGroup,
 } from '../cloudwatch';
 
 const DEFAULT_STREAM_NAME = 'metrics';
@@ -22,7 +22,7 @@ type StreamState = {
   [queryName: string]: {[queryHash: string]: {timestamp: string}};
 };
 type StreamSlice = {
-  query: NamedQuery;
+  queryGroup: QueryGroup;
   queryHash: string;
 };
 
@@ -53,11 +53,11 @@ export class Metrics extends AirbyteStreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const query of this.config.queries) {
+    for (const group of this.config.query_groups) {
       const queryHash = createHash('md5')
-        .update(CloudWatch.toQueryString(query.query))
+        .update(JSON.stringify(group.queries))
         .digest('hex');
-      yield {query, queryHash};
+      yield {queryGroup: group, queryHash};
     }
   }
 
@@ -70,33 +70,39 @@ export class Metrics extends AirbyteStreamBase {
     this.state = syncMode === SyncMode.INCREMENTAL ? streamState ?? {} : {};
 
     const timestamp = _.get(this.state, [
-      streamSlice?.query.name,
+      streamSlice?.queryGroup.name,
       streamSlice?.queryHash,
       'timestamp',
     ]);
     const cloudWatch = CloudWatch.instance(this.config);
 
-    if (!_.has(this.state, [streamSlice?.query.name, streamSlice?.queryHash])) {
-      _.set(this.state, [streamSlice?.query.name, streamSlice?.queryHash], {
-        timestamp: MIN_DATE,
-      });
+    if (
+      !_.has(this.state, [streamSlice?.queryGroup.name, streamSlice?.queryHash])
+    ) {
+      _.set(
+        this.state,
+        [streamSlice?.queryGroup.name, streamSlice?.queryHash],
+        {
+          timestamp: MIN_DATE,
+        }
+      );
     }
 
     for await (const record of cloudWatch.getMetricData(
-      streamSlice?.query.query,
+      streamSlice?.queryGroup.queries,
       timestamp,
       this.logger
     )) {
       const queryTimestamp =
-        this.state?.[streamSlice?.query.name][streamSlice?.queryHash]
+        this.state?.[streamSlice?.queryGroup.name][streamSlice?.queryHash]
           ?.timestamp;
       const latestRecordTimestamp = record?.timestamp ?? MIN_DATE;
       if (new Date(latestRecordTimestamp) > new Date(queryTimestamp)) {
-        this.state[streamSlice?.query.name][streamSlice?.queryHash] = {
+        this.state[streamSlice?.queryGroup.name][streamSlice?.queryHash] = {
           timestamp: latestRecordTimestamp,
         };
       }
-      yield {queryName: streamSlice?.query.name, ...record};
+      yield {queryName: streamSlice?.queryGroup.name, ...record};
     }
   }
 

--- a/sources/aws-cloudwatch-metrics-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/aws-cloudwatch-metrics-source/test/__snapshots__/index.test.ts.snap
@@ -4,13 +4,13 @@ exports[`index metrics full 1`] = `
 Array [
   Object {
     "label": "CPUUtilization",
-    "queryName": "ExampleQuery1",
+    "queryName": "ExampleQueryGroup",
     "timestamp": "2021-01-01T00:00:00.000Z",
     "value": 0.5,
   },
   Object {
     "label": "CPUUtilization",
-    "queryName": "ExampleQuery1",
+    "queryName": "ExampleQueryGroup",
     "timestamp": "2021-01-02T00:00:00.000Z",
     "value": 0.6,
   },
@@ -21,13 +21,13 @@ exports[`index metrics incremental 1`] = `
 Array [
   Object {
     "label": "CPUUtilization",
-    "queryName": "ExampleQuery1",
+    "queryName": "ExampleQueryGroup",
     "timestamp": "2021-01-01T00:00:00.000Z",
     "value": 0.5,
   },
   Object {
     "label": "CPUUtilization",
-    "queryName": "ExampleQuery1",
+    "queryName": "ExampleQueryGroup",
     "timestamp": "2021-01-02T00:00:00.000Z",
     "value": 0.6,
   },

--- a/sources/aws-cloudwatch-metrics-source/test/index.test.ts
+++ b/sources/aws-cloudwatch-metrics-source/test/index.test.ts
@@ -144,6 +144,13 @@ describe('index', () => {
 
     expect(fnSend).toHaveBeenCalledTimes(1);
     expect(items).toMatchSnapshot();
+    expect(stream.getUpdatedState(undefined, undefined)).toEqual({
+      ExampleQueryGroup: {
+        hash: {
+          timestamp: latestTimestamp,
+        },
+      },
+    });
   });
 
   test('metrics full', async () => {

--- a/sources/aws-cloudwatch-metrics-source/test/index.test.ts
+++ b/sources/aws-cloudwatch-metrics-source/test/index.test.ts
@@ -12,7 +12,6 @@ import * as sut from '../src/index';
 
 describe('index', () => {
   const logger = new AirbyteLogger(
-    // Shush messages in tests, unless in debug
     process.env.LOG_LEVEL === 'debug'
       ? AirbyteLogLevel.DEBUG
       : AirbyteLogLevel.FATAL
@@ -25,7 +24,12 @@ describe('index', () => {
       aws_secret_access_key: 'YOUR_AWS_SECRET_ACCESS_KEY',
       aws_session_token: 'YOUR_AWS_SESSION_TOKEN',
     },
-    queries: [{name: 'ExampleQuery1', query: '{"metric":"CPUUtilization"}'}],
+    query_groups: [
+      {
+        name: 'ExampleQueryGroup',
+        queries: [{query: '{"metric":"CPUUtilization"}'}],
+      },
+    ],
     page_size: 100,
   };
 
@@ -84,16 +88,11 @@ describe('index', () => {
         100
       );
     });
+
     await expect(source.checkConnection(validConfig)).resolves.toStrictEqual([
       true,
       undefined,
     ]);
-    await expect(
-      source.checkConnection({
-        ...validConfig,
-        queries: [{name: 'ExampleQuery1', query: {metric: 'CPUUtilization'}}],
-      })
-    ).resolves.toStrictEqual([true, undefined]);
   });
 
   test('metrics incremental', async () => {
@@ -128,12 +127,9 @@ describe('index', () => {
     const iter = stream.readRecords(
       SyncMode.INCREMENTAL,
       undefined,
+      {queryGroup: validConfig.query_groups[0], queryHash: 'hash'},
       {
-        query: {name: 'ExampleQuery1', query: {metric: 'CPUUtilization'}},
-        queryHash: 'hash',
-      },
-      {
-        ExampleQuery1: {
+        ExampleQueryGroup: {
           hash: {
             timestamp: '2021-01-01T00:00:00.000Z',
           },
@@ -148,13 +144,6 @@ describe('index', () => {
 
     expect(fnSend).toHaveBeenCalledTimes(1);
     expect(items).toMatchSnapshot();
-    expect(stream.getUpdatedState(undefined, undefined)).toEqual({
-      ExampleQuery1: {
-        hash: {
-          timestamp: latestTimestamp,
-        },
-      },
-    });
   });
 
   test('metrics full', async () => {
@@ -186,7 +175,7 @@ describe('index', () => {
     const streams = source.streams(validConfig);
     const stream = streams[0];
     const iter = stream.readRecords(SyncMode.FULL_REFRESH, undefined, {
-      query: {name: 'ExampleQuery1', query: '{"metric":"CPUUtilization"}'},
+      queryGroup: validConfig.query_groups[0],
       queryHash: 'hash',
     });
 


### PR DESCRIPTION
## Description

Support query groups to make it possible to use [metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html).

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
