### PR TITLE
FAI-11093 Refactor tests + add ability to check records

### DIFF
--- a/destinations/airbyte-faros-destination/test/cli.ts
+++ b/destinations/airbyte-faros-destination/test/cli.ts
@@ -4,11 +4,16 @@ import path from 'path';
 import {Readable, Writable} from 'stream';
 
 export async function read(s: Readable): Promise<string> {
+  const lines = await readLines(s);
+  return lines.join('');
+}
+
+export async function readLines(s: Readable): Promise<ReadonlyArray<string>> {
   const lines: string[] = [];
   for await (const line of s) {
     lines.push(line);
   }
-  return lines.join('');
+  return lines;
 }
 
 export interface CLIOptions {

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_jira.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_jira.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`faros_jira process records from all streams 1`] = `
+Array [
+  Object {
+    "tms_TaskBoardRelationship": Object {
+      "board": Object {
+        "source": "Jira",
+        "uid": "1",
+      },
+      "source": "Jira",
+      "task": Object {
+        "source": "Jira",
+        "uid": "TEST-1",
+      },
+    },
+  },
+]
+`;

--- a/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/azurepipeline.test.ts
@@ -1,13 +1,11 @@
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
-import {CLI, read} from './../cli';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {azurepipelineAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('azurepipeline', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/azurepipeline/catalog.json';
   let configPath: string;
@@ -15,7 +13,7 @@ describe('azurepipeline', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -23,32 +21,12 @@ describe('azurepipeline', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(azurepipelineAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       builds: 4,
       pipelines: 2,
       releases: 1,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       cicd_Build: 4,
       cicd_BuildCommitAssociation: 1,
       cicd_BuildStep: 6,
@@ -57,6 +35,13 @@ describe('azurepipeline', () => {
       cicd_Release: 1,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: azurepipelineAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/bamboohr.test.ts
@@ -2,13 +2,11 @@ import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
 import {Edition, InvalidRecordStrategy} from '../../src';
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {bamboohrAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('bamboohr', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/bamboohr/catalog.json';
   let configPath: string;
@@ -16,18 +14,18 @@ describe('bamboohr', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(
-      mockttp.url,
-      InvalidRecordStrategy.SKIP,
-      Edition.CLOUD,
-      {},
-      {
+    configPath = await tempConfig({
+      api_url: mockttp.url,
+      invalid_record_strategy: InvalidRecordStrategy.SKIP,
+      edition: Edition.CLOUD,
+      edition_configs: {},
+      source_specific_configs: {
         bamboohr: {
           bootstrap_teams_from_managers: true,
           inactive_employment_history_status: ['Terminated', 'On-Leave'],
         },
-      }
-    );
+      },
+    });
   });
 
   afterEach(async () => {
@@ -35,30 +33,10 @@ describe('bamboohr', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(bamboohrAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       users: 87,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       geo_Address: 87,
       geo_Location: 87,
       identity_Identity: 87,
@@ -68,6 +46,13 @@ describe('bamboohr', () => {
       org_TeamMembership: 110,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: bamboohrAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/data.ts
+++ b/destinations/airbyte-faros-destination/test/converters/data.ts
@@ -8,6 +8,9 @@ export const githubAllStreamsLog = readTestResourceFile(
 export const jenkinsAllStreamsLog = readTestResourceFile(
   'jenkins/all-streams.log'
 );
+export const farosJiraAllStreamsLog = readTestResourceFile(
+  'faros_jira/all-streams.log'
+);
 export const jiraAllStreamsLog = readTestResourceFile('jira/all-streams.log');
 export const airtableSurveysAllStreamsLog = readTestResourceFile(
   'abstract-surveys/surveys/all-streams.log'

--- a/destinations/airbyte-faros-destination/test/converters/faros_jira.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/faros_jira.test.ts
@@ -1,19 +1,23 @@
 import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
+import {Edition, InvalidRecordStrategy} from '../../src';
 import {initMockttp, tempConfig} from '../testing-tools';
-import {backlogAllStreamsLog} from './data';
+import {farosJiraAllStreamsLog} from './data';
 import {destinationWriteTest} from './utils';
 
-describe('backlog', () => {
+describe('faros_jira', () => {
   const mockttp = getLocal({debug: false, recordTraffic: false});
-  const catalogPath = 'test/resources/backlog/catalog.json';
+  const catalogPath = 'test/resources/faros_jira/catalog.json';
   let configPath: string;
-  const streamNamePrefix = 'mytestsource__backlog__';
+  const streamNamePrefix = 'mytestsource__jira__';
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig({api_url: mockttp.url});
+    configPath = await tempConfig({
+      api_url: mockttp.url,
+      log_records: true,
+    });
   });
 
   afterEach(async () => {
@@ -22,30 +26,20 @@ describe('backlog', () => {
 
   test('process records from all streams', async () => {
     const expectedProcessedByStream = {
-      issues: 3,
-      projects: 1,
-      users: 2,
+      faros_board_issues: 1,
     };
     const expectedWrittenByModel = {
-      tms_Project: 1,
-      tms_Release: 1,
-      tms_Sprint: 2,
-      tms_Task: 3,
-      tms_TaskAssignment: 1,
-      tms_TaskBoard: 1,
-      tms_TaskBoardProjectRelationship: 1,
-      tms_TaskBoardRelationship: 3,
-      tms_TaskProjectRelationship: 3,
-      tms_User: 2,
+      tms_TaskBoardRelationship: 1,
     };
 
     await destinationWriteTest({
       configPath,
       catalogPath,
-      streamsLog: backlogAllStreamsLog,
+      streamsLog: farosJiraAllStreamsLog,
       streamNamePrefix,
       expectedProcessedByStream,
       expectedWrittenByModel,
+      checkRecordsData: (records) => expect(records).toMatchSnapshot(),
     });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/gitlab-ci.test.ts
@@ -1,13 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {gitlabCiAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('gitlab-ci', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/gitlab-ci/catalog.json';
   let configPath: string;
@@ -15,7 +12,7 @@ describe('gitlab-ci', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -23,34 +20,13 @@ describe('gitlab-ci', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(gitlabCiAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       groups: 5,
       projects: 8,
       pipelines: 9,
       jobs: 9,
     };
-
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       cicd_Build: 9,
       cicd_BuildCommitAssociation: 9,
       cicd_BuildStep: 9,
@@ -58,6 +34,13 @@ describe('gitlab-ci', () => {
       cicd_Pipeline: 8,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: gitlabCiAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/harness.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/harness.test.ts
@@ -1,13 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {harnessAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('harness', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/harness/catalog.json';
   let configPath: string;
@@ -15,7 +12,7 @@ describe('harness', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -23,35 +20,22 @@ describe('harness', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(harnessAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       executions: 2,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       cicd_Build: 1,
       cicd_Deployment: 2,
       compute_Application: 2,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: harnessAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/hygieia.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/hygieia.test.ts
@@ -1,18 +1,10 @@
-import {
-  AirbyteLog,
-  AirbyteLogLevel,
-} from 'faros-airbyte-cdk';
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {Edition, InvalidRecordStrategy} from '../../src';
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {hygieiaAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('hygieia', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/hygieia/catalog.json';
   let configPath: string;
@@ -20,7 +12,7 @@ describe('hygieia', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -28,34 +20,21 @@ describe('hygieia', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(hygieiaAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       collector_items: 1,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       cicd_Organization: 1,
       cicd_Pipeline: 1,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: hygieiaAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/notion.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/notion.test.ts
@@ -1,13 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {initMockttp, sourceSpecificTempConfig, testLogger} from '../testing-tools';
+import {initMockttp, sourceSpecificTempConfig} from '../testing-tools';
 import {notionAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('notion', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const streamNamePrefix = 'mytestsource__notion__';
   const catalogPath = 'test/resources/notion/catalog.json';
@@ -15,65 +12,42 @@ describe('notion', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await sourceSpecificTempConfig(
-      mockttp.url,
-      {
-        notion: {
-          kind_property: 'Kind',
-          projects: {
-            kind: 'Project',
-          },
-          epics: {
-            kind: 'Epic',
-          },
-          sprints: {
-            kind: 'Sprint',
-          },
-          tasks: {
-            kind: 'Task',
-            include_additional_properties: true,
-            properties: {
-              type: 'Task Type',
-              status: {
-                name: 'Status',
-                mapping: {
-                  todo: ['Not started'],
-                  in_progress: ['In progress'],
-                  done: ['Done'],
-                },
+    configPath = await sourceSpecificTempConfig(mockttp.url, {
+      notion: {
+        kind_property: 'Kind',
+        projects: {
+          kind: 'Project',
+        },
+        epics: {
+          kind: 'Epic',
+        },
+        sprints: {
+          kind: 'Sprint',
+        },
+        tasks: {
+          kind: 'Task',
+          include_additional_properties: true,
+          properties: {
+            type: 'Task Type',
+            status: {
+              name: 'Status',
+              mapping: {
+                todo: ['Not started'],
+                in_progress: ['In progress'],
+                done: ['Done'],
               },
             },
           },
         },
-      }
-    );
+      },
+    });
   });
 
   afterEach(() => mockttp.stop());
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(notionAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {pages: 8, users: 2};
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedProcessedByStream = {pages: 8, users: 2};
+    const expectedWrittenByModel = {
       tms_Epic: 2,
       tms_Project: 1,
       tms_Sprint: 2,
@@ -86,6 +60,13 @@ describe('notion', () => {
       tms_User: 2,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: notionAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/pagerduty.test.ts
@@ -1,17 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {
-  initMockttp,
-  sourceSpecificTempConfig,
-  testLogger,
-} from '../testing-tools';
+import {initMockttp, sourceSpecificTempConfig} from '../testing-tools';
 import {pagerdutyAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('pagerduty', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/pagerduty/catalog.json';
   let configPath: string;
@@ -40,33 +33,13 @@ describe('pagerduty', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(pagerdutyAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       incident_log_entries: 3,
       incidents: 3,
       services: 1,
       users: 1,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       compute_Application: 2,
       ims_Incident: 3,
       ims_IncidentApplicationImpact: 3,
@@ -76,6 +49,13 @@ describe('pagerduty', () => {
       org_ApplicationOwnership: 1,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: pagerdutyAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/phabricator.test.ts
@@ -1,13 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {phabricatorAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('phabricator', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/phabricator/catalog.json';
   let configPath: string;
@@ -15,7 +12,7 @@ describe('phabricator', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -23,20 +20,7 @@ describe('phabricator', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(phabricatorAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       commits: 7,
       projects: 4,
       repositories: 2,
@@ -45,14 +29,7 @@ describe('phabricator', () => {
       transactions: 3,
       users: 4,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       tms_Project: 4,
       tms_TaskBoard: 4,
       tms_TaskBoardProjectRelationship: 4,
@@ -70,6 +47,13 @@ describe('phabricator', () => {
       vcs_User: 4,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: phabricatorAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/sheets.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/sheets.test.ts
@@ -53,7 +53,7 @@ describe('sheets', () => {
         row: {
           'How much do you like ice cream?': 5,
           'Team Name': 'X',
-          'Timestamp': '2023-10-09T14:09:37.000Z',
+          Timestamp: '2023-10-09T14:09:37.000Z',
         },
       });
       const ctx = new StreamContext(
@@ -70,7 +70,9 @@ describe('sheets', () => {
       expect(res).toMatchSnapshot();
 
       const id = converter.id(record);
-      expect(id).toEqual('10hWFrCr5c0J7wUjoPODgd7jt6pRjPBGJTtD6y_z2He4_survey_responses_1');
+      expect(id).toEqual(
+        '10hWFrCr5c0J7wUjoPODgd7jt6pRjPBGJTtD6y_z2He4_survey_responses_1'
+      );
 
       const submittedAt = converter.getSubmittedAt(record);
       expect(submittedAt).toEqual('2023-10-09T14:09:37.000Z');
@@ -80,8 +82,6 @@ describe('sheets', () => {
 
       const tableName = converter.getTableName(record);
       expect(tableName).toEqual('Survey Responses');
-
-
     });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/statuspage.test.ts
@@ -1,13 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {statuspageAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from './utils';
+import {destinationWriteTest} from './utils';
 
 describe('statuspage', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/statuspage/catalog.json';
   let configPath: string;
@@ -15,7 +12,7 @@ describe('statuspage', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -23,20 +20,7 @@ describe('statuspage', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(statuspageAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       component_groups: 3,
       components: 9,
       incidents: 5,
@@ -44,14 +28,7 @@ describe('statuspage', () => {
       users: 1,
       component_uptimes: 5,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       compute_Application: 6,
       ims_ApplicationUptime: 5,
       ims_Incident: 5,
@@ -60,12 +37,13 @@ describe('statuspage', () => {
       ims_User: 1,
     };
 
-    await assertProcessedAndWrittenModels(
-      processedByStream,
-      writtenByModel,
-      stdout,
-      processed,
-      cli
-    );
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: statuspageAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/utils.ts
+++ b/destinations/airbyte-faros-destination/test/converters/utils.ts
@@ -1,56 +1,40 @@
-import {AirbyteLog, AirbyteLogLevel} from 'faros-airbyte-cdk';
+import {
+  AirbyteLog,
+  AirbyteLogLevel,
+  AirbyteMessageType,
+  AirbyteRecord,
+  parseAirbyteMessage,
+} from 'faros-airbyte-cdk';
 import _ from 'lodash';
 import {Dictionary} from 'ts-essentials';
 
-import {CLI, read} from '../cli';
+import {CLI, read, readLines} from '../cli';
 
-export type ProcessedAndWrittenModels = {
-  processedTotal: number;
-  writtenTotal: number;
-};
-/** Function to assert records written and processed from stream */
-export async function assertProcessedAndWrittenModels<T>(
-  processedByStream: Dictionary<number>,
-  writtenByModel: Dictionary<number>,
-  stdout: string,
-  processed: Dictionary<T>,
-  cli: CLI
-): Promise<ProcessedAndWrittenModels> {
-  const processedTotal = _(processedByStream).values().sum();
-  const writtenTotal = _(writtenByModel).values().sum();
-  expect(stdout).toMatch(`Processed ${processedTotal} records`);
-  expect(stdout).toMatch(`Would write ${writtenTotal} records`);
-  expect(stdout).toMatch('Errored 0 records');
-  expect(stdout).toMatch('Skipped 0 records');
-  expect(stdout).toMatch(
-    JSON.stringify(
-      AirbyteLog.make(
-        AirbyteLogLevel.INFO,
-        `Processed records by stream: ${JSON.stringify(processed)}`
-      )
-    )
-  );
-  expect(stdout).toMatch(
-    JSON.stringify(
-      AirbyteLog.make(
-        AirbyteLogLevel.INFO,
-        `Would write records by model: ${JSON.stringify(writtenByModel)}`
-      )
-    )
-  );
-  expect(await read(cli.stderr)).toBe('');
-  expect(await cli.wait()).toBe(0);
-  return {processedTotal, writtenTotal};
+export interface DestinationWriteTestOptions {
+  configPath: string;
+  catalogPath: string;
+  streamsLog: string;
+  streamNamePrefix: string;
+  expectedProcessedByStream?: Dictionary<number>;
+  expectedWrittenByModel?: Dictionary<number>;
+  checkRecordsData?: (records: ReadonlyArray<Dictionary<any>>) => void;
 }
 
-export const runTest = async (
-  configPath: string,
-  catalogPath: string,
-  processedByStream: Dictionary<number>,
-  writtenByModel: Dictionary<number>,
-  streamsLog: string,
-  streamNamePrefix: string
+// Executes the destination write command in dry-run mode and optionally checks:
+// - The processed and written records count
+// - The records data
+export const destinationWriteTest = async (
+  options: DestinationWriteTestOptions
 ): Promise<void> => {
+  const {
+    configPath,
+    catalogPath,
+    expectedProcessedByStream,
+    expectedWrittenByModel,
+    streamsLog,
+    streamNamePrefix,
+    checkRecordsData = undefined,
+  } = options;
   const cli = await CLI.runWith([
     'write',
     '--config',
@@ -59,20 +43,68 @@ export const runTest = async (
     catalogPath,
     '--dry-run',
   ]);
-  cli.stdin.end(streamsLog, 'utf8');
-  const stdout = await read(cli.stdout);
-  const processed = _(processedByStream)
-    .toPairs()
-    .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-    .orderBy(0, 'asc')
-    .fromPairs()
-    .value();
 
-  await assertProcessedAndWrittenModels(
-    processedByStream,
-    writtenByModel,
-    stdout,
-    processed,
-    cli
-  );
+  cli.stdin.end(streamsLog, 'utf8');
+
+  const stdoutLines = await readLines(cli.stdout);
+
+  if (expectedProcessedByStream && expectedWrittenByModel) {
+    const stdout = stdoutLines.join('');
+
+    const processed = _(expectedProcessedByStream)
+      .toPairs()
+      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
+      .orderBy(0, 'asc')
+      .fromPairs()
+      .value();
+
+    const processedTotal = _(expectedProcessedByStream).values().sum();
+    const writtenTotal = _(expectedWrittenByModel).values().sum();
+    expect(stdout).toMatch(`Processed ${processedTotal} records`);
+    expect(stdout).toMatch(`Would write ${writtenTotal} records`);
+    expect(stdout).toMatch('Errored 0 records');
+    expect(stdout).toMatch('Skipped 0 records');
+    expect(stdout).toMatch(
+      JSON.stringify(
+        AirbyteLog.make(
+          AirbyteLogLevel.INFO,
+          `Processed records by stream: ${JSON.stringify(processed)}`
+        )
+      )
+    );
+    expect(stdout).toMatch(
+      JSON.stringify(
+        AirbyteLog.make(
+          AirbyteLogLevel.INFO,
+          `Would write records by model: ${JSON.stringify(expectedWrittenByModel)}`
+        )
+      )
+    );
+  }
+
+  if (checkRecordsData) {
+    const records = await readRecordData(stdoutLines);
+    checkRecordsData(records);
+  }
+
+  expect(await read(cli.stderr)).toBe('');
+  expect(await cli.wait()).toBe(0);
 };
+
+export async function readRecordData(
+  lines: ReadonlyArray<string>
+): Promise<ReadonlyArray<Dictionary<any>>> {
+  const records: Dictionary<any>[] = [];
+  for (const line of lines) {
+    try {
+      const msg = parseAirbyteMessage(line);
+      if (msg.type === AirbyteMessageType.RECORD) {
+        const recordMessage = msg as AirbyteRecord;
+        records.push(recordMessage.record.data);
+      }
+    } catch (error) {
+      // Not a record message. Ignore.
+    }
+  }
+  return records;
+}

--- a/destinations/airbyte-faros-destination/test/converters/vanta.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/vanta.test.ts
@@ -7,7 +7,7 @@ import {
   readTestResourceFile,
   tempConfig,
 } from '../testing-tools';
-import {runTest} from './utils';
+import {destinationWriteTest} from './utils';
 
 const mockQueryToResponse: Record<string, any> = readTestResourceAsJSON(
   'vanta/mockQueryNamesToObjects.json'
@@ -74,7 +74,7 @@ describe('vanta', () => {
   });
 
   const getTempConfig = async (mockttp: Mockttp): Promise<string> => {
-    return await tempConfig(mockttp.url);
+    return await tempConfig({api_url: mockttp.url});
   };
 
   test('test entries', async () => {
@@ -87,14 +87,14 @@ describe('vanta', () => {
       sec_Vulnerability: 3,
       vcs_RepositoryVulnerability: 1,
     };
-    await runTest(
+    await destinationWriteTest({
       configPath,
       catalogPath,
-      processedByStream,
-      writtenByModel,
-      streamsLog2,
-      streamNamePrefix
-    );
+      expectedProcessedByStream: processedByStream,
+      expectedWrittenByModel: writtenByModel,
+      streamsLog: streamsLog2,
+      streamNamePrefix,
+    });
   });
 
   test('test no entries', async () => {
@@ -106,14 +106,14 @@ describe('vanta', () => {
       cicd_ArtifactVulnerability: 1,
       sec_Vulnerability: 3,
     };
-    await runTest(
+    await destinationWriteTest({
       configPath,
       catalogPath,
-      processedByStream,
-      writtenByModel,
-      streamsLog1,
-      streamNamePrefix
-    );
+      expectedProcessedByStream: processedByStream,
+      expectedWrittenByModel: writtenByModel,
+      streamsLog: streamsLog1,
+      streamNamePrefix,
+    });
   });
 
   test('test entries with duplicate UIDs', async () => {
@@ -126,14 +126,14 @@ describe('vanta', () => {
       sec_Vulnerability: 2,
       vcs_RepositoryVulnerability: 1,
     };
-    await runTest(
+    await destinationWriteTest({
       configPath,
       catalogPath,
-      processedByStream,
-      writtenByModel,
-      streamsLog3,
-      streamNamePrefix
-    );
+      expectedProcessedByStream: processedByStream,
+      expectedWrittenByModel: writtenByModel,
+      streamsLog: streamsLog3,
+      streamNamePrefix,
+    });
   });
 
   test('github commit sha', async () => {

--- a/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/victorops.test.ts
@@ -1,13 +1,10 @@
-import _ from 'lodash';
 import {getLocal} from 'mockttp';
 
-import {CLI, read} from '../cli';
-import {initMockttp, tempConfig, testLogger} from '../testing-tools';
+import {initMockttp, tempConfig} from '../testing-tools';
 import {victoropsAllStreamsLog} from './data';
-import {assertProcessedAndWrittenModels} from "./utils";
+import {destinationWriteTest} from './utils';
 
 describe('victorops', () => {
-  const logger = testLogger();
   const mockttp = getLocal({debug: false, recordTraffic: false});
   const catalogPath = 'test/resources/victorops/catalog.json';
   let configPath: string;
@@ -15,7 +12,7 @@ describe('victorops', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -23,32 +20,12 @@ describe('victorops', () => {
   });
 
   test('process records from all streams', async () => {
-    const cli = await CLI.runWith([
-      'write',
-      '--config',
-      configPath,
-      '--catalog',
-      catalogPath,
-      '--dry-run',
-    ]);
-    cli.stdin.end(victoropsAllStreamsLog, 'utf8');
-
-    const stdout = await read(cli.stdout);
-    logger.debug(stdout);
-
-    const processedByStream = {
+    const expectedProcessedByStream = {
       incidents: 2,
       teams: 2,
       users: 1,
     };
-    const processed = _(processedByStream)
-      .toPairs()
-      .map((v) => [`${streamNamePrefix}${v[0]}`, v[1]])
-      .orderBy(0, 'asc')
-      .fromPairs()
-      .value();
-
-    const writtenByModel = {
+    const expectedWrittenByModel = {
       compute_Application: 2,
       ims_Incident: 2,
       ims_IncidentApplicationImpact: 2,
@@ -59,6 +36,13 @@ describe('victorops', () => {
       ims_User: 1,
     };
 
-    await assertProcessedAndWrittenModels(processedByStream, writtenByModel, stdout, processed, cli);
+    await destinationWriteTest({
+      configPath,
+      catalogPath,
+      streamsLog: victoropsAllStreamsLog,
+      streamNamePrefix,
+      expectedProcessedByStream,
+      expectedWrittenByModel,
+    });
   });
 });

--- a/destinations/airbyte-faros-destination/test/converters/workday.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/workday.test.ts
@@ -19,7 +19,7 @@ import {
   workdayV3StreamsLog,
   workdayV4StreamsLog,
 } from './data';
-import {runTest} from './utils';
+import {destinationWriteTest} from './utils';
 
 function updateCustomReportWithFields(
   crDest: Customreports,
@@ -55,13 +55,15 @@ function getCustomReportandCtxGivenKey(
   const customReportDestination = new Customreports();
   const orgs_to_keep = [];
   const orgs_to_ignore = [];
-  const cfg = getConf(
-    mockttp.url,
-    InvalidRecordStrategy.SKIP,
-    Edition.CLOUD,
-    {},
-    {workday: {orgs_to_keep, orgs_to_ignore, fail_on_cycles}}
-  );
+  const cfg = getConf({
+    api_url: mockttp.url,
+    invalid_record_strategy: InvalidRecordStrategy.SKIP,
+    edition: Edition.CLOUD,
+    edition_configs: {},
+    source_specific_configs: {
+      workday: {orgs_to_keep, orgs_to_ignore, fail_on_cycles},
+    },
+  });
 
   const ctx: StreamContext = new StreamContext(
     new AirbyteLogger(AirbyteLogLevel.WARN),
@@ -91,13 +93,13 @@ describe('workday', () => {
     orgs_to_keep,
     orgs_to_ignore
   ): Promise<string> => {
-    return await tempConfig(
-      mockttp.url,
-      InvalidRecordStrategy.SKIP,
-      Edition.CLOUD,
-      {},
-      {workday: {orgs_to_keep, orgs_to_ignore}}
-    );
+    return await tempConfig({
+      api_url: mockttp.url,
+      invalid_record_strategy: InvalidRecordStrategy.SKIP,
+      edition: Edition.CLOUD,
+      edition_configs: {},
+      source_specific_configs: {workday: {orgs_to_keep, orgs_to_ignore}},
+    });
   };
 
   const runTestLocal = async (
@@ -106,14 +108,14 @@ describe('workday', () => {
     writtenByModel,
     workdayStreamsLog
   ): Promise<void> => {
-    await runTest(
+    await destinationWriteTest({
       configPath,
       catalogPath,
-      processedByStream,
-      writtenByModel,
-      workdayStreamsLog,
-      streamNamePrefix
-    );
+      expectedProcessedByStream: processedByStream,
+      expectedWrittenByModel: writtenByModel,
+      streamsLog: workdayStreamsLog,
+      streamNamePrefix,
+    });
   };
 
   beforeEach(async () => {

--- a/destinations/airbyte-faros-destination/test/index.test.ts
+++ b/destinations/airbyte-faros-destination/test/index.test.ts
@@ -19,7 +19,7 @@ describe('index', () => {
 
   beforeEach(async () => {
     await initMockttp(mockttp);
-    configPath = await tempConfig(mockttp.url);
+    configPath = await tempConfig({api_url: mockttp.url});
   });
 
   afterEach(async () => {
@@ -55,11 +55,11 @@ describe('index', () => {
   });
 
   test('check community edition config', async () => {
-    const configPath = await tempConfig(
-      mockttp.url,
-      InvalidRecordStrategy.SKIP,
-      Edition.COMMUNITY
-    );
+    const configPath = await tempConfig({
+      api_url: mockttp.url,
+      invalid_record_strategy: InvalidRecordStrategy.SKIP,
+      edition: Edition.COMMUNITY,
+    });
     const cli = await CLI.runWith(['check', '--config', configPath]);
 
     expect(await read(cli.stderr)).toBe('');
@@ -74,12 +74,12 @@ describe('index', () => {
   });
 
   test('fail check on invalid segment user id', async () => {
-    const configPath = await tempConfig(
-      mockttp.url,
-      InvalidRecordStrategy.SKIP,
-      Edition.COMMUNITY,
-      {segment_user_id: 'badid'}
-    );
+    const configPath = await tempConfig({
+      api_url: mockttp.url,
+      invalid_record_strategy: InvalidRecordStrategy.SKIP,
+      edition: Edition.COMMUNITY,
+      edition_configs: {segment_user_id: 'badid'},
+    });
     const cli = await CLI.runWith(['check', '--config', configPath]);
 
     expect(await read(cli.stderr)).toBe('');

--- a/destinations/airbyte-faros-destination/test/resources/faros_jira/all-streams.log
+++ b/destinations/airbyte-faros-destination/test/resources/faros_jira/all-streams.log
@@ -1,0 +1,1 @@
+{"type": "RECORD", "record": {"stream": "mytestsource__jira__faros_board_issues", "emitted_at": 1712673836940,"data": {"key": "TEST-1","boardId": "1"}}}

--- a/destinations/airbyte-faros-destination/test/resources/faros_jira/catalog.json
+++ b/destinations/airbyte-faros-destination/test/resources/faros_jira/catalog.json
@@ -1,0 +1,10 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "mytestsource__jira__faros_board_issues"
+      },
+      "destination_sync_mode": "append"
+    }
+  ]
+}

--- a/destinations/airbyte-faros-destination/test/testing-tools.ts
+++ b/destinations/airbyte-faros-destination/test/testing-tools.ts
@@ -38,56 +38,55 @@ export async function tempFile(data: string, postfix: string): Promise<string> {
   return file.path;
 }
 
+export interface TempConfigOptions {
+  readonly api_url: string;
+  readonly invalid_record_strategy?: InvalidRecordStrategy;
+  readonly edition?: Edition;
+  readonly edition_configs?: Dictionary<any>;
+  readonly source_specific_configs?: Dictionary<any>;
+  readonly replace_origin_map?: Dictionary<any>;
+  readonly exclude_fields_map?: Dictionary<any>;
+  readonly log_records?: boolean;
+}
+
 /**
  * Creates a temporary file with testing configuration
  * @return path to the temporary config file to delete
  */
-export async function tempConfig(
-  url: string,
-  invalid_record_strategy: InvalidRecordStrategy = InvalidRecordStrategy.SKIP,
-  edition = Edition.CLOUD,
-  edition_configs?: Dictionary<any>,
-  source_specific_configs?: Dictionary<any>,
-  replace_origin_map?: Dictionary<any>,
-  exclude_fields_map?: Dictionary<any>
-): Promise<string> {
-  const conf = getConf(
-    url,
-    invalid_record_strategy,
-    edition,
-    edition_configs,
-    source_specific_configs,
-    replace_origin_map,
-    exclude_fields_map
-  );
+export async function tempConfig(options: TempConfigOptions): Promise<string> {
+  const conf = getConf(options);
 
   return tempFile(JSON.stringify(conf), '.json');
 }
 
-export function getConf(
-  url: string,
-  invalid_record_strategy: InvalidRecordStrategy = InvalidRecordStrategy.SKIP,
-  edition = Edition.CLOUD,
-  edition_configs?: Dictionary<any>,
-  source_specific_configs?: Dictionary<any>,
-  replace_origin_map?: Dictionary<any>,
-  exclude_fields_map?: Dictionary<any>
-): any {
+export function getConf(options: TempConfigOptions): any {
+  const {
+    api_url,
+    invalid_record_strategy = InvalidRecordStrategy.FAIL,
+    edition = Edition.CLOUD,
+    edition_configs = {},
+    source_specific_configs = {},
+    replace_origin_map = {},
+    exclude_fields_map = {},
+    log_records = false,
+  } = options;
+
   const edition_configs_defaults =
     edition === Edition.CLOUD
       ? {
           edition,
-          api_url: url,
+          api_url,
           api_key: 'test-api-key',
           graph: 'test-graph',
           graphql_api: 'v1',
         }
       : {
           edition,
-          hasura_url: url,
+          hasura_url: api_url,
           segment_user_id: 'bacaf6e6-41d8-4102-a3a4-5d28100e642f',
-          segment_test_host: url,
+          segment_test_host: api_url,
         };
+
   const conf = {
     edition_configs: {...edition_configs_defaults, ...edition_configs},
     invalid_record_strategy,
@@ -104,7 +103,9 @@ export function getConf(
     replace_origin_map: JSON.stringify(replace_origin_map),
     exclude_fields_map: JSON.stringify(exclude_fields_map),
     faros_source_id: TEST_SOURCE_ID,
+    log_records,
   };
+
   return conf;
 }
 
@@ -112,13 +113,7 @@ export function sourceSpecificTempConfig(
   url: string,
   source_specific_configs: Dictionary<any>
 ): Promise<string> {
-  return tempConfig(
-    url,
-    InvalidRecordStrategy.SKIP,
-    Edition.CLOUD,
-    {},
-    source_specific_configs
-  );
+  return tempConfig({api_url: url, source_specific_configs});
 }
 
 export async function initMockttp(mockttp: Mockttp): Promise<void> {


### PR DESCRIPTION
Refactor of `runTest` (renamed to `destinationWriteTest`) to, in addition to check the records processed/written stats, be able to run a validation function over the converted records.

This makes it possible to write tests in the following manner:

Given: input records (source output, the files we usually name `all_streams.log`)
When: the destination `write` command is run
Then: the processed/written stats should match the expected stats and the converted records should pass the validation function (e.g., simply match a local snapshot)

See [faros_jira.test.ts](https://github.com/faros-ai/airbyte-connectors/pull/1471/files#diff-e4f72f546121f0cf65668e5891468a6b2b130134f0d1cff1b1666526caec9c39) for an example
