### PR TITLE
FAI-8950 - Optimize CircleCI source by removing stream slices

### DIFF
--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -260,6 +260,10 @@ export class CircleCI {
     projectName: string,
     since?: string
   ): AsyncGenerator<Pipeline> {
+    this.logger.debug(
+      `Fetching pipelines for project ${projectName} since ${since}`
+    );
+
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - this.cutoffDays);
 

--- a/sources/circleci-source/src/streams/common.ts
+++ b/sources/circleci-source/src/streams/common.ts
@@ -11,7 +11,3 @@ export abstract class CircleCIStreamBase extends AirbyteStreamBase {
     super(logger);
   }
 }
-
-export type StreamSlice = {
-  projectSlug: string;
-};

--- a/sources/circleci-source/src/streams/projects.ts
+++ b/sources/circleci-source/src/streams/projects.ts
@@ -1,8 +1,7 @@
-import {SyncMode} from 'faros-airbyte-cdk';
 import {Dictionary} from 'ts-essentials';
 
 import {Project} from '../circleci/types';
-import {CircleCIStreamBase, StreamSlice} from './common';
+import {CircleCIStreamBase} from './common';
 
 export class Projects extends CircleCIStreamBase {
   getJsonSchema(): Dictionary<any, string> {
@@ -13,17 +12,9 @@ export class Projects extends CircleCIStreamBase {
     return 'id';
   }
 
-  async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const projectSlug of this.cfg.project_slugs) {
-      yield {projectSlug};
+  async *readRecords(): AsyncGenerator<Project, any, unknown> {
+    for await (const project of this.cfg.project_slugs) {
+      yield await this.circleCI.fetchProject(project);
     }
-  }
-
-  async *readRecords(
-    syncMode: SyncMode,
-    cursorField?: string[],
-    streamSlice?: StreamSlice
-  ): AsyncGenerator<Project, any, unknown> {
-    yield await this.circleCI.fetchProject(streamSlice.projectSlug);
   }
 }


### PR DESCRIPTION
## Description

Stream slices have a large performance impact because of how model batching is done. Only models from the same stream slice are batched. If we remove stream slices, then models from across streams can be batched.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
