### PR TITLE
Support backfills

### DIFF
--- a/faros-airbyte-cdk/src/destinations/destination-runner.ts
+++ b/faros-airbyte-cdk/src/destinations/destination-runner.ts
@@ -13,7 +13,7 @@ import {PACKAGE_VERSION, redactConfig, withDefaults} from '../utils';
 import {AirbyteDestination} from './destination';
 
 export class AirbyteDestinationRunner<
-  Config extends AirbyteConfig
+  Config extends AirbyteConfig,
 > extends Runner {
   constructor(
     protected readonly logger: AirbyteLogger,

--- a/faros-airbyte-cdk/src/destinations/destination.ts
+++ b/faros-airbyte-cdk/src/destinations/destination.ts
@@ -10,7 +10,7 @@ import {
  * https://docs.airbyte.io/understanding-airbyte/airbyte-specification#destination
  */
 export abstract class AirbyteDestination<
-  Config extends AirbyteConfig
+  Config extends AirbyteConfig,
 > extends AirbyteConnector {
   /**
    * Implement to define how the connector writes data to the destination

--- a/faros-airbyte-cdk/src/protocol.ts
+++ b/faros-airbyte-cdk/src/protocol.ts
@@ -49,8 +49,8 @@ export enum AirbyteTraceFailureType {
   CONFIG_ERROR = 'config_error',
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AirbyteConfig {
+  backfill?: boolean;
   compress_state?: boolean;
   max_stream_failures?: number; // -1 means unlimited
   max_slice_failures?: number; // -1 means unlimited
@@ -339,7 +339,10 @@ export interface AirbyteSourceLog {
 
 export class AirbyteSourceLogsMessage extends AirbyteStateMessage {
   readonly type: AirbyteMessageType = AirbyteMessageType.STATE;
-  constructor(state: {data: AirbyteState}, readonly logs: AirbyteSourceLog[]) {
+  constructor(
+    state: {data: AirbyteState},
+    readonly logs: AirbyteSourceLog[]
+  ) {
     super(state);
   }
 }

--- a/faros-airbyte-cdk/src/sources/source.ts
+++ b/faros-airbyte-cdk/src/sources/source.ts
@@ -12,7 +12,7 @@ import {
  * https://docs.airbyte.io/understanding-airbyte/airbyte-specification#source
  */
 export abstract class AirbyteSource<
-  Config extends AirbyteConfig
+  Config extends AirbyteConfig,
 > extends AirbyteConnector {
   /**
    * @returns An AirbyteCatalog representing the available streams and fields in

--- a/faros-airbyte-common/package.json
+++ b/faros-airbyte-common/package.json
@@ -57,7 +57,8 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
-    "jira.js": "^4.0.0"
+    "jira.js": "^4.0.0",
+    "luxon": "^3.4.4"
   },
   "jest": {
     "coverageDirectory": "out/coverage",

--- a/faros-airbyte-common/src/common/index.ts
+++ b/faros-airbyte-common/src/common/index.ts
@@ -1,4 +1,5 @@
 import {createHmac} from 'crypto';
+import {DateTime} from 'luxon';
 
 // TODO: Try https://www.npmjs.com/package/diff
 export interface FileDiff {
@@ -15,4 +16,48 @@ export function bucket(key: string, data: string, bucketTotal: number): number {
   md5.update(data);
   const hex = md5.digest('hex').substring(0, 8);
   return (parseInt(hex, 16) % bucketTotal) + 1; // 1-index for readability
+}
+
+export function calculateDateRange(options: {
+  start_date?: string;
+  end_date?: string;
+  cutoff_days?: number;
+  logger: (message: string) => void;
+}) {
+  const {start_date, end_date, cutoff_days, logger} = options;
+
+  let startDate: Date;
+  let endDate: Date;
+
+  if (!end_date) {
+    logger('End date not provided, using current date');
+    endDate = new Date();
+  } else {
+    endDate = new Date(end_date);
+  }
+
+  if (start_date && cutoff_days) {
+    logger('Both start date and cutoff days provided, discarding cutoff days');
+  }
+
+  if (start_date) {
+    startDate = new Date(start_date);
+  } else {
+    if (cutoff_days) {
+      logger('Cutoff days provided, calculating start date from end date');
+      startDate = DateTime.fromJSDate(endDate)
+        .minus({days: cutoff_days})
+        .toJSDate();
+    } else {
+      throw new Error('Either start_date or cutoff_days must be provided');
+    }
+  }
+
+  if (startDate > endDate) {
+    throw new Error(`Start date: ${startDate} is after end date: ${endDate}`);
+  }
+
+  logger(`Will process data from ${startDate} to ${endDate}`);
+
+  return {startDate, endDate};
 }

--- a/faros-airbyte-common/test/common/__snapshots__/index.test.ts.snap
+++ b/faros-airbyte-common/test/common/__snapshots__/index.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calculateDateRange should calculate date range with current date as end date if not provided 1`] = `2022-01-01T00:00:00.000Z`;
+
+exports[`calculateDateRange should calculate date range with end date and cutoff days 1`] = `
+Object {
+  "endDate": 2022-01-31T00:00:00.000Z,
+  "startDate": 2022-01-21T00:00:00.000Z,
+}
+`;
+
+exports[`calculateDateRange should calculate date range with start and end date 1`] = `
+Object {
+  "endDate": 2022-01-31T00:00:00.000Z,
+  "startDate": 2022-01-01T00:00:00.000Z,
+}
+`;

--- a/faros-airbyte-common/test/common/index.test.ts
+++ b/faros-airbyte-common/test/common/index.test.ts
@@ -1,0 +1,78 @@
+import {calculateDateRange} from '../../src/common';
+
+describe('calculateDateRange', () => {
+  const logger = jest.fn();
+
+  beforeEach(() => {
+    logger.mockClear();
+  });
+
+  it('should calculate date range with start and end date', () => {
+    const result = calculateDateRange({
+      start_date: '2022-01-01',
+      end_date: '2022-01-31',
+      logger,
+    });
+
+    expect(result).toMatchSnapshot();
+    expect(logger).toHaveBeenCalledWith(
+      `Will process data from ${result.startDate} to ${result.endDate}`
+    );
+  });
+
+  it('should calculate date range with end date and cutoff days', () => {
+    const result = calculateDateRange({
+      end_date: '2022-01-31',
+      cutoff_days: 10,
+      logger,
+    });
+
+    expect(result).toMatchSnapshot();
+    expect(logger).toHaveBeenCalledWith(
+      'Cutoff days provided, calculating start date from end date'
+    );
+  });
+
+  it('should calculate date range with current date as end date if not provided', () => {
+    const result = calculateDateRange({
+      start_date: '2022-01-01',
+      logger,
+    });
+
+    expect(result.startDate).toMatchSnapshot();
+    expect(result.endDate).toBeDefined();
+    expect(logger).toHaveBeenCalledWith(
+      'End date not provided, using current date'
+    );
+  });
+
+  it('should throw error if start date is after end date', () => {
+    expect(() =>
+      calculateDateRange({
+        start_date: '2022-02-01',
+        end_date: '2022-01-31',
+        logger,
+      })
+    ).toThrow(/Start date: .* is after end date: .*/);
+  });
+
+  it('should throw error if neither start date nor cutoff days are provided', () => {
+    expect(() =>
+      calculateDateRange({
+        end_date: '2022-01-31',
+        logger,
+      })
+    ).toThrow('Either start_date or cutoff_days must be provided');
+  });
+
+  it('should throw error if both start date and cutoff days are provided', () => {
+    calculateDateRange({
+      start_date: '2022-01-01',
+      cutoff_days: 10,
+      logger,
+    });
+    expect(logger).toHaveBeenCalledWith(
+      'Both start date and cutoff days provided, discarding cutoff days'
+    );
+  });
+});

