### PR TITLE
FAI-13399 | GitHub request timeouts reimplemented to work with retries and rate limits

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -111,7 +111,6 @@ export abstract class GitHub {
   protected readonly bucketTotal: number;
   protected readonly pageSize: number;
   protected readonly pullRequestsPageSize: number;
-  protected readonly timeoutMs: number;
   protected readonly backfill: boolean;
 
   constructor(
@@ -128,7 +127,6 @@ export abstract class GitHub {
     this.pageSize = config.page_size ?? DEFAULT_PAGE_SIZE;
     this.pullRequestsPageSize =
       config.pull_requests_page_size ?? DEFAULT_PR_PAGE_SIZE;
-    this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS;
     this.backfill = config.backfill ?? DEFAULT_BACKFILL;
   }
 
@@ -254,10 +252,7 @@ export abstract class GitHub {
         currentCursor,
       });
       try {
-        for await (const res of this.wrapIterable(
-          iter,
-          this.timeout.bind(this)
-        )) {
+        for await (const res of iter) {
           querySuccess = true;
           for (const pr of res.repository.pullRequests.nodes) {
             if (
@@ -329,7 +324,7 @@ export abstract class GitHub {
         page_size: this.pageSize,
       }
     );
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const pr of res.repository.pullRequests.nodes) {
         if (Utils.toDate(pr.updatedAt) < endDate) {
           return res.repository.pullRequests.pageInfo.startCursor;
@@ -406,7 +401,7 @@ export abstract class GitHub {
       }
     );
     const labels: PullRequestLabel[] = [];
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const label of res.data) {
         labels.push(pick(label, ['name']));
       }
@@ -451,7 +446,7 @@ export abstract class GitHub {
       }
     );
     const files: PullRequestFile[] = [];
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const file of res.data) {
         files.push({
           additions: file.additions,
@@ -504,7 +499,7 @@ export abstract class GitHub {
       }
     );
     const reviews: PullRequestReview[] = [];
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const review of res.repository.pullRequest.reviews.nodes) {
         reviews.push(review);
       }
@@ -531,7 +526,7 @@ export abstract class GitHub {
         per_page: this.pageSize,
       }
     );
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const comment of res.data) {
         if (
           this.backfill &&
@@ -570,7 +565,7 @@ export abstract class GitHub {
         page_size: this.pageSize,
       }
     );
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const label of res.repository.labels.nodes) {
         yield {
           org,
@@ -624,7 +619,7 @@ export abstract class GitHub {
       }
     );
     const reviewRequests: PullRequestReviewRequest[] = [];
-    for await (const res of this.wrapIterable(iter, this.timeout.bind(this))) {
+    for await (const res of iter) {
       for (const review of res.repository.pullRequest.reviewRequests.nodes) {
         reviewRequests.push(review);
       }
@@ -717,14 +712,12 @@ export abstract class GitHub {
     queryParameters: any
   ): Promise<boolean> {
     try {
-      await this.timeout<Commit>(
-        this.octokit(queryParameters.owner).graphql(
-          COMMITS_CHANGED_FILES_IF_AVAILABLE_QUERY,
-          {
-            ...queryParameters,
-            page_size: 1,
-          }
-        )
+      await this.octokit(queryParameters.owner).graphql(
+        COMMITS_CHANGED_FILES_IF_AVAILABLE_QUERY,
+        {
+          ...queryParameters,
+          page_size: 1,
+        }
       );
     } catch (err: any) {
       const errorCode = err?.errors?.[0]?.extensions?.code;
@@ -751,7 +744,6 @@ export abstract class GitHub {
     );
     for await (const res of this.wrapIterable(
       iter,
-      this.timeout.bind(this),
       this.acceptPartialResponseWrapper(`org users for ${org}`)
     )) {
       for (const member of res.organization.membersWithRole.nodes) {
@@ -1458,22 +1450,6 @@ export abstract class GitHub {
   ): (promise: Promise<T>) => Promise<T> {
     return (promise: Promise<T>) =>
       this.acceptPartialResponse(dataType, promise);
-  }
-
-  private async timeout<T>(promise: Promise<T>): Promise<T> {
-    let timeoutId: NodeJS.Timeout;
-    const timeout: Promise<T> = new Promise((_, reject) => {
-      timeoutId = setTimeout(
-        () => reject(new Error(`Promise timed out after ${this.timeoutMs} ms`)),
-        this.timeoutMs
-      );
-    });
-
-    try {
-      return await Promise.race([promise, timeout]);
-    } finally {
-      clearTimeout(timeoutId);
-    }
   }
 
   private wrapIterable<T>(


### PR DESCRIPTION
## Description

GitHub request timeouts reimplemented to work with retries and rate limits

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
