### PR TITLE
Fix project_names type in TestRail source spec

### DIFF
--- a/sources/testrails-source/resources/spec.json
+++ b/sources/testrails-source/resources/spec.json
@@ -22,7 +22,7 @@
         "examples": ["https://example.testrail.com"]
       },
       "project_names": {
-        "type": "string",
+        "type": "array",
         "title": "TestRails Projects to Sync",
         "description": "If no Projects provided, all Projects will be synced.",
         "items": {


### PR DESCRIPTION
## Description
Set correct field type. It's currently failing on airbyte cause it expects a string and its receiving an array.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
