### PR TITLE
FAI-13447 | Ignore state cutoff if copilot licenses fix is disabled

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -820,7 +820,7 @@ export abstract class GitHub {
   async *getCopilotSeats(
     org: string,
     cutoffDate: Date,
-    licensesDatesFix: boolean
+    useCopilotTeamAssignmentsFix: boolean
   ): AsyncGenerator<CopilotSeatsStreamRecord> {
     let seatsFound: boolean = false;
     const assignedTeams: CopilotAssignedTeams = {};
@@ -842,7 +842,7 @@ export abstract class GitHub {
           let teamJoinedAt: Date;
           let startedAt = Utils.toDate(seat.created_at);
           assignedUsers.add(userAssignee);
-          if (teamAssignee && licensesDatesFix) {
+          if (teamAssignee && useCopilotTeamAssignmentsFix) {
             if (!assignedTeams[teamAssignee]) {
               assignedTeams[teamAssignee] = pick(seat, ['created_at']);
             }

--- a/sources/github-source/src/streams/faros_copilot_seats.ts
+++ b/sources/github-source/src/streams/faros_copilot_seats.ts
@@ -52,9 +52,10 @@ export class FarosCopilotSeats extends StreamWithOrgSlices {
     const org = streamSlice?.org;
     const state = streamState?.[StreamBase.orgKey(org)];
     // for Copilot data, cutoff default is beginning of time
-    const cutoffDate = state?.cutoff
-      ? Utils.toDate(state.cutoff)
-      : Utils.toDate(0);
+    const cutoffDate =
+      this.copilotLicensesDatesFix && state?.cutoff
+        ? Utils.toDate(state.cutoff)
+        : Utils.toDate(0);
     yield* github.getCopilotSeats(
       org,
       cutoffDate,

--- a/sources/github-source/src/streams/faros_copilot_seats.ts
+++ b/sources/github-source/src/streams/faros_copilot_seats.ts
@@ -18,7 +18,7 @@ import {
 } from './common';
 
 export class FarosCopilotSeats extends StreamWithOrgSlices {
-  protected readonly copilotLicensesDatesFix: boolean;
+  protected readonly useCopilotTeamAssignmentsFix: boolean;
 
   constructor(
     protected readonly config: GitHubConfig,
@@ -26,7 +26,7 @@ export class FarosCopilotSeats extends StreamWithOrgSlices {
     protected readonly farosClient?: FarosClient
   ) {
     super(config, logger, farosClient);
-    this.copilotLicensesDatesFix =
+    this.useCopilotTeamAssignmentsFix =
       config.copilot_licenses_dates_fix ?? DEFAULT_COPILOT_LICENSES_DATES_FIX;
   }
 
@@ -53,13 +53,13 @@ export class FarosCopilotSeats extends StreamWithOrgSlices {
     const state = streamState?.[StreamBase.orgKey(org)];
     // for Copilot data, cutoff default is beginning of time
     const cutoffDate =
-      this.copilotLicensesDatesFix && state?.cutoff
+      this.useCopilotTeamAssignmentsFix && state?.cutoff
         ? Utils.toDate(state.cutoff)
         : Utils.toDate(0);
     yield* github.getCopilotSeats(
       org,
       cutoffDate,
-      this.copilotLicensesDatesFix
+      this.useCopilotTeamAssignmentsFix
     );
   }
 
@@ -68,7 +68,7 @@ export class FarosCopilotSeats extends StreamWithOrgSlices {
     latestRecord: CopilotSeatsStreamRecord,
     slice: RepoStreamSlice
   ): StreamState {
-    if (!this.copilotLicensesDatesFix) {
+    if (!this.useCopilotTeamAssignmentsFix) {
       return {};
     }
     if (latestRecord.empty) {


### PR DESCRIPTION
## Description

Ignore state cutoff if copilot licenses fix is disabled. This is to avoid having to run the sync 2 times after disabling the toggle because state is reset after the first sync.
Follow-up PR to https://github.com/faros-ai/airbyte-connectors/pull/1732

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
