### PR TITLE
FAI-13600 | Add retries for 422 error on PR files API (GitHub)

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -1,3 +1,4 @@
+import {RequestError} from '@octokit/types';
 import {AirbyteLogger} from 'faros-airbyte-cdk';
 import {bucket, validateBucketingConfig} from 'faros-airbyte-common/common';
 import {
@@ -448,6 +449,9 @@ export abstract class GitHub {
         pull_number: number,
         per_page: this.pageSize,
         page: startingPage,
+        request: {
+          retryAdditionalError: (err: RequestError) => err.status === 422,
+        },
       }
     );
     const files: PullRequestFile[] = [];

--- a/sources/github-source/src/octokit.ts
+++ b/sources/github-source/src/octokit.ts
@@ -186,6 +186,9 @@ function beforeRequestHook(
   }
 }
 
+// Fake HTTP status code used by manually thrown errors to trigger retries by the retry-plugin
+const RETRYABLE_STATUS_CODE = 1000;
+
 function timeout(octokit: OctokitCore, octokitOptions: any) {
   const timeoutMs = octokitOptions.timeout?.ms;
   if (timeoutMs > 0) {
@@ -208,7 +211,7 @@ function timeout(octokit: OctokitCore, octokitOptions: any) {
           // simulate request error so that retry plugin retries the request
           throw new RequestError(
             `GitHub request timed-out after ${timeoutMs} ms`,
-            1000,
+            RETRYABLE_STATUS_CODE,
             {
               request: options,
             }
@@ -231,7 +234,7 @@ function retryAdditionalConditions(octokit: OctokitCore) {
     }
 
     // simulate request error so that retry plugin retries the request
-    throw new RequestError(error.message, 1000, {
+    throw new RequestError(error.message, RETRYABLE_STATUS_CODE, {
       request: options,
     });
   });

--- a/sources/github-source/src/octokit.ts
+++ b/sources/github-source/src/octokit.ts
@@ -229,7 +229,7 @@ function timeout(octokit: OctokitCore, octokitOptions: any) {
 function retryAdditionalConditions(octokit: OctokitCore) {
   octokit.hook.error('request', async (error, options) => {
     const retryAdditionalError = options.request.retryAdditionalError;
-    if (!retryAdditionalError || !retryAdditionalError(error)) {
+    if (!retryAdditionalError?.(error)) {
       throw error;
     }
 


### PR DESCRIPTION
## Description

Add retries for 422 error on PR files API (GitHub)
- Added custom plugin / hook because retries plugin doNotRetry parameter is fixed after initializing Octokit instance ([#1](https://github.com/octokit/plugin-retry.js/blob/e3f082e7b6dc996ca1d157b1a5c322ab708f1c84/src/error-request.ts#L10)  [#2](https://github.com/octokit/plugin-retry.js/blob/main/src/index.ts#L14))  and to avoid having to do retry logic manually.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
