### PR TITLE
Removing unused dataquality tests

### DIFF
--- a/sources/faros-graphdoctor-source/resources/spec.json
+++ b/sources/faros-graphdoctor-source/resources/spec.json
@@ -28,8 +28,15 @@
         "title": "Graph name",
         "description": "The graph name."
       },
-      "day_delay_threshold": {
+      "compute_data_issues": {
         "order": 3,
+        "type": "boolean",
+        "title": "Compute Data Issues",
+        "description": "Whether to compute data issues or not.",
+        "default": false
+      },
+      "day_delay_threshold": {
+        "order": 4,
         "type": "integer",
         "title": "Day Threshold For Alert",
         "description": "How many days can pass before we raise an alert for data that has stopped being ingested.",

--- a/sources/faros-graphdoctor-source/src/graphdoctor/graphdoctor.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/graphdoctor.ts
@@ -41,7 +41,6 @@ export const orgTeamParentNull: GraphDoctorTestFunction = async function* (
   }
 };
 
-// Ignore the function:
 const identityNulls: GraphDoctorTestFunction = async function* (
   cfg: any,
   fc: FarosClient,

--- a/sources/faros-graphdoctor-source/src/graphdoctor/graphdoctor.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/graphdoctor.ts
@@ -2,9 +2,9 @@ import {FarosClient} from 'faros-js-client';
 import _ from 'lodash';
 
 import {getDataQualitySummary} from './dataSummary';
-// import {duplicateNames} from './duplicateNames';
+import {duplicateNames} from './duplicateNames';
 import {DataSummaryKey, GraphDoctorTestFunction} from './models';
-// import {checkIfWithinLastXDays, runAllZScoreTests} from './timeTests';
+import {checkIfWithinLastXDays, runAllZScoreTests} from './timeTests';
 import {getCurrentTimestamp, missingRelationsTest, simpleHash} from './utils';
 
 export const orgTeamParentNull: GraphDoctorTestFunction = async function* (
@@ -114,21 +114,23 @@ export async function* runGraphDoctorTests(cfg: any, fc: FarosClient): any {
     uid: start_timestamp,
     source: 'faros-graphdoctor',
   };
-  // cfg.logger.info('Running Graph Doctor Tests');
+  if (cfg.compute_data_issues) {
+    cfg.logger.info('Running Graph Doctor Tests');
 
-  // const testFunctions: GraphDoctorTestFunction[] = [
-  //   orgTeamParentNull,
-  //   teamOwnershipNulls,
-  //   identityNulls,
-  //   duplicateNames,
-  //   runAllZScoreTests,
-  //   checkIfWithinLastXDays,
-  // ];
+    const testFunctions: GraphDoctorTestFunction[] = [
+      orgTeamParentNull,
+      teamOwnershipNulls,
+      identityNulls,
+      duplicateNames,
+      runAllZScoreTests,
+      checkIfWithinLastXDays,
+    ];
 
-  // for (const test_func of testFunctions) {
-  //   cfg.logger.info(`Running test function "${test_func.name}".`);
-  //   yield* test_func(cfg, fc, summaryKey);
-  // }
+    for (const test_func of testFunctions) {
+      cfg.logger.info(`Running test function "${test_func.name}".`);
+      yield* test_func(cfg, fc, summaryKey);
+    }
+  }
 
   cfg.logger.info('Running Graph Doctor Diagnostic Summary');
   const dataQualitySummary = await getDataQualitySummary(

--- a/sources/faros-graphdoctor-source/src/graphdoctor/graphdoctor.ts
+++ b/sources/faros-graphdoctor-source/src/graphdoctor/graphdoctor.ts
@@ -2,9 +2,9 @@ import {FarosClient} from 'faros-js-client';
 import _ from 'lodash';
 
 import {getDataQualitySummary} from './dataSummary';
-import {duplicateNames} from './duplicateNames';
+// import {duplicateNames} from './duplicateNames';
 import {DataSummaryKey, GraphDoctorTestFunction} from './models';
-import {checkIfWithinLastXDays, runAllZScoreTests} from './timeTests';
+// import {checkIfWithinLastXDays, runAllZScoreTests} from './timeTests';
 import {getCurrentTimestamp, missingRelationsTest, simpleHash} from './utils';
 
 export const orgTeamParentNull: GraphDoctorTestFunction = async function* (
@@ -41,6 +41,7 @@ export const orgTeamParentNull: GraphDoctorTestFunction = async function* (
   }
 };
 
+// Ignore the function:
 const identityNulls: GraphDoctorTestFunction = async function* (
   cfg: any,
   fc: FarosClient,
@@ -113,21 +114,21 @@ export async function* runGraphDoctorTests(cfg: any, fc: FarosClient): any {
     uid: start_timestamp,
     source: 'faros-graphdoctor',
   };
-  cfg.logger.info('Running Graph Doctor Tests');
+  // cfg.logger.info('Running Graph Doctor Tests');
 
-  const testFunctions: GraphDoctorTestFunction[] = [
-    orgTeamParentNull,
-    teamOwnershipNulls,
-    identityNulls,
-    duplicateNames,
-    runAllZScoreTests,
-    checkIfWithinLastXDays,
-  ];
+  // const testFunctions: GraphDoctorTestFunction[] = [
+  //   orgTeamParentNull,
+  //   teamOwnershipNulls,
+  //   identityNulls,
+  //   duplicateNames,
+  //   runAllZScoreTests,
+  //   checkIfWithinLastXDays,
+  // ];
 
-  for (const test_func of testFunctions) {
-    cfg.logger.info(`Running test function "${test_func.name}".`);
-    yield* test_func(cfg, fc, summaryKey);
-  }
+  // for (const test_func of testFunctions) {
+  //   cfg.logger.info(`Running test function "${test_func.name}".`);
+  //   yield* test_func(cfg, fc, summaryKey);
+  // }
 
   cfg.logger.info('Running Graph Doctor Diagnostic Summary');
   const dataQualitySummary = await getDataQualitySummary(


### PR DESCRIPTION
## Description
It seems that the data generated by the queries which are computing Z Scores and more sophisticated data aren't being used, so let's save the computing space for now.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

