### PR TITLE
FAI-11601 | Fix run_mode param behavior when not passed (GitHub)

### DIFF
--- a/sources/github-source/src/index.ts
+++ b/sources/github-source/src/index.ts
@@ -11,7 +11,7 @@ import {
 import VError from 'verror';
 
 import {GitHub} from './github';
-import {RunMode, RunModeStreams, TeamStreamNames} from './streams/common';
+import {RunModeStreams, TeamStreamNames} from './streams/common';
 import {FarosCopilotSeats} from './streams/faros_copilot_seats';
 import {FarosCopilotUsage} from './streams/faros_copilot_usage';
 import {FarosOrganizations} from './streams/faros_organizations';
@@ -67,11 +67,12 @@ export class GitHubSource extends AirbyteSourceBase<GitHubConfig> {
     catalog: AirbyteConfiguredCatalog;
     state?: AirbyteState;
   }> {
-    const streamNames = [
-      ...RunModeStreams[config.run_mode ?? RunMode.Standard],
-    ];
-    if (config.fetch_teams) {
-      streamNames.push(...TeamStreamNames);
+    let streamNames = catalog.streams.map((s) => s.stream.name);
+    if (config.run_mode) {
+      streamNames = [...RunModeStreams[config.run_mode]];
+      if (config.fetch_teams) {
+        streamNames.push(...TeamStreamNames);
+      }
     }
     const streams = catalog.streams.filter((stream) =>
       streamNames.includes(stream.stream.name)


### PR DESCRIPTION
## Description

Fix run_mode param behavior when not passed (GitHub).
If not passed keep streams passed from original catalog.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
