### PR TITLE
Jira migrate to 4.0.0 client

### DIFF
--- a/faros-airbyte-common/package.json
+++ b/faros-airbyte-common/package.json
@@ -57,7 +57,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "jira.js": "^3.0.1"
+    "jira.js": "^4.0.0"
   },
   "jest": {
     "coverageDirectory": "out/coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "graphql-request": "^5.0.0",
         "is-retry-allowed": "^2.2.0",
         "jenkins": "^0.28.1",
-        "jira.js": "^3.0.1",
+        "jira.js": "^4.0.0",
         "json-schema-traverse": "^1.0.0",
         "json-to-graphql-query": "^2.2.0",
         "jsonata": "^1.8.7",
@@ -12897,9 +12897,9 @@
       }
     },
     "node_modules/jira.js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/jira.js/-/jira.js-3.0.5.tgz",
-      "integrity": "sha512-czIz7IxSGgW8eO9POYV7KTyLfRvrUvnw0DWfRZp4zWwPtiTNL8tkDa4E8HuFeOBk/aCG2SG0mJ/kdrKInn3cQw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jira.js/-/jira.js-4.0.0.tgz",
+      "integrity": "sha512-gFBKo4yjWmG3b6OZ8wz5xKLfa5GURg93FmAVX3YM3X5qtw7DvayXGsfe5JZnTaHD//qU2GCULYp4gz5POTggPg==",
       "dependencies": {
         "axios": "^1.6.8",
         "form-data": "^4.0.0",

--- a/sources/jira-source/package.json
+++ b/sources/jira-source/package.json
@@ -38,7 +38,6 @@
     "faros-js-client": "^0.4.1",
     "moment": "^2.29.1",
     "typescript-memoize": "^1.1.0",
-    "jira.js": "^3.0.1",
     "verror": "^1.10.1",
     "p-limit": "3.1.0"
   },

--- a/sources/jira-source/src/retry.ts
+++ b/sources/jira-source/src/retry.ts
@@ -1,4 +1,4 @@
-import {AirbyteLogger} from 'faros-airbyte-cdk';
+import {AirbyteLogger, wrapApiError} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-js-client';
 import jira from 'jira.js';
 import _ from 'lodash';
