### PR TITLE
FAI-9368 - Configurable stream failure resiliency

### DIFF
--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -52,6 +52,7 @@ export enum AirbyteTraceFailureType {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AirbyteConfig {
   compress_state?: boolean;
+  max_stream_failures?: number; // -1 means unlimited
   max_slice_failures?: number; // -1 means unlimited
   [k: string]: any;
 }


### PR DESCRIPTION
## Description

Similar to what we did for slice resiliency, this PR allows setting the number of allowed stream failures before the source process is failed. `-1` mean unlimited failures are allowed. If any stream fails, the source will fail in the end after attempting the configured allowed number.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
