### PR TITLE
add run_attempt to workflow runs

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/github/workflow_runs.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/workflow_runs.ts
@@ -30,6 +30,7 @@ export class WorkflowRuns extends GitHubConverter {
     const build = {
       uid: run.id.toString(),
       name: run.name,
+      runAttempt: run.run_attempt,
       number: run.run_number,
       createdAt: Utils.toDate(run.created_at),
       startedAt: Utils.toDate(run.run_started_at),


### PR DESCRIPTION
## Description

Add `run_attempt` info for github actions builds

Depends of https://github.com/faros-ai/faros-community-edition/pull/351

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
