### PR TITLE
Include resources in faros-airbyte-common package

### DIFF
--- a/faros-airbyte-common/package.json
+++ b/faros-airbyte-common/package.json
@@ -18,7 +18,8 @@
     "test": "test"
   },
   "files": [
-    "lib/"
+    "lib/",
+    "resources/"
   ],
   "main": "./lib",
   "engines": {


### PR DESCRIPTION
## Description

This is not a problem in this repo because the package is symlinked but it fails in other repos:
![Screenshot 2024-11-25 at 5 47 05 PM](https://github.com/user-attachments/assets/847fbecf-462e-4b6a-b5ca-7d620e4a3e5f)


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
