### PR TITLE
FAI-14536 Fix bucketing for circleci tests stream

### DIFF
--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -19,12 +19,6 @@ export class Tests extends StreamWithProjectSlices {
     return ['job_stopped_at'];
   }
 
-  async *streamSlices(): AsyncGenerator<StreamSlice> {
-    for (const projectSlug of this.cfg.project_slugs) {
-      yield {projectSlug};
-    }
-  }
-
   async *readRecords(
     syncMode: SyncMode,
     cursorField?: string[],


### PR DESCRIPTION
## Description

Didn't remove the `streamSlices` impl from the tests stream in https://github.com/faros-ai/airbyte-connectors/pull/1836

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
