### PR TITLE
Update example source spec to make acceptance tests pass

### DIFF
--- a/sources/example-source/test_files/spec.json
+++ b/sources/example-source/test_files/spec.json
@@ -47,6 +47,12 @@
         "title": "Debug",
         "description": "Enable debug mode",
         "default": false
+      },
+      "faros_source_id": {
+        "order": 1003,
+        "type": "string",
+        "title": "The source ID",
+        "description": "The ID of the source (aka account)"
       }
     }
   }


### PR DESCRIPTION
Needed after #1660 which adds a common config field to all sources specs