--- a/sources/jira-source/resources/spec.json
+++ b/sources/jira-source/resources/spec.json
@@ -194,6 +194,28 @@
         "type": "boolean",
         "title": "Fetch closed sprints starting with most recent in backlog. Use this for Jira instances with a lots closed sprints and syncing sprints is slow.",
         "default": false
+      },
+      "backfill": {
+        "airbyte_hidden": true,
+        "order": 25,
+        "type": "boolean",
+        "title": "Backfill",
+        "description": "Backfill data from the start date to the end date.",
+        "default": false
+      },
+      "start_date": {
+        "airbyte_hidden": true,
+        "order": 26,
+        "type": "string",
+        "title": "Start Date",
+        "description": "The date from which to start syncing data. Only use for backfilling."
+      },
+      "end_date": {
+        "airbyte_hidden": true,
+        "order": 27,
+        "type": "string",
+        "title": "End Date",
+        "description": "The date at which to stop syncing data. Only use for backfilling."
       }
     }
   }

--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -1,7 +1,7 @@
 import axios, {AxiosInstance} from 'axios';
 import {setupCache} from 'axios-cache-interceptor';
 import {AirbyteConfig, AirbyteLogger} from 'faros-airbyte-cdk';
-import {bucket} from 'faros-airbyte-common/common';
+import {bucket, calculateDateRange} from 'faros-airbyte-common/common';
 import {
   FarosProject,
   Issue,
@@ -19,7 +19,15 @@ import * as fs from 'fs';
 import parseGitUrl from 'git-url-parse';
 import https from 'https';
 import jira, {AgileModels, Version2Models} from 'jira.js';
-import {chunk, concat, isEmpty, isNil, pick, toInteger, toLower} from 'lodash';
+import _, {
+  chunk,
+  concat,
+  isEmpty,
+  isNil,
+  pick,
+  toInteger,
+  toLower,
+} from 'lodash';
 import moment from 'moment';
 import pLimit from 'p-limit';
 import path from 'path';
@@ -56,8 +64,10 @@ export interface JiraConfig extends AirbyteConfig {
   readonly graph?: string;
   readonly requestedStreams?: Set<string>;
   readonly use_sprints_reverse_search?: boolean;
-  start_date?: Date;
-  end_date?: Date;
+  readonly start_date?: string;
+  readonly end_date?: string;
+  startDate?: Date;
+  endDate?: Date;
 }
 
 export const toFloat = (value: any): number | undefined =>
@@ -244,11 +254,14 @@ export class Jira {
       }
     }
 
