### PR TITLE
FAI-13912 | GitHub - Change faros graph inclusion behavior when org has no filters

### DIFF
--- a/sources/github-source/src/github.ts
+++ b/sources/github-source/src/github.ts
@@ -17,6 +17,7 @@ import {
   EnterpriseCopilotSeat,
   EnterpriseCopilotSeatsEmpty,
   EnterpriseCopilotSeatsResponse,
+  EnterpriseCopilotSeatsStreamRecord,
   EnterpriseCopilotUsageSummary,
   EnterpriseTeam,
   EnterpriseTeamMembership,
@@ -80,7 +81,6 @@ import {
   REVIEW_REQUESTS_FRAGMENT,
   REVIEWS_FRAGMENT,
 } from 'faros-airbyte-common/github/queries';
-import {EnterpriseCopilotSeatsStreamRecord} from 'faros-airbyte-common/lib/github';
 import {Utils} from 'faros-js-client';
 import {isEmpty, isNil, pick, toLower, toString} from 'lodash';
 import {Memoize} from 'typescript-memoize';

--- a/sources/github-source/src/org-repo-filter.ts
+++ b/sources/github-source/src/org-repo-filter.ts
@@ -169,11 +169,15 @@ export class OrgRepoFilter {
     const excludedRepos = excludedReposByOrg.get(org);
 
     if (this.useFarosGraphReposSelection) {
-      const included = true;
-
+      // if no inclusions / exclusions found (for all organizations) sync all repos
+      const noFiltersForAll = !reposByOrg.size && !excludedReposByOrg.size;
+      const noFilters = !repos?.size && !excludedRepos?.size;
       const syncRepoData =
-        (!repos?.size || repos.has(repo)) && !excludedRepos?.has(repo);
-      return {included, syncRepoData};
+        noFiltersForAll ||
+        (!noFilters &&
+          (!repos?.size || repos.has(repo)) &&
+          !excludedRepos?.has(repo));
+      return {included: true, syncRepoData};
     }
 
     if (repos?.size) {

--- a/sources/github-source/test/__snapshots__/org-repo-filter.test.ts.snap
+++ b/sources/github-source/test/__snapshots__/org-repo-filter.test.ts.snap
@@ -146,21 +146,21 @@ exports[`OrgRepoFilter getRepositories (FarosGraph) - nothing included - some ex
       "name": "repo-1",
       "org": "org-3",
     },
-    "syncRepoData": true,
+    "syncRepoData": false,
   },
   {
     "repo": {
       "name": "repo-2",
       "org": "org-3",
     },
-    "syncRepoData": true,
+    "syncRepoData": false,
   },
   {
     "repo": {
       "name": "repo-3",
       "org": "org-3",
     },
-    "syncRepoData": true,
+    "syncRepoData": false,
   },
 ]
 `;
@@ -214,21 +214,21 @@ exports[`OrgRepoFilter getRepositories (FarosGraph) - some included - nothing ex
       "name": "repo-1",
       "org": "org-3",
     },
-    "syncRepoData": true,
+    "syncRepoData": false,
   },
   {
     "repo": {
       "name": "repo-2",
       "org": "org-3",
     },
-    "syncRepoData": true,
+    "syncRepoData": false,
   },
   {
     "repo": {
       "name": "repo-3",
       "org": "org-3",
     },
-    "syncRepoData": true,
+    "syncRepoData": false,
   },
 ]
 `;


### PR DESCRIPTION
## Description

Before this change when an organization had no inclusions / exclusions (faros graph options), all repositories for that organization would be synced and included. We only want this behavior if ALL the organizations have no inclusions / exclusions (e.g. only during first sync).

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
