### PR TITLE
DOD Percent Change

### DIFF
--- a/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
@@ -141,7 +141,8 @@ async function getPreviousDataQualitySummary(
   fc: FarosClient,
   cfg: any
 ): Promise<DataSummaryInterface | null> {
-  const query = `query DQS_Query { faros_DataQualitySummary(order_by: {createdAt: desc}, limit: 1) { uid createdAt counts }`;
+  const query = `query DQS_Query { faros_DataQualitySummary(order_by: {createdAt: desc}, limit: 1) { uid createdAt counts }}`;
+  cfg.logger.info(`Running query to get previous data quality summary.`);
   const result = await fc.gql(cfg.graph, query);
   if (result?.faros_DataQualitySummary?.length == 0) {
     return null;

--- a/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
@@ -173,7 +173,7 @@ async function getPreviousDataQualitySummary(
   fc: FarosClient,
   cfg: any
 ): Promise<DataSummaryInterface | null> {
-  const query = `query DQS_Query { faros_DataQualitySummary(order_by: {createdAt: desc}, limit: 1) { uid createdAt counts }}`;
+  const query = `query Last__faros_DataQualitySummary { faros_DataQualitySummary(order_by: {createdAt: desc}, limit: 1) { uid createdAt counts }}`;
   cfg.logger.info(`Running query to get previous data quality summary.`);
   const result = await fc.gql(cfg.graph, query);
   if (result?.faros_DataQualitySummary?.length == 0) {

--- a/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
@@ -3,7 +3,6 @@
 import {FarosClient} from 'faros-js-client';
 import {Phantom} from 'faros-js-client/lib/types';
 import _ from 'lodash';
-import {intersection} from 'lodash';
 
 import {
   DataSummaryInterface,

--- a/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
@@ -148,6 +148,7 @@ async function getPreviousDataQualitySummary(
     return null;
   }
   const prev_DQS = result[0];
+  cfg.logger.info(prev_DQS);
   if (checkIfCreatedWithinLastXHours(prev_DQS.createdAt, 25)) {
     return prev_DQS;
   } else {

--- a/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/dataSummary.ts
@@ -141,7 +141,7 @@ async function getPreviousDataQualitySummary(
   fc: FarosClient,
   cfg: any
 ): Promise<DataSummaryInterface | null> {
-  const query = `query DQS_Query { faros_DataQualitySummary({order_by: {createdAt: desc}}) { uid createdAt counts }`;
+  const query = `query DQS_Query { faros_DataQualitySummary(order_by: {createdAt: desc}, limit: 1) { uid createdAt counts }`;
   const result = await fc.gql(cfg.graph, query);
   if (result?.faros_DataQualitySummary?.length == 0) {
     return null;

--- a/sources/faros-graphdoctor-source/src/graphdoctor/models.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/models.ts
@@ -44,9 +44,9 @@ export interface FarosDataQualityRecordCount {
 export interface DataSummaryInterface {
   uid: string;
   source: string;
+  counts: FarosDataQualityRecordCount[];
   createdAt?: Date;
   elapsedMs?: number;
-  counts?: FarosDataQualityRecordCount[];
 }
 
 export interface DataIssueWrapper {

--- a/sources/faros-graphdoctor-source/test/resources/queryTitleToResponse.json
+++ b/sources/faros-graphdoctor-source/test/resources/queryTitleToResponse.json
@@ -38,5 +38,115 @@
         "tms_Project_aggregate": {"aggregate": {"count": 0}},
         "vcs_PullRequest_aggregate": {"aggregate": {"count": 0}},
         "vcs_Commit_aggregate": {"aggregate": {"count": 0}}
+    },
+    "Last": {
+        "faros_DataQualitySummary":  [{
+              "uid": "2024-02-26T02:32:01.579Z",
+              "createdAt": "2024-02-26T02:33:58.764+00:00",
+              "counts": [
+                {
+                  "model": "ams_Project",
+                  "total": 0,
+                  "phantoms": 0,
+                  "nonPhantoms": 0
+                },
+                {
+                  "model": "ams_Activity",
+                  "total": 0,
+                  "phantoms": 0,
+                  "nonPhantoms": 0
+                },
+                {
+                  "model": "cal_Event",
+                  "total": 0,
+                  "phantoms": 0,
+                  "nonPhantoms": 0
+                },
+                {
+                  "model": "cicd_Pipeline",
+                  "total": 6,
+                  "phantoms": 0,
+                  "nonPhantoms": 6
+                },
+                {
+                  "model": "cicd_Build",
+                  "total": 2461,
+                  "phantoms": 0,
+                  "nonPhantoms": 2461
+                },
+                {
+                  "model": "cicd_Repository",
+                  "total": 2,
+                  "phantoms": 0,
+                  "nonPhantoms": 2
+                },
+                {
+                  "model": "cicd_Artifact",
+                  "total": 2377,
+                  "phantoms": 2,
+                  "nonPhantoms": 2375
+                },
+                {
+                  "model": "cicd_Deployment",
+                  "total": 2187,
+                  "phantoms": 0,
+                  "nonPhantoms": 2187
+                },
+                {
+                  "model": "faros_Tag",
+                  "total": 1,
+                  "phantoms": 0,
+                  "nonPhantoms": 1
+                },
+                {
+                  "model": "ims_Incident",
+                  "total": 15547,
+                  "phantoms": 0,
+                  "nonPhantoms": 15547
+                },
+                {
+                  "model": "qa_TestCase",
+                  "total": 0,
+                  "phantoms": 0,
+                  "nonPhantoms": 0
+                },
+                {
+                  "model": "qa_TestExecution",
+                  "total": 0,
+                  "phantoms": 0,
+                  "nonPhantoms": 0
+                },
+                {
+                  "model": "survey_Survey",
+                  "total": 0,
+                  "phantoms": 0,
+                  "nonPhantoms": 0
+                },
+                {
+                  "model": "tms_Task",
+                  "total": 24368,
+                  "phantoms": 12338,
+                  "nonPhantoms": 12030
+                },
+                {
+                  "model": "tms_Project",
+                  "total": 101,
+                  "phantoms": 1,
+                  "nonPhantoms": 100
+                },
+                {
+                  "model": "vcs_PullRequest",
+                  "total": 15904,
+                  "phantoms": 120,
+                  "nonPhantoms": 15784
+                },
+                {
+                  "model": "vcs_Commit",
+                  "total": 61778,
+                  "phantoms": 1196,
+                  "nonPhantoms": 60582
+                }
+              ]
+            }]
     }
 }


### PR DESCRIPTION
## Description
Get day over day percentage change for total model counts.
For example, total tms_Tasks in day X is 100, total tms_Tasks in day X + 1 is 103, then 
we compute percentage change (3/100) = .03


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change