-    cfg.end_date = moment().utc().toDate();
-    cfg.start_date = moment()
-      .utc()
-      .subtract(cfg.cutoff_days || DEFAULT_CUTOFF_DAYS, 'days')
-      .toDate();
+    const {startDate, endDate} = calculateDateRange({
+      start_date: cfg.start_date,
+      end_date: cfg.end_date,
+      cutoff_days: cfg.cutoff_days ?? DEFAULT_CUTOFF_DAYS,
+      logger: logger.info.bind(logger),
+    });
+    cfg.startDate = startDate;
+    cfg.endDate = endDate;
 
     Jira.jira = new Jira(
       cfg.url,

--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -19,16 +19,7 @@ import * as fs from 'fs';
 import parseGitUrl from 'git-url-parse';
 import https from 'https';
 import jira, {AgileModels, Version2Models} from 'jira.js';
-import _, {
-  chunk,
-  concat,
-  isEmpty,
-  isNil,
-  pick,
-  toInteger,
-  toLower,
-} from 'lodash';
-import moment from 'moment';
+import {chunk, concat, isEmpty, isNil, pick, toInteger, toLower} from 'lodash';
 import pLimit from 'p-limit';
 import path from 'path';
 import {Memoize} from 'typescript-memoize';

--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -66,6 +66,7 @@ export interface JiraConfig extends AirbyteConfig {
   readonly use_sprints_reverse_search?: boolean;
   readonly start_date?: string;
   readonly end_date?: string;
+  // startDate and endDate are calculated from start_date, end_date, and cutoff_days
   startDate?: Date;
   endDate?: Date;
 }

--- a/sources/jira-source/src/streams/common.ts
+++ b/sources/jira-source/src/streams/common.ts
@@ -46,8 +46,8 @@ export abstract class StreamBase extends AirbyteStreamBase {
 
   protected getUpdateRange(cutoff?: number): [Date, Date] {
     return [
-      cutoff ? Utils.toDate(cutoff) : this.config.start_date,
-      this.config.end_date,
+      cutoff ? Utils.toDate(cutoff) : this.config.startDate,
+      this.config.endDate,
     ];
   }
 

--- a/sources/jira-source/test/index.test.ts
+++ b/sources/jira-source/test/index.test.ts
@@ -241,8 +241,8 @@ describe('index', () => {
       {
         ...config,
         requestedStreams: new Set(['faros_issue_pull_requests']),
-        start_date: new Date('2021-01-01'),
-        end_date: new Date('2021-01-02'),
+        startDate: new Date('2021-01-01'),
+        endDate: new Date('2021-01-02'),
       },
       getIssuePullRequestsMockedImplementation(),
       {project: 'TEST'}


### PR DESCRIPTION
## Description

Adds support for backfills. When a source is configured with `backfill`, the streams state will be ignored and unmodified. The destination will NOT reset the models. This way, one can temporarily reuse a configured sync for backfill, by setting `backfill` to `true` and providing `start_date` and `end_date`. Once the backfill is completed, one can turn `backfill` off and the configured sync will continue normally from where it left off.

Also adds some utility function to deal with calculating the date range to sync based on `start_date`, `end_date` and `cutoff_days`

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
