### PR TITLE
Save incremental state from source status messages

### DIFF
--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -780,6 +780,7 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
                   syncErrors.warnings.push(syncMessage);
                 }
               }
+              stateMessage = new AirbyteStateMessage(msg.state);
             } else if (isSourceConfigMessage(msg)) {
               await updateLocalAccount?.(msg);
             } else if (isSourceLogsMessage(msg)) {


### PR DESCRIPTION
## Description

If a stream has a non-fatal error,  our source cdk outputs a source status message with state instead of a standard state message. The Faros destination should output that state data instead of ignoring it.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
