### PR TITLE
Azure Repos: mergedAt, updatedAt, and diffStats logic

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/azure-repos/models.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-repos/models.ts
@@ -88,6 +88,8 @@ export interface PullRequestThread {
 interface MergeSourceCommit {
   commitId: string;
   url: string;
+  author?: CommitAuthor;
+  committer?: CommitAuthor;
 }
 
 export interface PullRequestRepository {

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/azure-repos.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/azure-repos.test.ts.snap
@@ -543,7 +543,7 @@ Array [
       },
       "title": "Updated AnotherFile.md",
       "uid": "2",
-      "updatedAt": "2023-01-07T01:20:10.168Z",
+      "updatedAt": "2023-01-07T01:20:34.537Z",
     },
   },
   Object {
@@ -696,7 +696,7 @@ Array [
       },
       "title": "Test PR 1",
       "uid": "1",
-      "updatedAt": "2023-01-05T18:04:45.699Z",
+      "updatedAt": "2023-01-05T18:05:32.003Z",
     },
   },
   Object {


### PR DESCRIPTION
## Description

mergedAt: use mergeCommit timestamps if available and only set if a mergeCommit exists
updatedAt: use max of thread lastUpdated timestamps
diffStats: only set in record if exists

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
