### PR TITLE
FAI-13204 FAI-13424 | Fix repositories inclusion/exclusions query

### DIFF
--- a/faros-airbyte-common/resources/common/queries/faros-vcs-repository-options.gql
+++ b/faros-airbyte-common/resources/common/queries/faros-vcs-repository-options.gql
@@ -4,12 +4,14 @@ query VcsRepositoryOptions(
   faros_VcsRepositoryOptions(
     where: {
       repository: {
-        source: { _eq: $source }
+      	organization: {
+          source: {_eq: $source}
+        }
       }
     }
   ) {
     repository {
-      uid
+      name
       organization {
         uid
       }

--- a/faros-airbyte-common/src/common/index.ts
+++ b/faros-airbyte-common/src/common/index.ts
@@ -176,7 +176,7 @@ const getFarosOptionsItemKey = (
       return board;
     }
     case 'repository': {
-      const repo = options.repository?.uid;
+      const repo = options.repository?.name;
       const org = options.repository?.organization?.uid;
       if (!repo || !org) {
         return;

--- a/sources/github-source/test/org-repo-filter.test.ts
+++ b/sources/github-source/test/org-repo-filter.test.ts
@@ -192,7 +192,7 @@ function repositoryOptions(
   const [org, repo] = key.split('/');
   return {
     repository: {
-      uid: repo,
+      name: repo,
       organization: {
         uid: org,
       },


### PR DESCRIPTION
## Description

Fix repositories inclusion/exclusions query used when `use_faros_graph_repos_selection` param is true on GitHub source.
Tested locally with airbyte-cli.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
