### PR TITLE
Always persist state (even in backfill syncs)

### DIFF
--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -885,7 +885,7 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
           }
         });
 
-        if (stateMessage && !isBackfillSync) {
+        if (stateMessage) {
           yield stateMessage;
         }
       }
@@ -1178,8 +1178,8 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
       onLoadError
     );
     return this.jsonataMode === JSONataApplyMode.OVERRIDE
-      ? this.jsonataConverter ?? converter
-      : converter ?? this.jsonataConverter;
+      ? (this.jsonataConverter ?? converter)
+      : (converter ?? this.jsonataConverter);
   }
 
   private async writeRecord(

--- a/sources/github-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/github-source/test/__snapshots__/index.test.ts.snap
@@ -1855,10 +1855,15 @@ exports[`index streams - pull requests 2`] = `
 }
 `;
 
-exports[`index streams - pull requests backfill with bucketing 1`] = `
+exports[`index streams - pull requests backfill with bucketing and round robin execution only affects bucketing state 1`] = `
 {
   "__bucket_execution_state": {
     "last_executed_bucket_id": 1,
+  },
+  "faros_pull_requests": {
+    "github/hello-world": {
+      "cutoff": 123,
+    },
   },
 }
 `;

--- a/sources/github-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/github-source/test/__snapshots__/index.test.ts.snap
@@ -1845,6 +1845,24 @@ N/A
 ]
 `;
 
+exports[`index streams - pull requests 2`] = `
+{
+  "faros_pull_requests": {
+    "github/hello-world": {
+      "cutoff": 1613495729000,
+    },
+  },
+}
+`;
+
+exports[`index streams - pull requests backfill with bucketing 1`] = `
+{
+  "__bucket_execution_state": {
+    "last_executed_bucket_id": 1,
+  },
+}
+`;
+
 exports[`index streams - pull requests diff coverage 1`] = `
 [
   {

--- a/sources/github-source/test/index.test.ts
+++ b/sources/github-source/test/index.test.ts
@@ -440,6 +440,13 @@ describe('index', () => {
       source,
       configOrPath: 'config.json',
       catalogOrPath: 'pull_requests/catalog.json',
+      stateOrPath: {
+        faros_pull_requests: {
+          'github/hello-world': {
+            cutoff: 123,
+          },
+        },
+      },
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
           merge(
@@ -474,6 +481,13 @@ describe('index', () => {
         round_robin_bucket_execution: true,
       },
       catalogOrPath: 'pull_requests/catalog.json',
+      stateOrPath: {
+        faros_pull_requests: {
+          'github/hello-world': {
+            cutoff: 123,
+          },
+        },
+      },
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
           merge(

--- a/sources/github-source/test/index.test.ts
+++ b/sources/github-source/test/index.test.ts
@@ -456,6 +456,40 @@ describe('index', () => {
       checkRecordsData: (records) => {
         expect(records).toMatchSnapshot();
       },
+      checkFinalState: (state) => {
+        expect(state).toMatchSnapshot();
+      },
+    });
+  });
+
+  test('streams - pull requests backfill with bucketing and round robin execution only affects bucketing state', async () => {
+    const config = readTestResourceAsJSON('config.json');
+    await sourceReadTest({
+      source,
+      configOrPath: {
+        ...config,
+        bucket_id: 1,
+        bucket_total: 3,
+        backfill: true,
+        round_robin_bucket_execution: true,
+      },
+      catalogOrPath: 'pull_requests/catalog.json',
+      onBeforeReadResultConsumer: (res) => {
+        setupGitHubInstance(
+          merge(
+            getRepositoriesMockedImplementation(
+              readTestResourceAsJSON('repositories/repositories.json')
+            ),
+            getPullRequestsMockedImplementation(
+              readTestResourceAsJSON('pull_requests/pull_requests.json')
+            )
+          ),
+          logger
+        );
+      },
+      checkFinalState: (state) => {
+        expect(state).toMatchSnapshot();
+      },
     });
   });
 


### PR DESCRIPTION
It's safe to persist the state even when running in backfill because we don't modify the streams' state. But we want to persist the state anyway so that we advance the bucket id when using round robin bucketing in a backfill