### PR TITLE
Pass decompressed state to onBeforeRead

### DIFF
--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -109,7 +109,11 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
 
           try {
             this.logger.getState = () => maybeCompressState(config, state);
-            const res = await this.source.onBeforeRead(config, catalog, state);
+            const res = await this.source.onBeforeRead(
+              config,
+              catalog,
+              State.decompress(state)
+            );
             const clonedState = State.decompress(cloneDeep(res.state ?? {}));
             this.logger.getState = () =>
               maybeCompressState(config, clonedState);


### PR DESCRIPTION
## Description

Noticed that my previous [PR](https://github.com/faros-ai/airbyte-connectors/pull/1633) , which uses the state, was not working. We're passing the possibly compressed state to the `onBeforeRead` function, so that's why [this](https://github.com/faros-ai/airbyte-connectors/blob/902803d196fb2e2c519819c63c7a947f447dbe71/sources/asana-source/src/index.ts#L78C43-L78C56) wouldn't work.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
