### PR TITLE
Revert "Sign package-lock.json formatting commits"

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -56,5 +56,3 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Reformat package-lock.json [dependabot skip]"
-          commit_options: '--gpg-sign'
-


### PR DESCRIPTION
Reverts faros-ai/airbyte-connectors#1681

Should follow https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#signing-commits instead