### PR TITLE
CircleCI Optimization: Moving logs to end of stream and avoiding duplicate writes

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/circleci/projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/circleci/projects.ts
@@ -10,6 +10,8 @@ export class Projects extends CircleCIConverter {
     'cicd_Pipeline',
   ];
 
+  private seenOrganizations: Set<string> = new Set<string>();
+
   async convert(
     record: AirbyteRecord
   ): Promise<ReadonlyArray<DestinationRecord>> {
@@ -18,14 +20,21 @@ export class Projects extends CircleCIConverter {
     const projectUid = CircleCICommon.getProject(project.slug);
     const orgUid = CircleCICommon.getOrganization(project.slug);
     const res: DestinationRecord[] = [];
-    res.push({
-      model: 'cicd_Organization',
-      record: {
-        uid: orgUid,
-        name: project.organization_name,
-        source,
-      },
-    });
+    const organizationKey = this.getOrganizationKey(
+      orgUid,
+      project.organization_name
+    );
+    if (!this.seenOrganizations.has(organizationKey)) {
+      res.push({
+        model: 'cicd_Organization',
+        record: {
+          uid: orgUid,
+          name: project.organization_name,
+          source,
+        },
+      });
+      this.seenOrganizations.add(organizationKey);
+    }
     res.push({
       model: 'cicd_Pipeline',
       record: {
@@ -35,5 +44,9 @@ export class Projects extends CircleCIConverter {
       },
     });
     return res;
+  }
+
+  private getOrganizationKey(orgUid: string, organizationName: string): string {
+    return `${orgUid}__${organizationName}`;
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/circleci/projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/circleci/projects.ts
@@ -24,6 +24,7 @@ export class Projects extends CircleCIConverter {
       orgUid,
       project.organization_name
     );
+    // avoiding writing the same organization multiple times to reduce runtime
     if (!this.seenOrganizations.has(organizationKey)) {
       res.push({
         model: 'cicd_Organization',
@@ -47,6 +48,7 @@ export class Projects extends CircleCIConverter {
   }
 
   private getOrganizationKey(orgUid: string, organizationName: string): string {
+    // gets a key that is unique for the organization to avoid duplicates
     return `${orgUid}__${organizationName}`;
   }
 }

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -36,6 +36,10 @@ export class Tests extends CircleCIStreamBase {
         ? streamState?.[streamSlice.projectSlug]?.lastUpdatedAt
         : undefined;
 
+    // We store the logs of undefined job numbers to a variable and log it at the end of the stream
+    let undefinedJobNumberLogs: string =
+      'Undefined job numbers and related projects:\n';
+
     for await (const pipeline of this.circleCI.fetchPipelines(
       streamSlice.projectSlug,
       since
@@ -45,9 +49,7 @@ export class Tests extends CircleCIStreamBase {
         for (const job of workflow.jobs ?? []) {
           const jobNum = job.job_number;
           if (jobNum === undefined) {
-            this.logger.debug(
-              `Job number for job [${job.id}] is undefined in project [${pipeline.project_slug}] - Skipping`
-            );
+            undefinedJobNumberLogs += `${job.id} - ${pipeline.project_slug}\n`;
             continue;
           }
           if (seenJobs.has(jobNum)) {
@@ -79,6 +81,7 @@ export class Tests extends CircleCIStreamBase {
         }
       }
     }
+    this.logger.debug(undefinedJobNumberLogs);
   }
 
   getUpdatedState(


### PR DESCRIPTION
## Description
To improve runtime for Circle CI, we combine debug logs into a single log.
We also avoid duplicate writes of cicd_Organization in the destination

