### PR TITLE
FAI-11028 Refactor project/board slicing + handle 400

### DIFF
--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -643,25 +643,13 @@ export class Jira {
     );
     return this.iterate(
       (startAt) =>
-        this.api.v2.issueSearch
-          .searchForIssuesUsingJql({
-            jql,
-            startAt,
-            fields: [...fieldIds, ...additionalFieldIds],
-            expand: fetchKeysOnly ? undefined : 'changelog',
-            maxResults: this.maxPageSize,
-          })
-          .catch((err: any) => {
-            // https://github.com/MrRefactoring/jira.js/blob/master/src/clients/baseClient.ts#L138
-            if (err?.status !== 400) {
-              throw wrapApiError(err);
-            }
-            // FAI-5497: Log an error instead of failing feed if 400
-            this.logger.warn(
-              `Failed to sync project ${projectId} due to invalid filter. Skipping.`
-            );
-            return {issues: []};
-          }),
+        this.api.v2.issueSearch.searchForIssuesUsingJql({
+          jql,
+          startAt,
+          fields: [...fieldIds, ...additionalFieldIds],
+          expand: fetchKeysOnly ? undefined : 'changelog',
+          maxResults: this.maxPageSize,
+        }),
       async (item: any) => {
         return issueTransformer.toIssue(item);
       },

--- a/sources/jira-source/src/project-board-filter.ts
+++ b/sources/jira-source/src/project-board-filter.ts
@@ -1,0 +1,93 @@
+import {AirbyteLogger} from 'faros-airbyte-cdk';
+import {FarosClient} from 'faros-js-client';
+import {Memoize} from 'typescript-memoize';
+
+import {DEFAULT_GRAPH, Jira, JiraConfig} from './jira';
+import {RunMode} from './streams/common';
+
+export class ProjectBoardFilter {
+  projects: Set<string> | undefined;
+  boards: Set<string> | undefined;
+
+  constructor(
+    private readonly config: JiraConfig,
+    private readonly logger: AirbyteLogger,
+    private readonly farosClient?: FarosClient
+  ) {}
+
+  @Memoize()
+  async getProjects(): Promise<ReadonlyArray<string>> {
+    if (!this.projects) {
+      this.projects = new Set();
+
+      const jira = await Jira.instance(this.config, this.logger);
+      if (!this.config.projects) {
+        const projects = this.supportsFarosClient()
+          ? jira.getProjectsFromGraph(
+              this.farosClient,
+              this.config.graph ?? DEFAULT_GRAPH
+            )
+          : jira.getProjects();
+        for await (const project of projects) {
+          this.projects.add(project.key);
+        }
+      } else {
+        for (const project of this.config.projects) {
+          if (jira.isProjectInBucket(project)) this.projects.add(project);
+        }
+      }
+    }
+    return Array.from(this.projects);
+  }
+
+  @Memoize()
+  async getBoards(): Promise<ReadonlyArray<string>> {
+    if (!this.boards) {
+      this.boards = new Set();
+
+      const jira = await Jira.instance(this.config, this.logger);
+      if (!this.config.boards) {
+        const boards = this.supportsFarosClient()
+          ? jira.getBoardsFromGraph(
+              this.farosClient,
+              this.config.graph ?? DEFAULT_GRAPH
+            )
+          : jira.getBoards();
+        for await (const board of boards) {
+          await this.maybeIncludeBoard(board.id.toString());
+        }
+      } else {
+        for (const board of this.config.boards) {
+          if (await jira.isBoardInBucket(board)) {
+            await this.maybeIncludeBoard(board);
+          }
+        }
+      }
+    }
+    return Array.from(this.boards);
+  }
+
+  private async maybeIncludeBoard(boardId: string): Promise<void> {
+    const jira = await Jira.instance(this.config, this.logger);
+    const boardConfig = await jira.getBoardConfiguration(boardId);
+    // Jira Agile API GetConfiguration response type does not include key property
+    const projectKey = (boardConfig.location as any)?.key;
+    if (!projectKey) {
+      this.logger.warn(`No project key found for board ${boardId}`);
+      return;
+    }
+
+    // Ensure projects is populated
+    await this.getProjects();
+
+    if (this.projects.has(projectKey)) {
+      this.boards.add(boardId);
+    }
+  }
+
+  private supportsFarosClient(): boolean {
+    return (
+      this.config.run_mode === RunMode.WebhookSupplement && !!this.farosClient
+    );
+  }
+}

--- a/sources/jira-source/src/streams/faros_board_issues.ts
+++ b/sources/jira-source/src/streams/faros_board_issues.ts
@@ -24,6 +24,8 @@ export class FarosBoardIssues extends StreamWithBoardSlices {
     const boardId = streamSlice.board;
     const boardConfig = await jira.getBoardConfiguration(boardId);
     const boardJql = await jira.getBoardJQL(boardConfig.filter.id);
+    // Jira Agile API GetConfiguration response type does not include key property
+    // but, in practice, it is actually present
     const projectKey = boardConfig.location['key'];
     try {
       for await (const issue of jira.getIssues(

--- a/sources/jira-source/src/streams/faros_board_issues.ts
+++ b/sources/jira-source/src/streams/faros_board_issues.ts
@@ -3,7 +3,7 @@ import {IssueCompact} from 'faros-airbyte-common/jira';
 import {Dictionary} from 'ts-essentials';
 
 import {Jira} from '../jira';
-import {BoardStreamSlice, StreamState, StreamWithBoardSlices} from './common';
+import {BoardStreamSlice, StreamWithBoardSlices} from './common';
 
 export class FarosBoardIssues extends StreamWithBoardSlices {
   getJsonSchema(): Dictionary<any, string> {
@@ -17,8 +17,7 @@ export class FarosBoardIssues extends StreamWithBoardSlices {
   async *readRecords(
     syncMode: SyncMode,
     cursorField?: string[],
-    streamSlice?: BoardStreamSlice,
-    streamState?: StreamState
+    streamSlice?: BoardStreamSlice
   ): AsyncGenerator<IssueCompact> {
     const jira = await Jira.instance(this.config, this.logger);
     const boardId = streamSlice.board;
@@ -26,10 +25,6 @@ export class FarosBoardIssues extends StreamWithBoardSlices {
     const boardJql = await jira.getBoardJQL(boardConfig.filter.id);
     // Jira Agile API GetConfiguration response type does not include key property
     const projectKey = (boardConfig.location as any)?.key;
-    if (!projectKey) {
-      this.logger.warn(`No project key found for board ${boardId}`);
-      return;
-    }
     for await (const issue of jira.getIssues(
       projectKey,
       undefined,

--- a/sources/jira-source/src/streams/faros_board_issues.ts
+++ b/sources/jira-source/src/streams/faros_board_issues.ts
@@ -23,8 +23,7 @@ export class FarosBoardIssues extends StreamWithBoardSlices {
     const boardId = streamSlice.board;
     const boardConfig = await jira.getBoardConfiguration(boardId);
     const boardJql = await jira.getBoardJQL(boardConfig.filter.id);
-    // Jira Agile API GetConfiguration response type does not include key property
-    const projectKey = (boardConfig.location as any)?.key;
+    const projectKey = boardConfig.location['key'];
     for await (const issue of jira.getIssues(
       projectKey,
       undefined,


### PR DESCRIPTION
## Description

Adds error handling for `searchForIssuesUsingJql`
Adds `ProjectBoardFilter` to encapsulate the logic that determines which projects and boards to pull (this includes a fix to make sure that boards to be pulled belong to a project being pulled as well).

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
