### PR TITLE
FAI-14167 | Save Copilot usage state to sync records only if new date added

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -1051,7 +1051,10 @@ export abstract class GitHub {
     );
   }
 
-  async *getCopilotUsage(org: string): AsyncGenerator<CopilotUsageSummary> {
+  async *getCopilotUsage(
+    org: string,
+    cutoffDate: number
+  ): AsyncGenerator<CopilotUsageSummary> {
     let data: CopilotUsageResponse;
     let useBetaAPI = false;
     try {
@@ -1082,6 +1085,16 @@ export abstract class GitHub {
       }
       if (isNil(data) || isEmpty(data)) {
         this.logger.warn(`No GitHub Copilot usage found for org ${org}.`);
+        return;
+      }
+      const latestDay = Math.max(
+        0,
+        ...data.map((usage) => Utils.toDate(usage.day).getTime())
+      );
+      if (latestDay <= cutoffDate) {
+        this.logger.info(
+          `GitHub Copilot usage data for org ${org} is already up-to-date: ${new Date(cutoffDate).toISOString()}`
+        );
         return;
       }
       for (const usage of data) {

--- a/sources/github-source/src/streams/faros_copilot_seats.ts
+++ b/sources/github-source/src/streams/faros_copilot_seats.ts
@@ -11,7 +11,6 @@ import {DEFAULT_COPILOT_LICENSES_DATES_FIX, GitHub} from '../github';
 import {GitHubConfig} from '../types';
 import {
   OrgStreamSlice,
-  RepoStreamSlice,
   StreamBase,
   StreamState,
   StreamWithOrgSlices,
@@ -66,7 +65,7 @@ export class FarosCopilotSeats extends StreamWithOrgSlices {
   getUpdatedState(
     currentStreamState: StreamState,
     latestRecord: CopilotSeatsStreamRecord,
-    slice: RepoStreamSlice
+    slice: OrgStreamSlice
   ): StreamState {
     if (!this.useCopilotTeamAssignmentsFix) {
       return {};

--- a/sources/github-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/github-source/test/__snapshots__/index.test.ts.snap
@@ -687,6 +687,16 @@ exports[`index streams - copilot usage with teams 1`] = `
 ]
 `;
 
+exports[`index streams - copilot usage with teams 2`] = `
+{
+  "faros_copilot_usage": {
+    "github": {
+      "cutoff": 1697414400000,
+    },
+  },
+}
+`;
+
 exports[`index streams - copilot usage without teams (GA API) 1`] = `
 [
   {
@@ -831,6 +841,16 @@ exports[`index streams - copilot usage without teams 1`] = `
     "total_suggestions_count": 800,
   },
 ]
+`;
+
+exports[`index streams - copilot usage without teams 2`] = `
+{
+  "faros_copilot_usage": {
+    "github": {
+      "cutoff": 1697414400000,
+    },
+  },
+}
 `;
 
 exports[`index streams - dependabot alerts 1`] = `

--- a/sources/github-source/test/index.test.ts
+++ b/sources/github-source/test/index.test.ts
@@ -232,6 +232,9 @@ describe('index', () => {
       checkRecordsData: (records) => {
         expect(records).toMatchSnapshot();
       },
+      checkFinalState: (state) => {
+        expect(state).toMatchSnapshot();
+      },
     });
   });
 
@@ -240,6 +243,11 @@ describe('index', () => {
       source,
       configOrPath: 'config.json',
       catalogOrPath: 'copilot_usage/catalog.json',
+      stateOrPath: {
+        faros_copilot_usage: {
+          github: {cutoff: new Date('2023-10-15').getTime()},
+        },
+      },
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
           merge(
@@ -258,6 +266,9 @@ describe('index', () => {
       },
       checkRecordsData: (records) => {
         expect(records).toMatchSnapshot();
+      },
+      checkFinalState: (state) => {
+        expect(state).toMatchSnapshot();
       },
     });
   });
@@ -319,6 +330,38 @@ describe('index', () => {
       },
       checkRecordsData: (records) => {
         expect(records).toMatchSnapshot();
+      },
+    });
+  });
+
+  test('streams - copilot usage with teams already up-to-date', async () => {
+    await sourceReadTest({
+      source,
+      configOrPath: 'config.json',
+      catalogOrPath: 'copilot_usage/catalog.json',
+      stateOrPath: {
+        faros_copilot_usage: {
+          github: {cutoff: new Date('2023-10-16').getTime()},
+        },
+      },
+      onBeforeReadResultConsumer: (res) => {
+        setupGitHubInstance(
+          merge(
+            getCopilotUsageForOrgMockedImplementation(
+              readTestResourceAsJSON('copilot_usage/copilot_usage.json')
+            ),
+            getTeamsMockedImplementation(
+              readTestResourceAsJSON('teams/teams.json')
+            ),
+            getCopilotUsageForTeamMockedImplementation(
+              readTestResourceAsJSON('copilot_usage/copilot_usage.json')
+            )
+          ),
+          logger
+        );
+      },
+      checkRecordsData: (records) => {
+        expect(records).toHaveLength(0);
       },
     });
   });


### PR DESCRIPTION
## Description

Save Copilot usage state with latest date to sync records only if newer date received on the org usage response

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
