### PR TITLE
Add .nx/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 acceptance_tests_logs/
 .vscode/
 .idea/
+.nx/
 
 .DS_Store
 acceptance-test-*.log


### PR DESCRIPTION
## Description

Our dependabot PRs have started pushing their nx cache (caused by our package-lock.json reformatting step).
https://github.com/faros-ai/airbyte-connectors/pull/1434

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
