### PR TITLE
FAI-12482 | Added "Custom" run mode option including ALL streams

### DIFF
--- a/sources/github-source/resources/spec.json
+++ b/sources/github-source/resources/spec.json
@@ -144,7 +144,8 @@
           "CopilotEvaluationApp",
           "CopilotEvaluation",
           "Minimum",
-          "Full"
+          "Full",
+          "Custom"
         ]
       },
       "fetch_teams": {

--- a/sources/github-source/src/streams/common.ts
+++ b/sources/github-source/src/streams/common.ts
@@ -29,6 +29,7 @@ export enum RunMode {
   CopilotEvaluation = 'CopilotEvaluation',
   Minimum = 'Minimum',
   Full = 'Full',
+  Custom = 'Custom',
 }
 
 export const CopilotEvaluationAppStreamNames = [
@@ -56,8 +57,20 @@ export const MinimumStreamNames = [
   'faros_users',
 ];
 
-// fill as streams are developed
 export const FullStreamNames = [
+  'faros_commits',
+  'faros_copilot_seats',
+  'faros_copilot_usage',
+  'faros_labels',
+  'faros_organizations',
+  'faros_pull_requests',
+  'faros_pull_request_comments',
+  'faros_repositories',
+  'faros_users',
+];
+
+// fill as streams are developed
+export const CustomStreamNames = [
   'faros_commits',
   'faros_copilot_seats',
   'faros_copilot_usage',
@@ -79,6 +92,7 @@ export const RunModeStreams = {
   [RunMode.CopilotEvaluation]: CopilotEvaluationStreamNames,
   [RunMode.Minimum]: MinimumStreamNames,
   [RunMode.Full]: FullStreamNames,
+  [RunMode.Custom]: CustomStreamNames,
 };
 
 export abstract class StreamBase extends AirbyteStreamBase {

--- a/sources/github-source/test/resources/config.json
+++ b/sources/github-source/test/resources/config.json
@@ -3,10 +3,11 @@
     "type": "token",
     "personal_access_token": "ghp_1234567890"
   },
-  "cutoff_days": 9999,
+  "run_mode": "Custom",
   "fetch_teams": true,
-  "bucket_id": 1,
-  "bucket_total": 1,
   "fetch_pull_request_files": true,
-  "fetch_pull_request_reviews": true
+  "fetch_pull_request_reviews": true,
+  "cutoff_days": 9999,
+  "bucket_id": 1,
+  "bucket_total": 1
 }

--- a/sources/jira-source/resources/spec.json
+++ b/sources/jira-source/resources/spec.json
@@ -169,7 +169,8 @@
           "Full",
           "Minimum",
           "WebhookSupplement",
-          "AdditionalFields"
+          "AdditionalFields",
+          "Custom"
         ]
       },
       "bucket_id": {

--- a/sources/jira-source/src/streams/common.ts
+++ b/sources/jira-source/src/streams/common.ts
@@ -42,6 +42,7 @@ export enum RunMode {
   Minimum = 'Minimum',
   WebhookSupplement = 'WebhookSupplement',
   AdditionalFields = 'AdditionalFields',
+  Custom = 'Custom',
 }
 
 export const FullStreamNames = [
@@ -74,6 +75,19 @@ export const WebhookSupplementStreamNames = [
 
 export const AdditionalFieldsStreamNames = ['faros_issue_additional_fields'];
 
+export const CustomStreamNames = [
+  'faros_issue_pull_requests',
+  'faros_sprint_reports',
+  'faros_board_issues',
+  'faros_sprints',
+  'faros_users',
+  'faros_projects',
+  'faros_issues',
+  'faros_boards',
+  'faros_project_versions',
+  'faros_project_version_issues',
+];
+
 export const TeamStreamNames = ['faros_teams', 'faros_team_memberships'];
 
 export const RunModeStreams = {
@@ -81,6 +95,7 @@ export const RunModeStreams = {
   [RunMode.Minimum]: MinimumStreamNames,
   [RunMode.WebhookSupplement]: WebhookSupplementStreamNames,
   [RunMode.AdditionalFields]: AdditionalFieldsStreamNames,
+  [RunMode.Custom]: CustomStreamNames,
 };
 
 export abstract class StreamBase extends AirbyteStreamBase {


### PR DESCRIPTION
## Description

Added "Custom" run mode option including ALL streams, so that Full/Standard (default) run mode can be a subset of all possible streams. When Custom is selected the stream selection is done through Airbyte stream settings.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
