### PR TITLE
Fix origin logic in dst for round robin syncs

### DIFF
--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -29,6 +29,7 @@ import traverse from 'traverse';
 import {assert, Dictionary} from 'ts-essentials';
 import {VError} from 'verror';
 
+import {StreamNameSeparator} from '../converters/converter';
 import {OriginProvider} from './graphql-writer';
 import {
   DeletionRecord,
@@ -380,7 +381,7 @@ export class GraphQLClient {
     );
     if (isResetSync) {
       this.logger.info(
-        `Also resetting data for bucketed origins (matching ${origin}__bucket__<number>)`
+        `Also resetting data for bucketed origins (matching ${origin}${StreamNameSeparator}bucket${StreamNameSeparator}<number>)`
       );
     }
 
@@ -388,7 +389,11 @@ export class GraphQLClient {
       ? {
           _or: [
             {origin: {_eq: origin}},
-            {origin: {_like: `${origin}__bucket__%`}},
+            {
+              origin: {
+                _like: `${origin}${StreamNameSeparator}bucket${StreamNameSeparator}%`,
+              },
+            },
           ],
         }
       : {origin: {_eq: origin}};

--- a/destinations/airbyte-faros-destination/src/common/graphql-client.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-client.ts
@@ -375,13 +375,13 @@ export class GraphQLClient {
       ? ` with session id ${deleteSessionId}`
       : '';
     const origin = originProvider.getOrigin();
-
+    const bucketedOriginPattern = `${origin}${StreamNameSeparator}bucket${StreamNameSeparator}`;
     this.logger.info(
       `Resetting data before ${minRefreshedAt} for origin ${origin}${sessionInfo}`
     );
     if (isResetSync) {
       this.logger.info(
-        `Also resetting data for bucketed origins (matching ${origin}${StreamNameSeparator}bucket${StreamNameSeparator}<number>)`
+        `Also resetting data for bucketed origins (matching ${bucketedOriginPattern}<number>)`
       );
     }
 
@@ -391,7 +391,7 @@ export class GraphQLClient {
             {origin: {_eq: origin}},
             {
               origin: {
-                _like: `${origin}${StreamNameSeparator}bucket${StreamNameSeparator}%`,
+                _like: `${bucketedOriginPattern}%`,
               },
             },
           ],

--- a/destinations/airbyte-faros-destination/src/common/graphql-writer.ts
+++ b/destinations/airbyte-faros-destination/src/common/graphql-writer.ts
@@ -14,7 +14,7 @@ export interface RecordProcessorHandler {
 }
 
 export interface OriginProvider {
-  getOrigin: (record: Dictionary<any>) => string;
+  getOrigin: (record?: Dictionary<any>) => string;
 }
 
 export class GraphQLWriter {

--- a/destinations/airbyte-faros-destination/src/converters/converter.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter.ts
@@ -96,7 +96,7 @@ export class StreamContext implements OriginProvider {
     readonly config: DestinationConfig,
     readonly streamsSyncMode: Dictionary<DestinationSyncMode>,
     readonly graph?: string,
-    private readonly _origin?: string,
+    private readonly origin?: string,
     readonly farosClient?: FarosClient
   ) {}
 
@@ -107,13 +107,13 @@ export class StreamContext implements OriginProvider {
       this.sourceConfig?.bucket_id
     ) {
       this.originWithBucketSuffix = [
-        this._origin,
+        this.origin,
         'bucket',
         this.sourceConfig.bucket_id,
       ].join(StreamNameSeparator);
       return this.originWithBucketSuffix;
     }
-    return this._origin;
+    return this.origin;
   }
 
   setSourceConfig(redactedConfig: AirbyteConfig) {

--- a/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
+++ b/destinations/airbyte-faros-destination/src/converters/servicenow/incidents.ts
@@ -174,7 +174,11 @@ export class Incidents extends ServiceNowConverter {
       return [];
     }
 
-    return this.cloudV2DeletionRecords(ctx.farosClient, ctx.graph, ctx.origin);
+    return this.cloudV2DeletionRecords(
+      ctx.farosClient,
+      ctx.graph,
+      ctx.getOrigin()
+    );
   }
 
   private async cloudV2DeletionRecords(

--- a/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/__snapshots__/graphql-client.test.ts.snap
@@ -97,7 +97,7 @@ exports[`graphql-client write batch upsert record with timestamptz primary key f
 exports[`graphql-client write batch upsert resetData 1`] = `
 "query paginatedQuery($id: String, $limit: Int) {
   vcs_Organization(
-    where: {_and: [{_and: {origin: {_eq: \\"foo\\"}, refreshedAt: {_lt: \\"2200-01-01T00:00:00.000Z\\"}}}, {id: {_gt: $id}}]}
+    where: {_and: [{_and: {refreshedAt: {_lt: \\"2200-01-01T00:00:00.000Z\\"}, origin: {_eq: \\"foo\\"}}}, {id: {_gt: $id}}]}
     order_by: {id: asc}
     limit: $limit
   ) {
@@ -130,7 +130,7 @@ exports[`graphql-client write batch upsert resetData 4`] = `undefined`;
 exports[`graphql-client write batch upsert resetData 5`] = `
 "query paginatedQuery($id: String, $limit: Int) {
   vcs_Organization(
-    where: {_and: [{_and: {origin: {_eq: \\"foo\\"}, refreshedAt: {_lt: \\"2200-01-01T00:00:00.000Z\\"}}}, {id: {_gt: $id}}]}
+    where: {_and: [{_and: {refreshedAt: {_lt: \\"2200-01-01T00:00:00.000Z\\"}, origin: {_eq: \\"foo\\"}}}, {id: {_gt: $id}}]}
     order_by: {id: asc}
     limit: $limit
   ) {

--- a/destinations/airbyte-faros-destination/test/graphql-client.test.ts
+++ b/destinations/airbyte-faros-destination/test/graphql-client.test.ts
@@ -981,7 +981,12 @@ describe('graphql-client write batch upsert', () => {
       3
     );
     await client.loadSchema();
-    await client.resetData('foo', ['vcs_Organization'], false);
+    await client.resetData(
+      {getOrigin: () => 'foo'},
+      ['vcs_Organization'],
+      false,
+      false
+    );
     expect(queries).toEqual(responses.length);
   });
 });

--- a/faros-airbyte-cdk/src/sources/source-runner.ts
+++ b/faros-airbyte-cdk/src/sources/source-runner.ts
@@ -120,7 +120,7 @@ export class AirbyteSourceRunner<Config extends AirbyteConfig> extends Runner {
               maybeCompressState(config, clonedState);
             const iter = this.source.read(
               res.config,
-              redactedConfig,
+              redactConfig(res.config, spec),
               res.catalog,
               clonedState
             );


### PR DESCRIPTION
When using `round_robin_bucket_execution`, we must suffix the `origin` with the bucket id so that resets only operate on records written by the corresponding sync (otherwise, e.g., the sync for bucket 2 would delete the records written by the sync for bucket 1 for full refresh streams)

In addition, when running a reset sync, we need to make sure we're deleting data for the origin AND for the origins with bucket suffix (which may or may not exist)

### First sync
<img width="1566" alt="Screenshot 2024-10-18 at 9 03 41 AM" src="https://github.com/user-attachments/assets/160a0e24-9b81-4cb0-a964-c3bfea0f491a">
<img width="1690" alt="Screenshot 2024-10-18 at 9 02 57 AM" src="https://github.com/user-attachments/assets/40e1f1e5-8b07-46d4-bc3d-c994bd041ede">
<img width="1067" alt="Screenshot 2024-10-18 at 9 02 28 AM" src="https://github.com/user-attachments/assets/f7543eb2-0ccf-4126-813f-09d34c8f47a1">
### Second sync
<img width="1574" alt="Screenshot 2024-10-18 at 9 08 53 AM" src="https://github.com/user-attachments/assets/7b7c0ed3-f02a-4aec-8383-3afaa5a62f55">
<img width="1563" alt="Screenshot 2024-10-18 at 9 08 23 AM" src="https://github.com/user-attachments/assets/b67a2f97-77e7-4be3-b9ca-6ea31e9a493f">
<img width="1074" alt="Screenshot 2024-10-18 at 9 07 57 AM" src="https://github.com/user-attachments/assets/a277ccd0-f477-4723-a1c0-ed7632f7ce4b">
### Reset sync
<img width="1559" alt="Screenshot 2024-10-18 at 11 11 51 AM" src="https://github.com/user-attachments/assets/7d9990d2-101e-4b14-aab0-74c116094526">
<img width="1054" alt="Screenshot 2024-10-18 at 11 39 16 AM" src="https://github.com/user-attachments/assets/11cdbc22-803b-4108-bcc4-030003b53e00">

