### PR TITLE
FAI-10151 - Jira Sprints source stream and converter

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/jira/faros_sprints.ts
+++ b/destinations/airbyte-faros-destination/src/converters/jira/faros_sprints.ts
@@ -1,0 +1,30 @@
+import {AirbyteRecord} from 'faros-airbyte-cdk';
+import {camelCase, upperFirst} from 'lodash';
+
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
+import {JiraConverter} from './common';
+
+export class FarosSprints extends JiraConverter {
+  readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_Sprint'];
+  async convert(
+    record: AirbyteRecord,
+    ctx: StreamContext
+  ): Promise<ReadonlyArray<DestinationRecord>> {
+    const sprint = record.record.data;
+
+    return [
+      {
+        model: 'tms_Sprint',
+        record: {
+          uid: String(sprint.id),
+          name: sprint.name,
+          state: upperFirst(camelCase(sprint.state)),
+          startedAt: sprint.startedAt,
+          endedAt: sprint.endedAt,
+          closedAt: sprint.closedAt,
+          source: this.source,
+        },
+      },
+    ];
+  }
+}

--- a/destinations/airbyte-faros-destination/test/converters/jira.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/jira.test.ts
@@ -82,6 +82,7 @@ describe('jira', () => {
       faros_issue_pull_requests: 1,
       faros_sprint_reports: 2,
       faros_board_issues: 4,
+      faros_sprints: 1,
     };
     const processed = _(processedByStream)
       .toPairs()
@@ -95,7 +96,7 @@ describe('jira', () => {
       tms_Project: 1,
       tms_ProjectReleaseRelationship: 3,
       tms_Release: 3,
-      tms_Sprint: 12,
+      tms_Sprint: 13,
       tms_Task: 5,
       tms_TaskAssignment: 1,
       tms_TaskBoard: 1,

--- a/destinations/airbyte-faros-destination/test/resources/jira/all-streams.log
+++ b/destinations/airbyte-faros-destination/test/resources/jira/all-streams.log
@@ -251,10 +251,11 @@
 {"type": "LOG", "log": {"level": "INFO", "message": "Syncing stream: workflow_status_categories "}}
 {"type": "LOG", "log": {"level": "INFO", "message": "Read 4 records from workflow_status_categories stream"}}
 {"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_issue_pull_requests", "emitted_at": 1709750000862, "data": {"issue": {"key": "TEST-123", "updated": "2024-03-05T17:56:24.884Z", "project": "TEST" }, "repo": {"source": "GitHub", "org": "faros", "name": "test" },"number": 1234}}}
-{"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_sprint_reports", "emitted_at": 1712673712093, "data": {"id": 52, "completedAt": null, "completedPoints": 10, "notCompletedPoints": 3, "puntedPoints": 4, "completedInAnotherSprintPoints": 1, "plannedPoints": 18, "projectKey": "TEST", "boardId": "1"}}}
-{"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_sprint_reports", "emitted_at": 1712673712187, "data": {"id": 53, "completedAt": null, "completedPoints": 9, "notCompletedPoints": 4, "puntedPoints": 4, "completedInAnotherSprintPoints": 3, "plannedPoints": 20, "projectKey": "TEST", "boardId": "2"}}}
+{"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_sprint_reports", "emitted_at": 1712673712093, "data": {"id": 52, "completedAt": null, "completedPoints": 10, "notCompletedPoints": 3, "puntedPoints": 4, "completedInAnotherSprintPoints": 1, "plannedPoints": 18, "boardId": "1"}}}
+{"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_sprint_reports", "emitted_at": 1712673712187, "data": {"id": 53, "completedAt": null, "completedPoints": 9, "notCompletedPoints": 4, "puntedPoints": 4, "completedInAnotherSprintPoints": 3, "plannedPoints": 20, "boardId": "2"}}}
 {"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_board_issues", "emitted_at": 1712673836940,"data": {"key": "TEST-1","boardId": "1"}}}
 {"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_board_issues", "emitted_at": 1712673836940,"data": {"key": "TEST-2","boardId": "1"}}}
 {"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_board_issues", "emitted_at": 1712673836940,"data": {"key": "TEST-3","boardId": "1"}}}
 {"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_board_issues", "emitted_at": 1712673836940,"data": {"key": "TEST-4","boardId": "1"}}}
