### PR TITLE
Fix code scanning alert no. 34: Incomplete regular expression for hostnames

### DIFF
--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -114,7 +114,7 @@ const prRegex = new RegExp(
     'stateCount=(?<count>[0-9]+)})'
 );
 
-const jiraCloudRegex = /^https:\/\/(.*).atlassian.net/g;
+const jiraCloudRegex = /^https:\/\/(.*)\.atlassian\.net/g;
 const PREFIX_CHARS = [...'abcdefghijklmnopqrstuvwxyz', ...'0123456789'];
 
 const MAX_SPRINT_HISTORY_FETCH_FAILURES = 5;


### PR DESCRIPTION
Fixes [https://github.com/faros-ai/airbyte-connectors/security/code-scanning/34](https://github.com/faros-ai/airbyte-connectors/security/code-scanning/34)

To fix the problem, we need to escape the `.` meta-character in the regular expression to ensure it matches a literal dot. This will make the regular expression more precise and prevent it from matching unintended hostnames. Specifically, we should replace `(.*).atlassian.net` with `(.*)\.atlassian\.net`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Note from @ypc-faros 
Previous regex would match incorrect URLs e.g., `https://x.yatlassian.net`