### PR TITLE
FAI-12666 | Dynamic page size for PRs query to avoid timeout failures

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/github/faros_commits.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/faros_commits.ts
@@ -69,9 +69,10 @@ export class FarosCommits extends GitHubConverter {
       commit.changedFiles,
     ])
       ? {
-          linesAdded: commit?.additions,
-          linesDeleted: commit?.deletions,
-          filesChanged: commit?.changedFilesIfAvailable ?? commit?.changedFiles,
+          linesAdded: commit?.additions ?? null,
+          linesDeleted: commit?.deletions ?? null,
+          filesChanged:
+            commit?.changedFilesIfAvailable ?? commit?.changedFiles ?? null,
         }
       : undefined;
   }

--- a/sources/github-source/resources/spec.json
+++ b/sources/github-source/resources/spec.json
@@ -197,35 +197,42 @@
         "description": "Maximum number of items in a paginated response",
         "default": 100
       },
-      "timeout": {
+      "max_pull_requests_page_size": {
         "order": 15,
+        "type": "integer",
+        "title": "Maximum Pull Requests Page Size",
+        "description": "Maximum number of items in a paginated response for pull requests",
+        "default": 25
+      },
+      "timeout": {
+        "order": 16,
         "type": "integer",
         "title": "Request Timeout",
         "description": "Timeout in milliseconds for each request to the GitHub API",
         "default": 120000
       },
       "concurrency_limit": {
-        "order": 16,
+        "order": 17,
         "type": "integer",
         "title": "Concurrency limit",
         "description": "Maximum concurrency to run with",
         "default": 4
       },
       "backfill": {
-        "order": 17,
+        "order": 18,
         "type": "boolean",
         "title": "Backfill",
         "description": "Backfill data from the start date to the end date.",
         "default": false
       },
       "start_date": {
-        "order": 18,
+        "order": 19,
         "type": "string",
         "title": "Start Date",
         "description": "The date from which to start syncing data. Only use for backfilling."
       },
       "end_date": {
-        "order": 19,
+        "order": 20,
         "type": "string",
         "title": "End Date",
         "description": "The date at which to stop syncing data. Only use for backfilling."

--- a/sources/github-source/resources/spec.json
+++ b/sources/github-source/resources/spec.json
@@ -197,10 +197,10 @@
         "description": "Maximum number of items in a paginated response",
         "default": 100
       },
-      "max_pull_requests_page_size": {
+      "pull_requests_page_size": {
         "order": 15,
         "type": "integer",
-        "title": "Maximum Pull Requests Page Size",
+        "title": "Pull Requests Page Size",
         "description": "Maximum number of items in a paginated response for pull requests",
         "default": 25
       },

--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -81,7 +81,7 @@ export const DEFAULT_CUTOFF_DAYS = 90;
 export const DEFAULT_BUCKET_ID = 1;
 export const DEFAULT_BUCKET_TOTAL = 1;
 export const DEFAULT_PAGE_SIZE = 100;
-export const DEFAULT_MAX_PR_PAGE_SIZE = 25;
+export const DEFAULT_PR_PAGE_SIZE = 25;
 export const DEFAULT_TIMEOUT_MS = 120_000;
 export const DEFAULT_CONCURRENCY = 4;
 export const DEFAULT_BACKFILL = false;
@@ -104,7 +104,7 @@ export abstract class GitHub {
   protected readonly bucketId: number;
   protected readonly bucketTotal: number;
   protected readonly pageSize: number;
-  protected readonly maxPullRequestsPageSize: number;
+  protected readonly pullRequestsPageSize: number;
   protected readonly timeoutMs: number;
   protected readonly backfill: boolean;
 
@@ -120,8 +120,8 @@ export abstract class GitHub {
     this.bucketId = config.bucket_id ?? DEFAULT_BUCKET_ID;
     this.bucketTotal = config.bucket_total ?? DEFAULT_BUCKET_TOTAL;
     this.pageSize = config.page_size ?? DEFAULT_PAGE_SIZE;
-    this.maxPullRequestsPageSize =
-      config.max_pull_requests_page_size ?? DEFAULT_MAX_PR_PAGE_SIZE;
+    this.pullRequestsPageSize =
+      config.pull_requests_page_size ?? DEFAULT_PR_PAGE_SIZE;
     this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS;
     this.backfill = config.backfill ?? DEFAULT_BACKFILL;
   }
@@ -232,7 +232,7 @@ export abstract class GitHub {
       return;
     }
     const query = this.buildPRQuery();
-    let currentPageSize = this.maxPullRequestsPageSize;
+    let currentPageSize = this.pullRequestsPageSize;
     let currentCursor = startCursor;
     let hasNextPage = true;
     let querySuccess = false;
@@ -280,7 +280,7 @@ export abstract class GitHub {
           // increase page size for the next iteration in case it was decreased previously
           currentPageSize = Math.min(
             currentPageSize * 2,
-            this.maxPullRequestsPageSize
+            this.pullRequestsPageSize
           );
           currentCursor = res.repository.pullRequests.pageInfo.endCursor;
           hasNextPage = res.repository.pullRequests.pageInfo.hasNextPage;

--- a/sources/github-source/src/types.ts
+++ b/sources/github-source/src/types.ts
@@ -19,6 +19,7 @@ export interface GitHubConfig extends AirbyteConfig {
   readonly bucket_id?: number;
   readonly bucket_total?: number;
   readonly page_size?: number;
+  readonly max_pull_requests_page_size?: number;
   readonly timeout?: number;
   readonly concurrency_limit?: number;
   readonly start_date?: string;

--- a/sources/github-source/src/types.ts
+++ b/sources/github-source/src/types.ts
@@ -19,7 +19,7 @@ export interface GitHubConfig extends AirbyteConfig {
   readonly bucket_id?: number;
   readonly bucket_total?: number;
   readonly page_size?: number;
-  readonly max_pull_requests_page_size?: number;
+  readonly pull_requests_page_size?: number;
   readonly timeout?: number;
   readonly concurrency_limit?: number;
   readonly start_date?: string;


### PR DESCRIPTION
## Description

Dynamic page size for PRs query to avoid timeout failures on PR stream. Applied same workaround and values (page size, multipliers) from [feeds implementation](https://github.com/faros-ai/feeds/blob/2f9f1ed6b189252bd3f8fca2c6c9229aff0ce185/feeds/vcs/github-feed/src/feed.ts#L1121)

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
