### PR TITLE
Filter virtual boards in Faros tms-project-boards query

### DIFF
--- a/sources/jira-source/resources/queries/tms-project-boards.gql
+++ b/sources/jira-source/resources/queries/tms-project-boards.gql
@@ -13,7 +13,15 @@ query ProjectBoards(
     offset: $offset
   ) {
     uid
-    boards {
+    boards(
+      where: {
+        board: {
+          uid: {
+            _regex: "^[0-9]+$"  # Get only boards that came from Jira (numeric) and filter virtual for board-less tasks
+          }
+        }
+      }
+    ) {
       board {
         uid
       }


### PR DESCRIPTION
## Description
While running the source in `WebhookSupplement` mode found this error:
"Invalid integer: faros-tasks-with-no-board-FAI","stack_trace":"VError: Invalid integer: faros-tasks-with-no-board-FAI"
When we sync `sprint_reports` stream for `WebhookSupplement` we get boards from Faros graph. If [virtual boards](https://github.com/faros-ai/airbyte-connectors/blob/4d25a2f5b389453dd093af9ac440e550918da3a1/sources/jira-source/src/streams/faros_boards.ts#L27-L32) to hold board-less tasks exist, we want to filter them as we will not associate anything to them in the graph.
The regex condition is added to get only boards that came from Jira, with a numeric uid.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
