### PR TITLE
FAI-13343 Fix force-marking streams for reset in Asana converter

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/asana/tasks_full.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/tasks_full.ts
@@ -1,9 +1,4 @@
-import {
-  DestinationModel,
-  DestinationRecord,
-  StreamContext,
-  StreamName,
-} from '../converter';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {ProjectTasks} from './project_tasks';
 import {Projects} from './projects';
 import {Tasks} from './tasks';
@@ -24,7 +19,7 @@ export class TasksFull extends Tasks {
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const streams = ['projects', 'project_tasks'];
     streams.forEach((stream) => {
-      ctx.markStreamForReset(new StreamName(this.source, stream).asString);
+      ctx.markStreamForReset(stream);
     });
 
     return [];


### PR DESCRIPTION
## Description

In [here](https://github.com/faros-ai/airbyte-connectors/blob/3cbecfc43c42188bb2fdcb3de6f42db4d91a82ac/destinations/airbyte-faros-destination/src/destination.ts#L556) we use the stream name without any kind of prefix (origin, source). I was incorrectly marking the stream for reset using the source prefix.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
