### PR TITLE
Skip spec check in acceptance tests

### DIFF
--- a/sources/agileaccelerator-source/acceptance-test-config.yml
+++ b/sources/agileaccelerator-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: agileaccelerator-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/azure-repos-source/acceptance-test-config.yml
+++ b/sources/azure-repos-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: azure-repos-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/azureactivedirectory-source/acceptance-test-config.yml
+++ b/sources/azureactivedirectory-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: azureactivedirectory-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/azurepipeline-source/acceptance-test-config.yml
+++ b/sources/azurepipeline-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: azurepipeline-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/backlog-source/acceptance-test-config.yml
+++ b/sources/backlog-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: backlog-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/bamboohr-source/acceptance-test-config.yml
+++ b/sources/bamboohr-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: bamboohr-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/bitbucket-server-source/acceptance-test-config.yml
+++ b/sources/bitbucket-server-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: bitbucket-server-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/bitbucket-source/acceptance-test-config.yml
+++ b/sources/bitbucket-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: bitbucket-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/buildkite-source/acceptance-test-config.yml
+++ b/sources/buildkite-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: buildkite-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/circleci-source/acceptance-test-config.yml
+++ b/sources/circleci-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: circleci-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/clickup-source/acceptance-test-config.yml
+++ b/sources/clickup-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: clickup-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/customer-io-source/acceptance-test-config.yml
+++ b/sources/customer-io-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: customer-io-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/docker-source/acceptance-test-config.yml
+++ b/sources/docker-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: docker-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/firehydrant-source/acceptance-test-config.yml
+++ b/sources/firehydrant-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: firehydrant-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/gitlab-ci-source/acceptance-test-config.yml
+++ b/sources/gitlab-ci-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: gitlab-ci-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/googlecalendar-source/acceptance-test-config.yml
+++ b/sources/googlecalendar-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: googlecalendar-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/harness-source/acceptance-test-config.yml
+++ b/sources/harness-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: harness-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/okta-source/acceptance-test-config.yml
+++ b/sources/okta-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: okta-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/pagerduty-source/acceptance-test-config.yml
+++ b/sources/pagerduty-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: pagerduty-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/semaphoreci-source/acceptance-test-config.yml
+++ b/sources/semaphoreci-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: semaphoreci-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/shortcut-source/acceptance-test-config.yml
+++ b/sources/shortcut-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: shortcut-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/squadcast-source/acceptance-test-config.yml
+++ b/sources/squadcast-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: squadcast-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/statuspage-source/acceptance-test-config.yml
+++ b/sources/statuspage-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: statuspage-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'

--- a/sources/victorops-source/acceptance-test-config.yml
+++ b/sources/victorops-source/acceptance-test-config.yml
@@ -1,8 +1,7 @@
 connector_image: victorops-source
 tests:
   spec:
-    - config_path: 'secrets/config.json'
-      spec_path: 'resources/spec.json'
+    bypass_reason: "Covered by unit test"
   connection:
     - config_path: 'secrets/config.json'
       status: 'succeed'


### PR DESCRIPTION
The acceptance tests compare the output of the `spec` command against the contents of a file (we use `spec.json`)
These tests now fail since we're adding common properties programmatically since #1571 

We can skip those tests given that we're covered by unit tests:

1. Sources have tests that compare the source's spec output against it's spec file ([example](https://github.com/faros-ai/airbyte-connectors/blob/876e5a328526ac001561f9dd171cc4132d992a50/sources/agileaccelerator-source/test/index.test.ts#L43))
2. The cdk has a [test](https://github.com/faros-ai/airbyte-connectors/blob/876e5a328526ac001561f9dd171cc4132d992a50/faros-airbyte-cdk/test/utils.test.ts#L72) that covers the addition of the common properties.