### PR TITLE
FAI-12025 - Disable skip_source_success_check for Faros sources

### DIFF
--- a/destinations/airbyte-faros-destination/resources/spec.json
+++ b/destinations/airbyte-faros-destination/resources/spec.json
@@ -160,7 +160,7 @@
         "order": 14,
         "type": "boolean",
         "title": "Skip source success check",
-        "description": "Skip checking if source ran successfully before resetting non-incremental models",
+        "description": "Skip checking if source ran successfully before resetting non-incremental models. Only applies to non-Faros sources.",
         "default": false
       },
       "faros_source_id": {


### PR DESCRIPTION
## Description

This option is only meant for non-Faros sources, which don't use our expanded message protocol.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
