### PR TITLE
FAI-12550 Add option to always full sync tasks and skip costly project-tasks streams

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/asana/project_tasks.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/project_tasks.ts
@@ -15,6 +15,13 @@ export class ProjectTasks extends AsanaConverter {
     const source = this.streamName.source;
     const projectTask: ProjectTaskAssociation = record.record
       .data as ProjectTaskAssociation;
+    return ProjectTasks.convertProjectTask(projectTask, source);
+  }
+
+  static convertProjectTask(
+    projectTask: ProjectTaskAssociation,
+    source: string
+  ) {
     const taskKey = {uid: projectTask.task_gid, source};
     const res: DestinationRecord[] = [];
 

--- a/destinations/airbyte-faros-destination/src/converters/asana/projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/projects.ts
@@ -16,9 +16,18 @@ export class Projects extends AsanaConverter {
     const source = this.streamName.source;
     const project: AsanaProject = record.record.data as AsanaProject;
 
+    return Projects.convertProject(
+      {gid: project.gid, name: project.name},
+      source
+    );
+  }
+
+  static convertProject(
+    project: Pick<AsanaProject, 'gid' | 'name'>,
+    source: string
+  ): DestinationRecord[] {
     // Since Asana doesn't have a concept of a board, we create a board and a project from the same Asana project.
     // This is the same behavior as the Jira connector when using project ownership.
-
     const board: DestinationRecord = {
       model: 'tms_TaskBoard',
       record: {

--- a/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
@@ -1,4 +1,4 @@
-import {AirbyteRecord} from 'faros-airbyte-cdk';
+import {AirbyteRecord, DestinationSyncMode} from 'faros-airbyte-cdk';
 import {Utils} from 'faros-js-client';
 import {Dictionary} from 'ts-essentials';
 
@@ -8,7 +8,9 @@ import {
   StreamContext,
   StreamName,
 } from '../converter';
-import {AsanaCommon, AsanaConverter, AsanaSection} from './common';
+import {AsanaCommon, AsanaConverter} from './common';
+import {ProjectTasks} from './project_tasks';
+import {Projects} from './projects';
 
 interface CustomField {
   gid: string;
@@ -117,6 +119,18 @@ export class Tasks extends AsanaConverter {
           value: membership.section.name,
         });
       }
+      if (membership.project && this.shouldProcessProjectMembership()) {
+        res.push(...Projects.convertProject(membership.project, source));
+        res.push(
+          ...ProjectTasks.convertProjectTask(
+            {
+              project_gid: membership.project.gid,
+              task_gid: task.gid,
+            },
+            source
+          )
+        );
+      }
     }
 
     res.push({
@@ -219,5 +233,9 @@ export class Tasks extends AsanaConverter {
         customField.multi_enum_values?.name ??
         customField.display_value,
     };
+  }
+
+  protected shouldProcessProjectMembership(): boolean {
+    return false;
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/asana/tasks_full.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/tasks_full.ts
@@ -1,0 +1,32 @@
+import {
+  DestinationModel,
+  DestinationRecord,
+  StreamContext,
+  StreamName,
+} from '../converter';
+import {ProjectTasks} from './project_tasks';
+import {Projects} from './projects';
+import {Tasks} from './tasks';
+
+export class TasksFull extends Tasks {
+  readonly destinationModels: ReadonlyArray<DestinationModel> = [
+    ...new Tasks().destinationModels,
+    ...new Projects().destinationModels,
+    ...new ProjectTasks().destinationModels,
+  ];
+
+  override shouldProcessProjectMembership(): boolean {
+    return true;
+  }
+
+  async onProcessingComplete(
+    ctx: StreamContext
+  ): Promise<ReadonlyArray<DestinationRecord>> {
+    const streams = ['projects', 'project_tasks'];
+    streams.forEach((stream) => {
+      ctx.markStreamForReset(new StreamName(this.source, stream).asString);
+    });
+
+    return [];
+  }
+}

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/asana.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/asana.test.ts.snap
@@ -375,6 +375,91 @@ Array [
 ]
 `;
 
+exports[`asana tasks tasks_full should process project membership 1`] = `
+Array [
+  Object {
+    "model": "tms_TaskBoard",
+    "record": Object {
+      "name": "Project 1",
+      "source": "Asana",
+      "uid": "1205346703408259",
+    },
+  },
+  Object {
+    "model": "tms_Project",
+    "record": Object {
+      "name": "Project 1",
+      "source": "Asana",
+      "uid": "1205346703408259",
+    },
+  },
+  Object {
+    "model": "tms_TaskBoardProjectRelationship",
+    "record": Object {
+      "board": Object {
+        "source": "Asana",
+        "uid": "1205346703408259",
+      },
+      "project": Object {
+        "source": "Asana",
+        "uid": "1205346703408259",
+      },
+    },
+  },
+  Object {
+    "model": "tms_TaskBoardRelationship",
+    "record": Object {
+      "board": Object {
+        "source": "Asana",
+        "uid": "1205346703408259",
+      },
+      "task": Object {
+        "source": "Asana",
+        "uid": "1205346703408262",
+      },
+    },
+  },
+  Object {
+    "model": "tms_TaskProjectRelationship",
+    "record": Object {
+      "project": Object {
+        "source": "Asana",
+        "uid": "1205346703408259",
+      },
+      "task": Object {
+        "source": "Asana",
+        "uid": "1205346703408262",
+      },
+    },
+  },
+  Object {
+    "model": "tms_Task",
+    "record": Object {
+      "additionalFields": Array [],
+      "createdAt": 2023-08-24T15:52:00.014Z,
+      "description": "Task 1 notes",
+      "name": "Task 1",
+      "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
+      "source": "Asana",
+      "status": Object {
+        "category": "Todo",
+        "detail": "incomplete",
+      },
+      "statusChangedAt": 2023-08-25T20:59:25.575Z,
+      "statusChangelog": Array [],
+      "type": Object {
+        "category": "Task",
+        "detail": "task",
+      },
+      "uid": "1205346703408262",
+      "updatedAt": 2023-08-25T20:59:25.575Z,
+      "url": "https://app.asana.com/0/1205346703408259/1205346703408262",
+    },
+  },
+]
+`;
+
 exports[`asana users basic user 1`] = `
 Array [
   Object {

--- a/destinations/airbyte-faros-destination/test/converters/asana.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/asana.test.ts
@@ -6,6 +6,7 @@ import {ProjectTasks} from '../../src/converters/asana/project_tasks';
 import {Projects} from '../../src/converters/asana/projects';
 import {Tags} from '../../src/converters/asana/tags';
 import {Tasks} from '../../src/converters/asana/tasks';
+import {TasksFull} from '../../src/converters/asana/tasks_full';
 import {Users} from '../../src/converters/asana/users';
 import {initMockttp, tempConfig} from '../testing-tools';
 import {generateBasicTestSuite} from './utils';
@@ -117,6 +118,7 @@ describe('asana', () => {
           {
             project: {
               gid: '1205346703408259',
+              name: 'Project 1',
             },
             section: {
               gid: '1205346703408260',
@@ -126,6 +128,23 @@ describe('asana', () => {
         ],
       });
       const res = await converter.convert(record);
+      expect(res).toMatchSnapshot();
+    });
+
+    test('tasks_full should process project membership', async () => {
+      const tasksFullConverter = new TasksFull();
+      const record = AirbyteRecord.make('tasks_full', {
+        ...TASK,
+        memberships: [
+          {
+            project: {
+              gid: '1205346703408259',
+              name: 'Project 1',
+            },
+          },
+        ],
+      });
+      const res = await tasksFullConverter.convert(record);
       expect(res).toMatchSnapshot();
     });
 

--- a/sources/asana-source/resources/spec.json
+++ b/sources/asana-source/resources/spec.json
@@ -108,6 +108,12 @@
         },
         "title": "Required Task Custom Fields gid(s)",
         "description": "Only fetch tasks that have at least one of the specified custom fields set."
+      },
+      "optimize_fetching_projects_and_tasks_with_full_tasks_sync": {
+        "order": 10,
+        "type": "boolean",
+        "title": "Optimize fetching projects/tasks by forcing full tasks sync.",
+        "description": "Forces a full sync of tasks and skips projects and project-tasks relationships sync. Depending on the number of tasks, this could be faster than the default behavior."
       }
     }
   }

--- a/sources/asana-source/src/asana.ts
+++ b/sources/asana-source/src/asana.ts
@@ -40,6 +40,7 @@ export interface AsanaConfig {
   cutoff_days?: number;
   project_tasks_max_staleness_hours?: number;
   required_task_custom_fields?: ReadonlyArray<string>;
+  optimize_fetching_projects_and_tasks_with_full_tasks_sync?: boolean;
 }
 
 export class Asana {
@@ -191,6 +192,8 @@ export class Asana {
       'completed',
       'created_at',
       'custom_fields',
+      'memberships.project',
+      'memberships.project.name',
       'memberships.section',
       'memberships.section.name',
       'modified_at',

--- a/sources/asana-source/src/streams/tasks_full.ts
+++ b/sources/asana-source/src/streams/tasks_full.ts
@@ -1,0 +1,7 @@
+import {Tasks} from './tasks';
+
+export class TasksFull extends Tasks {
+  get supportsIncremental(): boolean {
+    return false;
+  }
+}

--- a/sources/asana-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/asana-source/test/__snapshots__/index.test.ts.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`index onBeforeRead filters project_tasks does not sync project_tasks when optimize_fetching_projects_and_tasks_with_full_tasks_sync 1`] = `
+Object {
+  "streams": Array [
+    Object {
+      "destination_sync_mode": "overwrite",
+      "stream": Object {
+        "json_schema": Object {},
+        "name": "tasks_full",
+      },
+      "sync_mode": "full_refresh",
+    },
+  ],
+}
+`;
+
 exports[`index onBeforeRead filters project_tasks sync project_tasks when missing state 1`] = `
 Object {
   "streams": Array [
@@ -7,6 +22,13 @@ Object {
       "stream": Object {
         "json_schema": Object {},
         "name": "project_tasks",
+      },
+      "sync_mode": "full_refresh",
+    },
+    Object {
+      "stream": Object {
+        "json_schema": Object {},
+        "name": "projects",
       },
       "sync_mode": "full_refresh",
     },
@@ -34,6 +56,13 @@ Object {
     Object {
       "stream": Object {
         "json_schema": Object {},
+        "name": "projects",
+      },
+      "sync_mode": "full_refresh",
+    },
+    Object {
+      "stream": Object {
+        "json_schema": Object {},
         "name": "tasks",
       },
       "sync_mode": "incremental",
@@ -49,6 +78,13 @@ Object {
       "stream": Object {
         "json_schema": Object {},
         "name": "project_tasks",
+      },
+      "sync_mode": "full_refresh",
+    },
+    Object {
+      "stream": Object {
+        "json_schema": Object {},
+        "name": "projects",
       },
       "sync_mode": "full_refresh",
     },
@@ -76,6 +112,13 @@ Object {
     Object {
       "stream": Object {
         "json_schema": Object {},
+        "name": "projects",
+      },
+      "sync_mode": "full_refresh",
+    },
+    Object {
+      "stream": Object {
+        "json_schema": Object {},
         "name": "tasks",
       },
       "sync_mode": "incremental",
@@ -87,6 +130,13 @@ Object {
 exports[`index onBeforeRead filters project_tasks sync project_tasks when stale 2`] = `
 Object {
   "streams": Array [
+    Object {
+      "stream": Object {
+        "json_schema": Object {},
+        "name": "projects",
+      },
+      "sync_mode": "full_refresh",
+    },
     Object {
       "stream": Object {
         "json_schema": Object {},


### PR DESCRIPTION
## Description

There are cases where the project-tasks relationship is so costly that it accounts for the majority of the records pulled in a sync.

This PR introduces an optimization where, if the number of tasks pulled in a full sync is << number of records in the project-tasks relationship (always full sync), it could be more efficient to pull tasks in full sync (the tasks records would include the associated projects) VS tasks incrementally + projects(full) + project-tasks(full).

If the `optimize_fetching_projects_and_tasks_with_full_tasks_sync` is enabled, we simply remove the unwanted streams from the catalog and add `tasks_full`. A new stream (pretty much an alias) is needed so that we make sure that the destination receives the appropriate destination sync mode (`OVERWRITE`)

Another wrinkle that I had to deal with is that the destination doesn't reset models unless ALL the streams that write the model have succeeded. In this case there's an intersection of models between `tasks_full` and (`projects`, `project_tasks`). I [marked](https://github.com/faros-ai/airbyte-connectors/pull/1657/files#diff-bdfcc178277d99d541ceb3db141b777acec0551173f74b0c17e4b868079903bcR25) these two as safe for reset (they'd never succeed, since they are not synced at all) so that the destination frees the respective models for reset.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
