### PR TITLE
Fix GitHub PR review request query params

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -758,7 +758,7 @@ export abstract class GitHub {
       {
         owner: org,
         repo,
-        pull_number: number,
+        number,
         nested_page_size: this.pageSize,
         cursor: startCursor,
       }


### PR DESCRIPTION
## Description

[Query](https://github.com/faros-ai/airbyte-connectors/blob/ccc993d874b0fc37debd00b119ba1cce8bcc7020/faros-airbyte-common/resources/github/queries/pull-request-review-requests-query.gql#L1) expects var called number instead of pull_number

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
