### PR TITLE
FAI-12660 Fix missing task keys in Trello converter

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/trello/cards.ts
+++ b/destinations/airbyte-faros-destination/src/converters/trello/cards.ts
@@ -335,9 +335,9 @@ export class Cards extends TrelloConverter {
       100,
       paginatedQueryV2
     )) {
-      const taskKey = {uid: task.uid, source: task.source};
+      const taskKey = {uid: cardId, source: this.source};
       const statusChangelog: TmsTaskStatusChange[] = this.getStatusChangelog(
-        task.uid,
+        cardId,
         task.statusChangelog
           .filter((item) => !isNil(item.changedAt))
           .map((item) => ({


### PR DESCRIPTION
## Description

`task.uid` and `task.source` are always missing since they're not queried for 🤦‍♂️ 

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
