### PR TITLE
Better type for param and ret type of calculateUpdatedStreamState

### DIFF
--- a/faros-airbyte-cdk/src/sources/streams/stream-base.ts
+++ b/faros-airbyte-cdk/src/sources/streams/stream-base.ts
@@ -224,12 +224,18 @@ export abstract class AirbyteStreamBase {
   }
 }
 
+export interface StreamState {
+  [key: string]: {
+    cutoff: number;
+  };
+}
+
 export function calculateUpdatedStreamState(
   latestRecordCutoff: Date,
-  currentStreamState: Dictionary<any>,
+  currentStreamState: StreamState,
   key: string,
   cutoffLagDays: number = 0
-): Dictionary<any> {
+): StreamState {
   if (isNil(latestRecordCutoff)) {
     return currentStreamState;
   }


### PR DESCRIPTION
## Description

So that users of the utility function are alerted at compile time when they're using e.g., an unsupported type for cutoff.

Exporting `StreamState` since the majority of our streams use this simple shape for state.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
