### PR TITLE
Add Asana tasks `completed_at` field import

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
@@ -156,6 +156,7 @@ export class Tasks extends AsanaConverter {
         statusChangedAt: Utils.toDate(task.modified_at),
         parent,
         statusChangelog: statusChangelog ?? null,
+        resolvedAt: Utils.toDate(task.completed_at),
       },
     });
 

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/asana.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/asana.test.ts.snap
@@ -55,6 +55,7 @@ Array [
       "description": "Task 1 notes",
       "name": "Task 1",
       "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
       "source": "Asana",
       "status": Object {
         "category": "Todo",
@@ -97,6 +98,7 @@ Array [
       "description": "Task 1 notes",
       "name": "Task 1",
       "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
       "source": "Asana",
       "status": Object {
         "category": "Todo",
@@ -126,6 +128,7 @@ Array [
       "description": "Task 1 notes",
       "name": "Task 1",
       "parent": null,
+      "resolvedAt": 2023-08-25T20:59:25.481Z,
       "source": "Asana",
       "status": Object {
         "category": "Done",
@@ -190,6 +193,7 @@ Array [
       "description": "Task 1 notes",
       "name": "Task 1",
       "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
       "source": "Asana",
       "status": Object {
         "category": "Todo",
@@ -222,6 +226,7 @@ Array [
         "source": "Asana",
         "uid": "1205346703408261",
       },
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
       "source": "Asana",
       "status": Object {
         "category": "Todo",
@@ -265,6 +270,7 @@ Array [
       "description": "Task 1 notes",
       "name": "Task 1",
       "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
       "source": "Asana",
       "status": Object {
         "category": "Todo",
@@ -318,6 +324,7 @@ Array [
       "description": "Task 1 notes",
       "name": "Task 1",
       "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
       "source": "Asana",
       "status": Object {
         "category": "Todo",

--- a/destinations/airbyte-faros-destination/test/converters/asana.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/asana.test.ts
@@ -79,6 +79,7 @@ describe('asana', () => {
     const TASK = {
       gid: '1205346703408262',
       created_at: '2023-08-24T15:52:00.014Z',
+      completed_at: '2023-08-25T15:52:00.014Z',
       custom_fields: [],
       dependencies: [],
       dependents: [],

--- a/sources/asana-source/src/asana.ts
+++ b/sources/asana-source/src/asana.ts
@@ -166,6 +166,7 @@ export class Asana {
       'permalink_url',
       'resource_type',
       'workspace',
+      'completed_at',
     ];
 
     const params = {


### PR DESCRIPTION
## Description

Import the `completed_at` field in Asana tasks and save its value in `tms_Task:resolvedAt`

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Extra info

Based on https://developers.asana.com/reference/tasks this field should be available
