### PR TITLE
FAI-14237 - Add placeholder cursor fields to pseudo-incremental streams

### DIFF
--- a/sources/azure-repos-source/src/streams/users.ts
+++ b/sources/azure-repos-source/src/streams/users.ts
@@ -20,8 +20,16 @@ export class Users extends AirbyteStreamBase {
     return 'principalName';
   }
 
+  // Although not actually an incremental stream, we run it in incremental mode
+  // to avoid deleting the users that are written by the incremental
+  // pull_requests stream.
   get supportsIncremental(): boolean {
     return true;
+  }
+
+  // Not used, but necessary to pass Airbyte UI validation check
+  get cursorField(): string | string[] {
+    return 'url';
   }
 
   async *readRecords(): AsyncGenerator<User> {

--- a/sources/github-source/src/streams/faros_users.ts
+++ b/sources/github-source/src/streams/faros_users.ts
@@ -14,8 +14,15 @@ export class FarosUsers extends StreamWithOrgSlices {
     return ['org', 'login'];
   }
 
+  // Although not actually an incremental stream, we run it in incremental mode
+  // to avoid deleting the users that are written by other incremental streams.
   get supportsIncremental(): boolean {
     return true;
+  }
+
+  // Not used, but necessary to pass Airbyte UI validation check
+  get cursorField(): string | string[] {
+    return 'html_url';
   }
 
   async *readRecords(


### PR DESCRIPTION
## Description

If a stream is incremental but doesn't specify a cursor field, the Airbyte UI does not let you update the connection catalog.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
