### PR TITLE
Trello converter: handle card status changelog items with no timestamp

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/trello/cards.ts
+++ b/destinations/airbyte-faros-destination/src/converters/trello/cards.ts
@@ -461,6 +461,9 @@ export class Cards extends TrelloConverter {
 
     for (const action of this.updateActions.get(cardId) ?? []) {
       const changedAt: Date = Utils.toDate(action.date);
+      if (!changedAt) {
+        continue;
+      }
       if (action.data?.listAfter) {
         const status: TmsTaskStatus = this.getStatusFromList(
           action.data.listAfter


### PR DESCRIPTION
## Description

My change removes these changelog items from being uploaded, since I wasn't sure if theres's a way to keep them in the record.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
