### PR TITLE
FAI-13481 Do not throw on stream errors when max_stream_failures configured

### DIFF
--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -271,17 +271,18 @@ export abstract class AirbyteSourceBase<
     }
 
     if (failedStreams.length > 0) {
-      throw new VError(
+      this.logger.error(
         `Encountered an error while reading stream(s): ${JSON.stringify(
           failedStreams
         )}`
       );
+    } else {
+      yield new AirbyteSourceStatusMessage(
+        {data: maybeCompressState(config, state)},
+        {status: 'SUCCESS'}
+      );
     }
 
-    yield new AirbyteSourceStatusMessage(
-      {data: maybeCompressState(config, state)},
-      {status: 'SUCCESS'}
-    );
     this.logger.info(`Finished syncing ${this.name}`);
   }
 


### PR DESCRIPTION
## Description

This [throw](https://github.com/faros-ai/airbyte-connectors/blob/62d9710b8d7a29336dee96b34bd5f1df1ad03b7e/faros-airbyte-cdk/src/sources/source-base.ts#L274) is making the source exit with non-zero and Airbyte kills the whole connection.

Instead we just only log the error. We already emit an [error status](https://github.com/faros-ai/airbyte-connectors/blob/62d9710b8d7a29336dee96b34bd5f1df1ad03b7e/faros-airbyte-cdk/src/sources/source-base.ts#L237) that the destination knows how to handle properly.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
