### PR TITLE
FAI-10736 Fix project/repo inclusion logic in Bitbucket server source

### DIFF
--- a/sources/bitbucket-server-source/resources/spec.json
+++ b/sources/bitbucket-server-source/resources/spec.json
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "title": "Repositories",
-        "description": "Names of your Bitbucket repositories in the format 'project-key/repo-slug'. If none are provided, data from all repositories for the specified projects will be pulled.",
+        "description": "Names of your Bitbucket repositories in the format 'project-key/repo-slug'. If you want to pull all repositories from a project, you can add the project key to the Projects list instead of listing the repositories here",
         "examples": [
           "PROJ/myrepo"
         ]

--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -22,6 +22,7 @@ import {
   MoreEndpointMethodsPlugin,
   Prefix as MEP,
 } from './more-endpoint-methods';
+import {ProjectRepoFilter} from './project-repo-filter';
 
 export interface BitbucketServerConfig extends AirbyteConfig {
   readonly server_url?: string;
@@ -429,7 +430,7 @@ export class BitbucketServer {
   )
   async repositories(
     projectKey: string,
-    include?: ReadonlyArray<string>
+    projectRepoFilter?: ProjectRepoFilter
   ): Promise<ReadonlyArray<Repository>> {
     try {
       this.logger.debug(`Fetching repositories for project ${projectKey}`);
@@ -467,7 +468,8 @@ export class BitbucketServer {
           const repoFullName = repo.computedProperties.fullName;
           return {
             shouldEmit:
-              (!include || include.includes(repoFullName)) &&
+              (!projectRepoFilter ||
+                projectRepoFilter.isIncluded(repoFullName)) &&
               this.bucket(repoFullName) === this.repoBucketId,
             shouldBreakEarly: false,
           };

--- a/sources/bitbucket-server-source/src/bitbucket-server/project-repo-filter.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/project-repo-filter.ts
@@ -1,0 +1,47 @@
+import {toLower} from 'lodash';
+
+export class ProjectRepoFilter {
+  projects: Set<string>;
+  repos: Map<string, Set<string>>;
+
+  constructor(
+    projectKeys: ReadonlyArray<string>,
+    repositoryNames: ReadonlyArray<string>
+  ) {
+    this.projects = new Set(
+      projectKeys.map((projectKey) => toLower(projectKey))
+    );
+    this.repos = new Map();
+
+    for (const repositoryName of repositoryNames) {
+      const [projectKey, repoName] = this.parseRepository(repositoryName);
+
+      this.projects.add(projectKey);
+      if (!this.repos.has(projectKey)) {
+        this.repos.set(projectKey, new Set());
+      }
+      this.repos.get(projectKey).add(repoName);
+    }
+  }
+
+  getProjectKeys(): ReadonlyArray<string> {
+    return Array.from(this.projects);
+  }
+
+  isIncluded(repository: string): boolean {
+    const [projectKey, repoName] = this.parseRepository(repository);
+    return this.repos.has(projectKey)
+      ? this.repos.get(projectKey).has(repoName)
+      : this.projects.has(projectKey);
+  }
+
+  private parseRepository(repository: string): [string, string] {
+    let [projectKey, repoName] = repository.split('/');
+    if (!projectKey || !repoName) {
+      throw new Error(`Invalid repository name: ${repository}`);
+    }
+    projectKey = toLower(projectKey);
+    repoName = toLower(repoName);
+    return [projectKey, repoName];
+  }
+}

--- a/sources/bitbucket-server-source/src/streams/commits.ts
+++ b/sources/bitbucket-server-source/src/streams/commits.ts
@@ -15,7 +15,7 @@ export class Commits extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {
@@ -35,7 +35,7 @@ export class Commits extends StreamBase {
       const projectKey = await this.fetchProjectKey(project.key);
       for (const repo of await this.server.repositories(
         projectKey,
-        this.config.repositories
+        this.projectRepoFilter
       )) {
         yield {
           projectKey,

--- a/sources/bitbucket-server-source/src/streams/common.ts
+++ b/sources/bitbucket-server-source/src/streams/common.ts
@@ -2,16 +2,30 @@ import {AirbyteLogger, AirbyteStreamBase} from 'faros-airbyte-cdk';
 import {Project} from 'faros-airbyte-common/bitbucket-server';
 
 import {BitbucketServer, BitbucketServerConfig} from '../bitbucket-server';
+import {ProjectRepoFilter} from '../bitbucket-server/project-repo-filter';
 
 export abstract class StreamBase extends AirbyteStreamBase {
-  config: BitbucketServerConfig;
-  logger: AirbyteLogger;
+  readonly projectRepoFilter: ProjectRepoFilter;
+
+  constructor(
+    readonly config: BitbucketServerConfig,
+    readonly logger: AirbyteLogger
+  ) {
+    super(logger);
+    this.projectRepoFilter = new ProjectRepoFilter(
+      config.projects ?? [],
+      config.repositories ?? []
+    );
+  }
+
   get server(): BitbucketServer {
     return BitbucketServer.instance(this.config, this.logger);
   }
 
   async *projects(): AsyncGenerator<Project> {
-    for (const project of await this.server.projects(this.config.projects)) {
+    for (const project of await this.server.projects(
+      this.projectRepoFilter.getProjectKeys()
+    )) {
       yield project;
     }
   }

--- a/sources/bitbucket-server-source/src/streams/project_users.ts
+++ b/sources/bitbucket-server-source/src/streams/project_users.ts
@@ -12,7 +12,7 @@ export class ProjectUsers extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {
@@ -24,7 +24,7 @@ export class ProjectUsers extends StreamBase {
   }
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const project of await this.server.projects(this.config.projects)) {
+    for await (const project of this.projects()) {
       yield {projectKey: project.key};
     }
   }

--- a/sources/bitbucket-server-source/src/streams/projects.ts
+++ b/sources/bitbucket-server-source/src/streams/projects.ts
@@ -1,4 +1,4 @@
-import {AirbyteLogger, StreamKey, SyncMode} from 'faros-airbyte-cdk';
+import {AirbyteLogger, StreamKey} from 'faros-airbyte-cdk';
 import {Project} from 'faros-airbyte-common/bitbucket-server';
 import {Dictionary} from 'ts-essentials';
 
@@ -10,7 +10,7 @@ export class Projects extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {

--- a/sources/bitbucket-server-source/src/streams/pull_request_activities.ts
+++ b/sources/bitbucket-server-source/src/streams/pull_request_activities.ts
@@ -14,7 +14,7 @@ export class PullRequestActivities extends PullRequestSubStream {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {

--- a/sources/bitbucket-server-source/src/streams/pull_request_diffs.ts
+++ b/sources/bitbucket-server-source/src/streams/pull_request_diffs.ts
@@ -14,7 +14,7 @@ export class PullRequestDiffs extends PullRequestSubStream {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {

--- a/sources/bitbucket-server-source/src/streams/pull_request_substream.ts
+++ b/sources/bitbucket-server-source/src/streams/pull_request_substream.ts
@@ -29,7 +29,7 @@ export abstract class PullRequestSubStream extends StreamBase {
       const projectKey = await this.fetchProjectKey(project.key);
       for (const repo of await this.server.repositories(
         projectKey,
-        this.config.repositories
+        this.projectRepoFilter
       )) {
         yield {
           projectKey,

--- a/sources/bitbucket-server-source/src/streams/pull_requests.ts
+++ b/sources/bitbucket-server-source/src/streams/pull_requests.ts
@@ -15,7 +15,7 @@ export class PullRequests extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {
@@ -35,7 +35,7 @@ export class PullRequests extends StreamBase {
       const projectKey = await this.fetchProjectKey(project.key);
       for (const repo of await this.server.repositories(
         projectKey,
-        this.config.repositories
+        this.projectRepoFilter
       )) {
         yield {
           projectKey,

--- a/sources/bitbucket-server-source/src/streams/repositories.ts
+++ b/sources/bitbucket-server-source/src/streams/repositories.ts
@@ -12,7 +12,7 @@ export class Repositories extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {
@@ -36,7 +36,7 @@ export class Repositories extends StreamBase {
   ): AsyncGenerator<Repository> {
     for (const repo of await this.server.repositories(
       streamSlice.projectKey,
-      this.config.repositories
+      this.projectRepoFilter
     )) {
       yield repo;
     }

--- a/sources/bitbucket-server-source/src/streams/tags.ts
+++ b/sources/bitbucket-server-source/src/streams/tags.ts
@@ -12,7 +12,7 @@ export class Tags extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {
@@ -28,7 +28,7 @@ export class Tags extends StreamBase {
       const projectKey = await this.fetchProjectKey(project.key);
       for (const repo of await this.server.repositories(
         projectKey,
-        this.config.repositories
+        this.projectRepoFilter
       )) {
         yield {
           projectKey,

--- a/sources/bitbucket-server-source/src/streams/users.ts
+++ b/sources/bitbucket-server-source/src/streams/users.ts
@@ -1,4 +1,4 @@
-import {AirbyteLogger, StreamKey, SyncMode} from 'faros-airbyte-cdk';
+import {AirbyteLogger, StreamKey} from 'faros-airbyte-cdk';
 import {User} from 'faros-airbyte-common/bitbucket-server';
 import {Dictionary} from 'ts-essentials';
 
@@ -10,7 +10,7 @@ export class Users extends StreamBase {
     readonly config: BitbucketServerConfig,
     readonly logger: AirbyteLogger
   ) {
-    super(logger);
+    super(config, logger);
   }
 
   getJsonSchema(): Dictionary<any> {

--- a/sources/bitbucket-server-source/test/index.test.ts
+++ b/sources/bitbucket-server-source/test/index.test.ts
@@ -123,7 +123,7 @@ describe('index', () => {
       );
     });
     const source = new sut.BitbucketServerSource(logger);
-    const streams = source.streams({} as any);
+    const streams = source.streams({repositories: ['PROJ1/repo1']} as any);
     const projectsStream = streams[6];
     const iter = projectsStream.readRecords(SyncMode.FULL_REFRESH, null, {
       projectKey: 'PROJ1',

--- a/sources/bitbucket-server-source/test/project-repo-filter.test.ts
+++ b/sources/bitbucket-server-source/test/project-repo-filter.test.ts
@@ -1,0 +1,25 @@
+import * as sut from '../src/bitbucket-server/project-repo-filter';
+
+describe('ProjectRepoFilter', () => {
+  test('getProjectKeys', () => {
+    const filter = new sut.ProjectRepoFilter(
+      ['proj1', 'PROJ2'],
+      ['proj1/repo1', 'proj2/repo2', 'proj3/repo3']
+    );
+    expect(filter.getProjectKeys()).toStrictEqual(['proj1', 'proj2', 'proj3']);
+  });
+
+  test('isIncluded', () => {
+    const filter = new sut.ProjectRepoFilter(
+      ['proj3'],
+      ['proj1/repo1', 'proj2/repo2']
+    );
+    expect(filter.isIncluded('proj1/repo1')).toBe(true);
+    expect(filter.isIncluded('PROJ1/REPO1')).toBe(true);
+    expect(filter.isIncluded('proj2/repo2')).toBe(true);
+    expect(filter.isIncluded('proj3/repo3')).toBe(true);
+    expect(filter.isIncluded('proj1/repo4')).toBe(false);
+    expect(filter.isIncluded('proj2/repo5')).toBe(false);
+    expect(filter.isIncluded('proj4/repo6')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Fixes a couple of bugs:
1) Needed to normalize before comparisons of repo names with repos from the config
2) The list of repos from the config was being compared against for ALL project keys, so if we passed a config with projects `A` and `B` and repos `A/R1` we would pull `A/R1` and no repos from project `B`. The expectation was the we'd pull all repos from project `B`.

Additionally, we automatically include the projects from the repos' project keys now. So we don't need to list a project key if we already configure a repo from that project.

Example:
In this config:
projects: `A`, `B`
repos: `A/R1`

Project `A` is redundant, we can just specify:
projects: `B`
repos: `A/R1`

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
