### PR TITLE
FAI-13927: Fix assignees to prefer user keys

### DIFF
--- a/sources/jira-source/src/issue_transformer.ts
+++ b/sources/jira-source/src/issue_transformer.ts
@@ -403,7 +403,9 @@ export class IssueTransformer {
 
     const created = Utils.toDate(item.fields.created);
     const assignee =
-      item.fields.assignee?.accountId || item.fields.assignee?.name;
+      item.fields.assignee?.accountId ||
+      item.fields.assignee?.key ||
+      item.fields.assignee?.name;
 
     const changelog: any[] = item.changelog?.histories || [];
     changelog.sort((e1, e2) => {
@@ -444,6 +446,11 @@ export class IssueTransformer {
       item.fields.issuetype?.name
     );
 
+    const creator =
+      item.fields.creator?.accountId ||
+      item.fields.creator?.key ||
+      item.fields.creator?.name;
+
     return {
       id: item.id,
       key: item.key,
@@ -455,7 +462,7 @@ export class IssueTransformer {
       priority: item.fields.priority?.name,
       project: item.fields.project?.key,
       labels: item.fields.labels ?? [],
-      creator: item.fields.creator?.accountId || item.fields.creator?.name,
+      creator,
       created,
       updated: Utils.toDate(item.fields.updated),
       statusChanged,

--- a/sources/jira-source/test/resources/issues/issues.json
+++ b/sources/jira-source/test/resources/issues/issues.json
@@ -293,7 +293,7 @@
         "hierarchyLevel": 0
       },
       "creator": {
-        "accountId": "88a7f7f45b7d3b111232",
+        "key": "88a7f7f45b7d3b111232",
         "emailAddress": "user@mail.com",
         "displayName": "John Doe",
         "active": true,


### PR DESCRIPTION
## Description

- We use the user [key for uid ](https://github.com/faros-ai/airbyte-connectors/blob/main/sources/jira-source/src/streams/faros_users.ts#L22)

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
