### PR TITLE
FAI-13247 | Fixed GitHub actions API response iterator

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -1455,7 +1455,7 @@ export abstract class GitHub {
       }
     );
     for await (const res of iter) {
-      for (const workflow of res.data.workflows) {
+      for (const workflow of res.data) {
         yield {
           org,
           repo,
@@ -1487,7 +1487,7 @@ export abstract class GitHub {
       }
     );
     for await (const res of iter) {
-      for (const workflowRun of res.data.workflow_runs) {
+      for (const workflowRun of res.data) {
         // skip runs that were updated before the start date / updated_at cutoff
         if (Utils.toDate(workflowRun.updated_at) < startDate) {
           continue;
@@ -1535,7 +1535,7 @@ export abstract class GitHub {
       }
     );
     for await (const res of iter) {
-      for (const job of res.data.jobs) {
+      for (const job of res.data) {
         yield {
           org,
           repo,
@@ -1577,7 +1577,7 @@ export abstract class GitHub {
       }
     );
     for await (const res of iter) {
-      for (const artifact of res.data.artifacts) {
+      for (const artifact of res.data) {
         yield {
           org,
           repo,

--- a/sources/github-source/test/index.test.ts
+++ b/sources/github-source/test/index.test.ts
@@ -1046,24 +1046,24 @@ const getSecretScanningAlertsMockedImplementation = (res: any) => ({
 
 const getWorkflowsMockedImplementation = (res: any) => ({
   actions: {
-    listRepoWorkflows: jest.fn().mockReturnValue(res),
+    listRepoWorkflows: jest.fn().mockReturnValue(res.workflows),
   },
 });
 
 const getWorkflowRunsMockedImplementation = (res: any) => ({
   actions: {
-    listWorkflowRunsForRepo: jest.fn().mockReturnValue(res),
+    listWorkflowRunsForRepo: jest.fn().mockReturnValue(res.workflow_runs),
   },
 });
 
 const getWorkflowJobsMockedImplementation = (res: any) => ({
   actions: {
-    listJobsForWorkflowRun: jest.fn().mockReturnValue(res),
+    listJobsForWorkflowRun: jest.fn().mockReturnValue(res.jobs),
   },
 });
 
 const getArtifactsMockedImplementation = (res: any) => ({
   actions: {
-    listWorkflowRunArtifacts: jest.fn().mockReturnValue(res),
+    listWorkflowRunArtifacts: jest.fn().mockReturnValue(res.artifacts),
   },
 });


### PR DESCRIPTION
## Description

Fixed GitHub actions API response iterator
Octokit is already extracting from the API response the field that's being iterated, but the inferred type from the library wasn't taking that into account

API Response example:
```
{
    "total_count": 0,
    "workflows": []
}
```

![image](https://github.com/user-attachments/assets/d8ed195f-8389-461a-89e8-711cf819d60f)
![image](https://github.com/user-attachments/assets/857f747c-7346-42fd-bb45-8e2751648f57)


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
