### PR TITLE
Pass the slice being processed (if any) to getUpdatedState

### DIFF
--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -351,7 +351,8 @@ export abstract class AirbyteSourceBase<
           if (!config.backfill) {
             streamState = streamInstance.getUpdatedState(
               streamState,
-              recordData
+              recordData,
+              slice
             );
             if (
               checkpointInterval &&

--- a/faros-airbyte-cdk/src/sources/streams/stream-base.ts
+++ b/faros-airbyte-cdk/src/sources/streams/stream-base.ts
@@ -176,11 +176,13 @@ export abstract class AirbyteStreamBase {
    *
    * @param currentStreamState The stream's current state object
    * @param latestRecord The latest record extracted from the stream
+   * @param streamSlice The current stream slice being processed
    * @returns An updated state object
    */
   getUpdatedState(
     currentStreamState: Dictionary<any>,
-    latestRecord: Dictionary<any>
+    latestRecord: Dictionary<any>,
+    streamSlice?: Dictionary<any>
   ): Dictionary<any> {
     return {};
   }


### PR DESCRIPTION
## Description

It'd be nice to have access to the slice being processed when computing the updated state. Very frequently we need to update an object keyed by something in the slice, and the only way to do that now is to ensure that we include it in the stream output object so that we can access it from the `latestRecord`.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
