### PR TITLE
FAI-12259 | Google sheet source support for sheet filters and first row offset

### DIFF
--- a/sources/sheets-source/resources/spec.json
+++ b/sources/sheets-source/resources/spec.json
@@ -140,8 +140,30 @@
           }
         ]
       },
-      "sheet_page_size": {
+      "sheet_names": {
         "order": 2,
+        "title": "Sheet Names",
+        "description": "Names of the sheets to extract rows. By default, all sheets are used (only supports Google Sheet)",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "examples": [
+          [
+            "Sheet1",
+            "Sheet2"
+          ]
+        ]
+      },
+      "row_offset": {
+        "order": 3,
+        "title": "Row offset",
+        "description": "Number of rows to skip until headers row (only supports Google Sheet)",
+        "type": "integer",
+        "default": 0
+      },
+      "sheet_page_size": {
+        "order": 4,
         "title": "Sheet Page Size",
         "description": "Page size when fetching rows from a sheet",
         "type": "integer",
@@ -154,7 +176,7 @@
         ]
       },
       "stream_name": {
-        "order": 3,
+        "order": 5,
         "title": "Stream Name",
         "description": "Name of the data stream",
         "type": "string",


### PR DESCRIPTION
## Description

Google sheet source support for sheet filters and first row offset (local file and S3 support would need a bigger refactor).

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
