### PR TITLE
Fix bug in Jira Source Project filter

### DIFF
--- a/sources/jira-source/src/project-board-filter.ts
+++ b/sources/jira-source/src/project-board-filter.ts
@@ -22,7 +22,7 @@ export class ProjectBoardFilter {
       this.projects = new Set();
 
       const jira = await Jira.instance(this.config, this.logger);
-      if (!this.config.projects) {
+      if (!this.config.projects?.length) {
         const projects = this.supportsFarosClient()
           ? jira.getProjectsFromGraph(
               this.farosClient,

--- a/sources/jira-source/test/__snapshots__/project-board-filter.test.ts.snap
+++ b/sources/jira-source/test/__snapshots__/project-board-filter.test.ts.snap
@@ -22,7 +22,15 @@ exports[`ProjectBoardFilter getBoardsFromFaros - specific boards included 1`] = 
 ]
 `;
 
-exports[`ProjectBoardFilter getProjectsFromFaros - all projects 1`] = `
+exports[`ProjectBoardFilter getProjectsFromFaros - all projects - empty projects list 1`] = `
+[
+  "TEST-1",
+  "TEST-2",
+  "TEST-3",
+]
+`;
+
+exports[`ProjectBoardFilter getProjectsFromFaros - all projects - no projects list 1`] = `
 [
   "TEST-1",
   "TEST-2",

--- a/sources/jira-source/test/project-board-filter.test.ts
+++ b/sources/jira-source/test/project-board-filter.test.ts
@@ -37,8 +37,17 @@ describe('ProjectBoardFilter', () => {
     setupJiraInstance(mockedImplementation, true, config, logger);
   });
 
-  test('getProjectsFromFaros - all projects', async () => {
+  test('getProjectsFromFaros - all projects - no projects list', async () => {
     const projectBoardFilter = new ProjectBoardFilter(config, logger);
+    const projects = await projectBoardFilter.getProjects();
+    expect(projects).toMatchSnapshot();
+  });
+
+  test('getProjectsFromFaros - all projects - empty projects list', async () => {
+    const projectBoardFilter = new ProjectBoardFilter(
+      {...config, projects: []},
+      logger
+    );
     const projects = await projectBoardFilter.getProjects();
     expect(projects).toMatchSnapshot();
   });


### PR DESCRIPTION
## Description
Fix projects list check in project-board-filter. If `projects` is `[]` (empty array) we should sync all projects, which is the same behaviour as projects being `undefined`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
