### PR TITLE
FAI-11094 Make it possible to specify common config fields for all sources

### DIFF
--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -9,7 +9,11 @@ import {wrapApiError} from '../errors';
 import {buildArgs, buildJson, helpTable, traverseObject} from '../help';
 import {AirbyteConfig, AirbyteState} from '../protocol';
 import {ConnectorVersion, Runner} from '../runner';
-import {PACKAGE_VERSION, redactConfig} from '../utils';
+import {
+  addSourceCommonProperties,
+  PACKAGE_VERSION,
+  redactConfig,
+} from '../utils';
 import {AirbyteSource} from './source';
 import {maybeCompressState} from './source-base';
 import {AirbyteSourceLogger} from './source-logger';
@@ -41,7 +45,7 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
       .description('spec command')
       .alias('s')
       .action(async () => {
-        const spec = await this.source.spec();
+        const spec = addSourceCommonProperties(await this.source.spec());
 
         // Expected output
         this.logger.write(spec);
@@ -91,7 +95,7 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
           this.logNodeOptions('Source');
           const config = require(path.resolve(opts.config));
           const catalog = require(path.resolve(opts.catalog));
-          const spec = await this.source.spec();
+          const spec = addSourceCommonProperties(await this.source.spec());
           const redactedConfig = redactConfig(config, spec);
           this.logger.info(`Source version: ${ConnectorVersion}`);
           this.logger.info(`Config: ${JSON.stringify(redactedConfig)}`);
@@ -139,7 +143,7 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
       .command('spec-pretty')
       .description('pretty spec command')
       .action(async () => {
-        const spec = await this.source.spec(false);
+        const spec = addSourceCommonProperties(await this.source.spec(false));
         const rows = traverseObject(
           spec.spec.connectionSpecification,
           [
@@ -190,7 +194,7 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
       .action(async (opts) => {
         const spec = opts.specFile
           ? JSON.parse(fs.readFileSync(opts.specFile, 'utf8'))
-          : await this.source.spec(false);
+          : addSourceCommonProperties(await this.source.spec(false));
         const rows = traverseObject(
           spec.spec.connectionSpecification,
           opts.json

--- a/faros-airbyte-cdk/src/utils.ts
+++ b/faros-airbyte-cdk/src/utils.ts
@@ -151,3 +151,34 @@ function minimizeSpecObject(config: SpecObject): void {
     minimizeSpecProperty(prop);
   }
 }
+
+const SOURCE_COMMON_PROPERTIES = {
+  max_stream_failures: {
+    order: 1000,
+    type: 'integer',
+    title: 'Max Stream Failures',
+    description:
+      'The maximum number of stream failures before the sync fails. Use -1 for unlimited',
+    default: 0,
+  },
+  max_slice_failures: {
+    order: 1001,
+    type: 'integer',
+    title: 'Max Slice Failures',
+    description:
+      'The maximum number of slice failures before a stream sync fails. Use -1 for unlimited',
+    default: 0,
+  },
+};
+
+export function addSourceCommonProperties(spec: AirbyteSpec): AirbyteSpec {
+  const updatedSpec = _.cloneDeep(spec);
+  const connectionSpec = updatedSpec.spec.connectionSpecification;
+
+  connectionSpec.properties = {
+    ...(connectionSpec.properties ?? {}),
+    ...SOURCE_COMMON_PROPERTIES,
+  };
+
+  return updatedSpec;
+}

--- a/faros-airbyte-cdk/src/utils.ts
+++ b/faros-airbyte-cdk/src/utils.ts
@@ -154,6 +154,7 @@ function minimizeSpecObject(config: SpecObject): void {
 
 const SOURCE_COMMON_PROPERTIES = {
   max_stream_failures: {
+    // Use a high order to make sure these properties are displayed at the end
     order: 1000,
     type: 'integer',
     title: 'Max Stream Failures',

--- a/faros-airbyte-cdk/test/__snapshots__/utils.test.ts.snap
+++ b/faros-airbyte-cdk/test/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`utils add source common properties 1`] = `
+AirbyteSpec {
+  "spec": Object {
+    "connectionSpecification": Object {
+      "properties": Object {
+        "max_slice_failures": Object {
+          "default": 0,
+          "description": "The maximum number of slice failures before a stream sync fails. Use -1 for unlimited",
+          "order": 1001,
+          "title": "Max Slice Failures",
+          "type": "integer",
+        },
+        "max_stream_failures": Object {
+          "default": 0,
+          "description": "The maximum number of stream failures before the sync fails. Use -1 for unlimited",
+          "order": 1000,
+          "title": "Max Stream Failures",
+          "type": "integer",
+        },
+        "prop1": Object {
+          "type": "string",
+        },
+      },
+    },
+  },
+  "type": "SPEC",
+}
+`;

--- a/faros-airbyte-cdk/test/utils.test.ts
+++ b/faros-airbyte-cdk/test/utils.test.ts
@@ -1,6 +1,12 @@
 import path from 'path';
 
-import {redactConfig, redactConfigAsString, SpecLoader} from '../src';
+import {
+  addSourceCommonProperties,
+  AirbyteSpec,
+  redactConfig,
+  redactConfigAsString,
+  SpecLoader,
+} from '../src';
 
 const BASE_RESOURCES_DIR = path.join(__dirname, 'resources');
 
@@ -61,5 +67,20 @@ describe('utils', () => {
     };
     expect(redactConfig(cfg, spec)).toEqual(expected);
     expect(redactConfigAsString(cfg, spec)).toEqual(JSON.stringify(expected));
+  });
+
+  test('add source common properties', () => {
+    const spec = new AirbyteSpec({
+      connectionSpecification: {
+        properties: {
+          prop1: {
+            type: 'string',
+          },
+        },
+      },
+    });
+
+    const updatedSpec = addSourceCommonProperties(spec);
+    expect(updatedSpec).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
`./bin/main spec | jq`
(Last fragment of the Jira spec)
![Screenshot 2024-07-08 at 8 18 58 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/09d9f0b9-f0d7-46bc-8a4d-f831ebf5256a)

`./bin/main spec-pretty`

![Screenshot 2024-07-08 at 8 19 47 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/627bd9a4-878d-46f8-876c-62e6809a34c5)

`./bin/main airbyte-local-cli-wizard`
![Screenshot 2024-07-08 at 8 20 57 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/400ff64c-426c-4315-8037-85252cc4169f)
![Screenshot 2024-07-08 at 8 21 19 PM](https://github.com/faros-ai/airbyte-connectors/assets/99700024/982c4b11-a61b-4c14-80e3-d569b1420840)
