### PR TITLE
FAI-12259 | Sheets source only parse private key json if it's a string

### DIFF
--- a/sources/sheets-source/src/sheets-reader.ts
+++ b/sources/sheets-source/src/sheets-reader.ts
@@ -82,9 +82,14 @@ export class SheetsReader {
           );
         }
 
-        const creds = privateKey
-          ? (JSON.parse(privateKey) as ServiceAccountCredentials)
-          : apiKey;
+        let creds: string | ServiceAccountCredentials;
+        if (privateKey) {
+          creds = (
+            typeof privateKey === 'string' ? JSON.parse(privateKey) : privateKey
+          ) as ServiceAccountCredentials;
+        } else {
+          creds = apiKey;
+        }
 
         wb = await SheetsReader.loadSheets(
           config.spreadsheet_source.google_sheet_id,


### PR DESCRIPTION
## Description

Sheets source only parse private key json if it's a string

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
