### PR TITLE
FAI-11183: Process PR raw diffs as a streamed response

### DIFF
--- a/sources/bitbucket-server-source/package.json
+++ b/sources/bitbucket-server-source/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@atlassian/bitbucket-server": "^0.0.6",
+    "axios": "^1.7.4",
     "faros-airbyte-cdk": "0.0.1",
     "faros-airbyte-common": "0.0.1",
     "parse-diff": "^0.11.1",

--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -388,7 +388,7 @@ export class BitbucketServer {
   private async parseRawDiff(
     data: Readable
   ): Promise<ReadonlyArray<PullRequestDiff['files'][0]>> {
-    const rl = createInterface({
+    const lineReader = createInterface({
       input: data,
       crlfDelay: Infinity,
     });
@@ -403,7 +403,7 @@ export class BitbucketServer {
     };
 
     // read and parse each line accumulating a complete file diff
-    for await (const line of rl) {
+    for await (const line of lineReader) {
       if (line.startsWith('diff --git')) {
         if (currentFile) {
           parseAndPushDiff();

--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -110,8 +110,11 @@ export class BitbucketServer {
       headers: {
         Authorization:
           auth.type === 'token'
-            ? `Bearer ${auth.token}`
-            : `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString('base64')}`,
+            ? 'Bearer ' + auth.token
+            : 'Basic ' +
+              Buffer.from(`${auth.username}:${auth.password}`).toString(
+                'base64'
+              ),
       },
     });
     const bb = new BitbucketServer(

--- a/sources/bitbucket-server-source/src/bitbucket-server/index.ts
+++ b/sources/bitbucket-server-source/src/bitbucket-server/index.ts
@@ -108,13 +108,12 @@ export class BitbucketServer {
       baseURL: baseUrl,
       maxContentLength: Infinity, //default is 2000 bytes
       headers: {
-        Authorization:
-          auth.type === 'token'
-            ? 'Bearer ' + auth.token
-            : 'Basic ' +
-              Buffer.from(`${auth.username}:${auth.password}`).toString(
-                'base64'
-              ),
+        Authorization: config.token
+          ? 'Bearer ' + config.token
+          : 'Basic ' +
+            Buffer.from(`${config.username}:${config.password}`).toString(
+              'base64'
+            ),
       },
     });
     const bb = new BitbucketServer(
@@ -396,7 +395,7 @@ export class BitbucketServer {
     const files = [];
     let currentFile: string | null = null;
 
-    const parseAndPushDiff = () => {
+    const parseAndPushDiff = (): void => {
       const fileDiff = parseDiff(currentFile)[0];
       files.push(
         pick(fileDiff, 'deletions', 'additions', 'from', 'to', 'deleted', 'new')

--- a/sources/bitbucket-server-source/test/index.test.ts
+++ b/sources/bitbucket-server-source/test/index.test.ts
@@ -42,6 +42,7 @@ describe('index', () => {
     BitbucketServer.instance = jest.fn().mockImplementation(() => {
       return new BitbucketServer(
         {api: {getUsers: jest.fn().mockResolvedValue({})}} as any,
+        {} as any,
         100,
         logger,
         new Date('2010-03-27T14:03:51-0800'),
@@ -78,6 +79,7 @@ describe('index', () => {
           },
           hasNextPage: jest.fn(),
         } as any,
+        {} as any,
         100,
         logger,
         new Date('2010-03-27T14:03:51-0800'),
@@ -116,6 +118,7 @@ describe('index', () => {
           },
           hasNextPage: jest.fn(),
         } as any,
+        {} as any,
         100,
         logger,
         new Date('2010-03-27T14:03:51-0800'),


### PR DESCRIPTION
## Description
Use a stream to read PR raw diff instead of storing it into a string in memory to avoid error: "Cannot create a string longer than 0x1fffffe8 characters"

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