+{"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_sprints", "emmited_at": 1712678736940, "data": {"id": 54, "boardId": "1", "name": "Test Sprint", "state": "closed", "startedAt": "2024-04-12T15:30:44.439Z", "endedAt": "2024-04-19T07:00:00.000Z", "closedAt": "2024-04-12T15:31:06.115Z"}}}
 {"type": "LOG", "log": {"level": "INFO", "message": "Finished syncing SourceJira"}}

--- a/destinations/airbyte-faros-destination/test/resources/jira/catalog.json
+++ b/destinations/airbyte-faros-destination/test/resources/jira/catalog.json
@@ -323,6 +323,12 @@
         "name": "mytestsource__jira__faros_board_issues"
       },
       "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
+        "name": "mytestsource__jira__faros_sprints"
+      },
+      "destination_sync_mode": "append"
     }
   ]
 }

--- a/sources/jira-source/resources/queries/tms-sprint-board.gql
+++ b/sources/jira-source/resources/queries/tms-sprint-board.gql
@@ -2,7 +2,8 @@ query SprintBoardRelationship(
   $source: String!
   $board: String!
   $pageSize: Int,
-  $offset: Int
+  $offset: Int,
+  $closedAtAfter: timestamptz
 ) {
   tms_SprintBoardRelationship(
     where: {
@@ -12,6 +13,7 @@ query SprintBoardRelationship(
       },
       sprint: {
         source: { _eq: $source }
+        closedAt: { _gte: $closedAtAfter }
       },
     },
     limit: $pageSize,

--- a/sources/jira-source/resources/schemas/farosSprintReports.json
+++ b/sources/jira-source/resources/schemas/farosSprintReports.json
@@ -11,7 +11,7 @@
     "projectKey": {
       "type": "string"
     },
-    "completedAt": {
+    "closedAt": {
       "type": "string",
       "format": "date-time"
     },

--- a/sources/jira-source/resources/schemas/farosSprints.json
+++ b/sources/jira-source/resources/schemas/farosSprints.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "number"
+    },
+    "boardId": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "endedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/sources/jira-source/src/index.ts
+++ b/sources/jira-source/src/index.ts
@@ -16,6 +16,7 @@ import {RunMode, WebhookSupplementStreamNames} from './streams/common';
 import {FarosBoardIssues} from './streams/faros_board_issues';
 import {FarosIssuePullRequests} from './streams/faros_issue_pull_requests';
 import {FarosSprintReports} from './streams/faros_sprint_reports';
+import {FarosSprints} from './streams/faros_sprints';
 
 const DEFAULT_API_URL = 'https://prod.api.faros.ai';
 
@@ -62,6 +63,7 @@ export class JiraSource extends AirbyteSourceBase<JiraConfig> {
       new FarosIssuePullRequests(config, this.logger, farosClient),
       new FarosSprintReports(config, this.logger, farosClient),
       new FarosBoardIssues(config, this.logger, farosClient),
+      new FarosSprints(config, this.logger),
     ];
   }
 

--- a/sources/jira-source/src/models.ts
+++ b/sources/jira-source/src/models.ts
@@ -36,11 +36,20 @@ export interface PullRequest {
 export interface SprintReport {
   readonly id: number;
   readonly boardId?: string;
-  readonly projectKey?: string;
-  readonly completedAt?: Date;
+  readonly closedAt?: Date;
   readonly completedPoints?: number;
   readonly completedInAnotherSprintPoints?: number;
   readonly notCompletedPoints?: number;
   readonly puntedPoints?: number;
   readonly plannedPoints?: number;
+}
+
+export interface Sprint {
+  readonly id: number;
+  readonly boardId?: string;
+  readonly name: string;
+  readonly state: string;
+  readonly startedAt?: Date;
+  readonly endedAt?: Date;
+  readonly closedAt?: Date;
 }

--- a/sources/jira-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/jira-source/test/__snapshots__/index.test.ts.snap
@@ -130,13 +130,12 @@ exports[`index streams - sprint_reports 1`] = `
 [
   {
     "boardId": "1",
-    "completedAt": 2024-03-14T12:00:00.000Z,
+    "closedAt": 2024-03-14T12:00:00.000Z,
     "completedInAnotherSprintPoints": 5,
     "completedPoints": 10,
     "id": 1,
     "notCompletedPoints": 15,
     "plannedPoints": 50,
-    "projectKey": "TEST",
     "puntedPoints": 20,
   },
 ]
@@ -146,14 +145,27 @@ exports[`index streams - sprint_reports with run mode WebhookSupplement using Fa
 [
   {
     "boardId": "1",
-    "completedAt": 2024-01-01T00:00:00.000Z,
+    "closedAt": 2024-01-01T00:00:00.000Z,
     "completedInAnotherSprintPoints": 5,
     "completedPoints": 10,
     "id": "1",
     "notCompletedPoints": 15,
     "plannedPoints": 50,
-    "projectKey": "TEST",
     "puntedPoints": 20,
+  },
+]
+`;
+
+exports[`index streams - sprints 1`] = `
+[
+  {
+    "boardId": "1",
+    "closedAt": 2024-03-14T12:00:00.000Z,
+    "endedAt": undefined,
+    "id": 1,
+    "name": undefined,
+    "startedAt": undefined,
+    "state": "closed",
   },
 ]
 `;

--- a/sources/jira-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/jira-source/test/__snapshots__/index.test.ts.snap
@@ -161,10 +161,10 @@ exports[`index streams - sprints 1`] = `
   {
     "boardId": "1",
     "closedAt": 2024-03-14T12:00:00.000Z,
-    "endedAt": undefined,
+    "endedAt": 2024-03-14T12:00:00.000Z,
     "id": 1,
-    "name": undefined,
-    "startedAt": undefined,
+    "name": "Test Sprint",
+    "startedAt": 2024-03-14T12:00:00.000Z,
     "state": "closed",
   },
 ]

--- a/sources/jira-source/test/index.test.ts
+++ b/sources/jira-source/test/index.test.ts
@@ -246,6 +246,24 @@ describe('index', () => {
     );
   });
 
+  test('streams - sprints', async () => {
+    await testStream(
+      3,
+      readTestResourceFile('config.json'),
+      {
+        agile: {
+          board: {
+            getBoard: jest
+              .fn()
+              .mockResolvedValue(readTestResourceFile('board.json')),
+            getAllSprints: paginate(readTestResourceFile('sprints.json')),
+          },
+        },
+      },
+      {board: '1'}
+    );
+  });
+
   test('onBeforeRead with run_mode WebhookSupplement should filter streams', async () => {
     const source = new sut.JiraSource(logger);
     const catalog = readTestResourceFile('catalog.json');

--- a/sources/jira-source/test_files/sprints.json
+++ b/sources/jira-source/test_files/sprints.json
@@ -1,7 +1,10 @@
 [
   {
     "id": 1,
+    "name": "Test Sprint",
     "state": "closed",
+    "startDate": "2024-03-14T12:00:00Z",
+    "endDate": "2024-03-14T12:00:00Z",
     "completeDate": "2024-03-14T12:00:00Z"
   }
 ]


### PR DESCRIPTION
## Description
Jira Sprints source stream and converter and some refactor to sprint-reports stream to remove unnecessary checks and projectKey, and also support update range for faros gql query

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