@@ -32,9 +32,6 @@ export function WithRetry<T extends Retryable>(
 
     // https://developer.atlassian.com/cloud/jira/platform/rate-limiting/#rate-limit-responses
     static getDelay(attempt: number, response: any): number {
-      // TODO - Find a way to get the response headers as new client version
-      // suppresses them with no way to override behavior
-      // https://github.com/MrRefactoring/jira.js/issues/299
       const headers = response?.headers ?? {};
       const attemptDelay = 3000 * attempt;
       let responseDelay = 0;
@@ -51,7 +48,7 @@ export function WithRetry<T extends Retryable>(
       }
       // Override delay if one is present in the response
       // and is larger than the delay for this attempt
-      const jitter = _.random(0, 500);
+      const jitter = _.random(0, 5000);
       return Math.max(attemptDelay, responseDelay) + jitter;
     }
 
@@ -78,7 +75,7 @@ export function WithRetry<T extends Retryable>(
           if (!Retry._isRetryable(err)) {
             break;
           }
-          const delay = Retry.getDelay(attempt, err.response);
+          const delay = Retry.getDelay(attempt, err?.cause?.response);
           logger?.warn(
             `Retry attempt ${attempt} of ${this._maxAttempts}. Retrying in ${delay} milliseconds`
           );
@@ -86,7 +83,7 @@ export function WithRetry<T extends Retryable>(
           attempt++;
         }
       }
-      throw lastErr;
+      throw wrapApiError(lastErr);
     }
 
     async sendRequest<T>(

--- a/sources/jira-source/src/retry.ts
+++ b/sources/jira-source/src/retry.ts
@@ -33,7 +33,7 @@ export function WithRetry<T extends Retryable>(
     // https://developer.atlassian.com/cloud/jira/platform/rate-limiting/#rate-limit-responses
     static getDelay(attempt: number, response: any): number {
       const headers = response?.headers ?? {};
-      const attemptDelay = 3000 * attempt;
+      const attemptDelay = 5000 * attempt;
       let responseDelay = 0;
       if (_.isNumber(headers['Retry-After'])) {
         responseDelay = 1000 * headers['Retry-After'];
@@ -48,7 +48,7 @@ export function WithRetry<T extends Retryable>(
       }
       // Override delay if one is present in the response
       // and is larger than the delay for this attempt
-      const jitter = _.random(0, 5000);
+      const jitter = _.random(0, 500);
       return Math.max(attemptDelay, responseDelay) + jitter;
     }
 

--- a/sources/jira-source/test/client.test.ts
+++ b/sources/jira-source/test/client.test.ts
@@ -11,7 +11,7 @@ jest.mock('faros-js-client');
 function apiError(status: number, headers: Record<string, any> = {}): Error {
   const err = new Error('API error');
   (err as any).status = status;
-  (err as any).response = {headers};
+  (err as any).cause = {response: headers};
   return err;
 }
 
@@ -205,30 +205,30 @@ describe('client', () => {
 
   test('gets attempt delay', () => {
     const delay1 = ClientWithRetry.getDelay(1, {});
-    expect(delay1).toBeGreaterThanOrEqual(3000);
-    expect(delay1).toBeLessThanOrEqual(3500);
+    expect(delay1).toBeGreaterThanOrEqual(5000);
+    expect(delay1).toBeLessThanOrEqual(5500);
 
     const delay2 = ClientWithRetry.getDelay(2, {});
-    expect(delay2).toBeGreaterThanOrEqual(6000);
-    expect(delay2).toBeLessThanOrEqual(6500);
+    expect(delay2).toBeGreaterThanOrEqual(10_000);
+    expect(delay2).toBeLessThanOrEqual(10_500);
 
     const delay3 = ClientWithRetry.getDelay(3, {});
-    expect(delay3).toBeGreaterThanOrEqual(9000);
-    expect(delay3).toBeLessThanOrEqual(9500);
+    expect(delay3).toBeGreaterThanOrEqual(15_000);
+    expect(delay3).toBeLessThanOrEqual(15_500);
   });
 
   test('gets attempt delay when undefined response', () => {
     const delay1 = ClientWithRetry.getDelay(1, undefined);
-    expect(delay1).toBeGreaterThanOrEqual(3000);
-    expect(delay1).toBeLessThanOrEqual(3500);
+    expect(delay1).toBeGreaterThanOrEqual(5000);
+    expect(delay1).toBeLessThanOrEqual(5500);
 
     const delay2 = ClientWithRetry.getDelay(2, undefined);
-    expect(delay2).toBeGreaterThanOrEqual(6000);
-    expect(delay2).toBeLessThanOrEqual(6500);
+    expect(delay2).toBeGreaterThanOrEqual(10_000);
+    expect(delay2).toBeLessThanOrEqual(10_500);
 
     const delay3 = ClientWithRetry.getDelay(3, undefined);
-    expect(delay3).toBeGreaterThanOrEqual(9000);
-    expect(delay3).toBeLessThanOrEqual(9500);
+    expect(delay3).toBeGreaterThanOrEqual(15_000);
+    expect(delay3).toBeLessThanOrEqual(15_500);
   });
 
   test('gets delay from Retry-After header', () => {
@@ -242,29 +242,29 @@ describe('client', () => {
     const reset = DateTime.utc().plus({minutes: 1, seconds: 1}).toISO();
     const response = {headers: {'X-RateLimit-Reset': reset}};
     const delay = ClientWithRetry.getDelay(1, response);
-    expect(delay).toBeGreaterThanOrEqual(60_000);
+    expect(delay).toBeGreaterThanOrEqual(61_000);
     expect(delay).toBeLessThanOrEqual(61_500);
   });
 
   test('ignores invalid Retry-After header', () => {
     const response = {headers: {'Retry-After': 'invalid'}};
     const delay = ClientWithRetry.getDelay(1, response);
-    expect(delay).toBeGreaterThanOrEqual(3000);
-    expect(delay).toBeLessThanOrEqual(3500);
+    expect(delay).toBeGreaterThanOrEqual(5000);
+    expect(delay).toBeLessThanOrEqual(5500);
   });
 
   test('ignores invalid X-RateLimit-Reset header', () => {
     const response = {headers: {'X-RateLimit-Reset': 'invalid'}};
     const delay = ClientWithRetry.getDelay(1, response);
-    expect(delay).toBeGreaterThanOrEqual(3000);
-    expect(delay).toBeLessThanOrEqual(3500);
+    expect(delay).toBeGreaterThanOrEqual(5000);
+    expect(delay).toBeLessThanOrEqual(5500);
   });
 
   test('uses attempt delay if larger than response delay', () => {
     const response = {headers: {'Retry-After': 2}};
     const delay = ClientWithRetry.getDelay(1, response);
-    expect(delay).toBeGreaterThanOrEqual(3000);
-    expect(delay).toBeLessThanOrEqual(3500);
+    expect(delay).toBeGreaterThanOrEqual(5000);
+    expect(delay).toBeLessThanOrEqual(5500);
   });
 
   test('get API stats', async () => {


### PR DESCRIPTION
## Description

- Upgrade to https://github.com/MrRefactoring/jira.js?tab=readme-ov-file#error-handling
- Increase base sleep to 5s instead of 3s

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
