### PR TITLE
FAI-14659 | GitHub - use copilot metrics GA API by default

### DIFF
--- a/sources/github-source/resources/spec.json
+++ b/sources/github-source/resources/spec.json
@@ -210,11 +210,11 @@
         "description": "Fix the licenses dates for Copilot seats when using team assignments (requires Audit Log API)",
         "default": true
       },
-      "copilot_metrics_ga": {
+      "copilot_metrics_preview_api": {
         "order": 15,
         "type": "boolean",
-        "title": "Copilot Metrics GA",
-        "description": "Use Copilot Metrics GA API instead of Copilot Usage Beta API",
+        "title": "Copilot Metrics Preview API",
+        "description": "Use Copilot Metrics Preview API (/usage) instead of Copilot Metrics GA API (/metrics)",
         "default": false
       },
       "cutoff_days": {

--- a/sources/github-source/src/types.ts
+++ b/sources/github-source/src/types.ts
@@ -21,7 +21,7 @@ export interface GitHubConfig extends AirbyteConfig, RoundRobinConfig {
   readonly fetch_pull_request_files?: boolean;
   readonly fetch_pull_request_reviews?: boolean;
   readonly copilot_licenses_dates_fix?: boolean;
-  readonly copilot_metrics_ga?: boolean;
+  readonly copilot_metrics_preview_api?: boolean;
   readonly cutoff_days?: number;
   readonly api_url?: string;
   readonly api_key?: string;

--- a/sources/github-source/test/index.test.ts
+++ b/sources/github-source/test/index.test.ts
@@ -241,9 +241,13 @@ describe('index', () => {
   });
 
   test('streams - copilot usage without teams', async () => {
+    const config = {
+      ...readTestResourceAsJSON('config.json'),
+      copilot_metrics_preview_api: true,
+    };
     await sourceReadTest({
       source,
-      configOrPath: 'config.json',
+      configOrPath: config,
       catalogOrPath: 'copilot_usage/catalog.json',
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
@@ -255,7 +259,8 @@ describe('index', () => {
               new ErrorWithStatus(400, 'API not available')
             )
           ),
-          logger
+          logger,
+          config
         );
       },
       checkRecordsData: (records) => {
@@ -268,9 +273,13 @@ describe('index', () => {
   });
 
   test('streams - copilot usage with teams', async () => {
+    const config = {
+      ...readTestResourceAsJSON('config.json'),
+      copilot_metrics_preview_api: true,
+    };
     await sourceReadTest({
       source,
-      configOrPath: 'config.json',
+      configOrPath: config,
       catalogOrPath: 'copilot_usage/catalog.json',
       stateOrPath: {
         faros_copilot_usage: {
@@ -290,7 +299,8 @@ describe('index', () => {
               readTestResourceAsJSON('copilot_usage/copilot_usage.json')
             )
           ),
-          logger
+          logger,
+          config
         );
       },
       checkRecordsData: (records) => {
@@ -303,13 +313,9 @@ describe('index', () => {
   });
 
   test('streams - copilot usage without teams (GA API)', async () => {
-    const config = {
-      ...readTestResourceAsJSON('config.json'),
-      copilot_metrics_ga: true,
-    };
     await sourceReadTest({
       source,
-      configOrPath: config,
+      configOrPath: 'config.json',
       catalogOrPath: 'copilot_usage/catalog.json',
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
@@ -321,8 +327,7 @@ describe('index', () => {
               new ErrorWithStatus(400, 'API not available')
             )
           ),
-          logger,
-          config
+          logger
         );
       },
       checkRecordsData: (records) => {
@@ -332,13 +337,9 @@ describe('index', () => {
   });
 
   test('streams - copilot usage with teams (GA API)', async () => {
-    const config = {
-      ...readTestResourceAsJSON('config.json'),
-      copilot_metrics_ga: true,
-    };
     await sourceReadTest({
       source,
-      configOrPath: config,
+      configOrPath: 'config.json',
       catalogOrPath: 'copilot_usage/catalog.json',
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
@@ -353,8 +354,7 @@ describe('index', () => {
               readTestResourceAsJSON('copilot_usage/copilot_usage_ga.json')
             )
           ),
-          logger,
-          config
+          logger
         );
       },
       checkRecordsData: (records) => {
@@ -370,20 +370,20 @@ describe('index', () => {
       catalogOrPath: 'copilot_usage/catalog.json',
       stateOrPath: {
         faros_copilot_usage: {
-          github: {cutoff: new Date('2023-10-16').getTime()},
+          github: {cutoff: new Date('2024-06-24').getTime()},
         },
       },
       onBeforeReadResultConsumer: (res) => {
         setupGitHubInstance(
           merge(
-            getCopilotUsageForOrgMockedImplementation(
-              readTestResourceAsJSON('copilot_usage/copilot_usage.json')
+            getCopilotUsageForOrgGAMockedImplementation(
+              readTestResourceAsJSON('copilot_usage/copilot_usage_ga.json')
             ),
             getTeamsMockedImplementation(
               readTestResourceAsJSON('teams/teams.json')
             ),
-            getCopilotUsageForTeamMockedImplementation(
-              readTestResourceAsJSON('copilot_usage/copilot_usage.json')
+            getCopilotUsageForTeamGAMockedImplementation(
+              readTestResourceAsJSON('copilot_usage/copilot_usage_ga.json')
             )
           ),
           logger


### PR DESCRIPTION
Use copilot metrics GA API by default instead of the preview API (announced to be shutdown by end of January)