### PR TITLE
FAI-14934: Fix regression in graph source

### DIFF
--- a/sources/faros-graphql-source/src/streams/faros-graph.ts
+++ b/sources/faros-graphql-source/src/streams/faros-graph.ts
@@ -112,7 +112,7 @@ export class FarosGraph extends AirbyteStreamBase {
           graphSchema: schema,
           primaryKeys: gqlSchemaV2.primaryKeys,
           references: gqlSchemaV2.references,
-          scalarsOnly: false,
+          avoidCollisions: false,
         })
       );
       this.logger.debug(


### PR DESCRIPTION
## Description

Refactor introduced a bug.  The first boolean used to be `avoidCollisions` not `scalarsOnly`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

