### PR TITLE
FAI-9009 - Isolate stream slice failures

### DIFF
--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -119,7 +119,7 @@ export interface AirbyteConfiguredStream {
   cursor_field?: string[];
   destination_sync_mode?: DestinationSyncMode;
   primary_key?: string[][];
-  maxSliceFailures?: number; // -1 means no limit
+  maxSliceFailures?: number; // -1 means unlimited
 }
 
 export interface AirbyteConfiguredCatalog {

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -119,6 +119,7 @@ export interface AirbyteConfiguredStream {
   cursor_field?: string[];
   destination_sync_mode?: DestinationSyncMode;
   primary_key?: string[][];
+  maxSliceFailures?: number; // -1 means no limit
 }
 
 export interface AirbyteConfiguredCatalog {

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -52,6 +52,7 @@ export enum AirbyteTraceFailureType {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AirbyteConfig {
   compress_state?: boolean;
+  max_slice_failures?: number; // -1 means unlimited
   [k: string]: any;
 }
 
@@ -119,7 +120,6 @@ export interface AirbyteConfiguredStream {
   cursor_field?: string[];
   destination_sync_mode?: DestinationSyncMode;
   primary_key?: string[][];
-  maxSliceFailures?: number; // -1 means unlimited
 }
 
 export interface AirbyteConfiguredCatalog {

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -266,13 +266,8 @@ export abstract class AirbyteSourceBase<
         if (!slice || !configuredStream.maxSliceFailures) {
           throw e;
         }
+
         failedSlices.push(slice);
-        if (
-          configuredStream.maxSliceFailures !== -1 && // -1 means unlimited allowed slice failures
-          failedSlices.length > configuredStream.maxSliceFailures
-        ) {
-          break;
-        }
         this.logger.error(
           `Encountered an error while processing ${streamName} stream slice ${JSON.stringify(
             slice
@@ -280,6 +275,16 @@ export abstract class AirbyteSourceBase<
           e.stack
         );
         yield this.errorState(streamName, streamState, connectorState, e);
+
+        if (
+          configuredStream.maxSliceFailures !== -1 && // -1 means unlimited allowed slice failures
+          failedSlices.length > configuredStream.maxSliceFailures
+        ) {
+          this.logger.error(
+            `Exceeded maximum number of allowed slice failures: ${configuredStream.maxSliceFailures}`
+          );
+          break;
+        }
       }
     }
     if (failedSlices.length > 0) {

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -254,6 +254,14 @@ export abstract class AirbyteSourceBase<
             yield this.checkpointState(streamName, streamState, connectorState);
           }
         }
+        yield this.checkpointState(streamName, streamState, connectorState);
+        if (slice) {
+          this.logger.info(
+            `Finished processing ${streamName} stream slice ${JSON.stringify(
+              slice
+            )}. Read ${recordCounter} records`
+          );
+        }
       } catch (e: any) {
         if (slice && configuredStream.maxSliceFailures) {
           failedSlices.push(slice);
@@ -273,14 +281,6 @@ export abstract class AirbyteSourceBase<
         } else {
           throw e;
         }
-      }
-      yield this.checkpointState(streamName, streamState, connectorState);
-      if (slice) {
-        this.logger.info(
-          `Finished processing ${streamName} stream slice ${JSON.stringify(
-            slice
-          )}. Read ${recordCounter} records`
-        );
       }
     }
     if (failedSlices.length > 0) {

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -245,7 +245,6 @@ export abstract class AirbyteSourceBase<
         slice,
         streamState
       );
-
       try {
         for await (const recordData of records) {
           recordCounter++;

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -272,12 +272,11 @@ export abstract class AirbyteSourceBase<
               {data: connectorState},
               {status: 'ERRORED', error: e.message ?? JSON.stringify(e)}
             );
-            // Checkpoint the state before continuing with the next slice
-            yield this.checkpointState(streamName, streamState, connectorState);
             continue;
           }
+        } else {
+          throw e;
         }
-        throw e;
       }
       yield this.checkpointState(streamName, streamState, connectorState);
       if (slice) {

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -276,6 +276,8 @@ export abstract class AirbyteSourceBase<
               e.stack
             );
             yield this.errorState(streamName, streamState, connectorState, e);
+          } else {
+            break;
           }
         } else {
           throw e;

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -1,4 +1,4 @@
-import {cloneDeep, keyBy, max} from 'lodash';
+import {cloneDeep, keyBy} from 'lodash';
 import VError from 'verror';
 
 import {AirbyteLogger} from '../logger';

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -267,10 +267,7 @@ export abstract class AirbyteSourceBase<
               )}: ${e.message ?? JSON.stringify(e)}`,
               e.stack
             );
-            yield new AirbyteStateMessage(
-              {data: connectorState},
-              {status: 'ERRORED', error: e.message ?? JSON.stringify(e)}
-            );
+            yield this.errorState(streamName, streamState, connectorState, e);
             continue;
           }
         } else {
@@ -344,6 +341,19 @@ export abstract class AirbyteSourceBase<
   ): AirbyteStateMessage {
     connectorState[streamName] = streamState;
     return new AirbyteStateMessage({data: connectorState});
+  }
+
+  private errorState(
+    streamName: string,
+    streamState: any,
+    connectorState: AirbyteState,
+    error: Error
+  ): AirbyteStateMessage {
+    connectorState[streamName] = streamState;
+    return new AirbyteStateMessage(
+      {data: connectorState},
+      {status: 'ERRORED', error: error.message ?? JSON.stringify(error)}
+    );
   }
 }
 

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -275,7 +275,7 @@ export abstract class AirbyteSourceBase<
           );
         }
       } catch (e: any) {
-        if (!slice || typeof maxSliceFailures === 'undefined') {
+        if (!slice || maxSliceFailures == null) {
           throw e;
         }
         failedSlices.push(slice);
@@ -347,7 +347,7 @@ export abstract class AirbyteSourceBase<
           );
         }
       } catch (e: any) {
-        if (!slice || typeof maxSliceFailures === 'undefined') {
+        if (!slice || maxSliceFailures == null) {
           throw e;
         }
         failedSlices.push(slice);
@@ -365,13 +365,13 @@ export abstract class AirbyteSourceBase<
           break;
         }
       }
-      if (failedSlices.length > 0) {
-        throw new VError(
-          `Encountered an error while processing ${streamName} stream slice(s): ${JSON.stringify(
-            failedSlices
-          )}`
-        );
-      }
+    }
+    if (failedSlices.length > 0) {
+      throw new VError(
+        `Encountered an error while processing ${streamName} stream slice(s): ${JSON.stringify(
+          failedSlices
+        )}`
+      );
     }
   }
 

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -276,7 +276,6 @@ export abstract class AirbyteSourceBase<
               e.stack
             );
             yield this.errorState(streamName, streamState, connectorState, e);
-            continue;
           }
         } else {
           throw e;

--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -256,7 +256,7 @@ export abstract class AirbyteSourceBase<
         }
       } catch (err: any) {
         if (slice) {
-          // Slices should not cause the entire stream to fail
+          // Slice failure should not cause the entire stream to fail
           this.logger.error(
             `Error processing ${streamName} stream slice ${JSON.stringify(
               slice


### PR DESCRIPTION
## Description

Allows for continuing processing of slices even if N (configurable maximum up to unlimited represented by -1) of them fail. 

## Motivation

We want to do as much processing as possible. If a slice fails, it seems reasonable that we would want there to be a way to attempt processing other stream slices. This way, if a slice has a transient failure, it doesn't affect the processing of other slices.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change