### PR TITLE
Make it possible to store compact representation of input record in ctx for dependent streams

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/converter.ts
+++ b/destinations/airbyte-faros-destination/src/converters/converter.ts
@@ -42,6 +42,13 @@ export abstract class ConverterTyped<R> {
   /** Function to extract record id */
   abstract id(record: AirbyteRecord): any;
 
+  /** Returns a minimal version of the record suitable for context storage
+   * Override this to provide a reduced representation when this stream is a dependency
+   * By default returns the full record */
+  toContextStorageRecord(record: AirbyteRecord, ctx: StreamContext): AirbyteRecord {
+    return record;
+  }
+
   /** All the record models produced by converter */
   abstract get destinationModels(): ReadonlyArray<DestinationModel>;
 

--- a/destinations/airbyte-faros-destination/src/converters/wolken/configuration_items.ts
+++ b/destinations/airbyte-faros-destination/src/converters/wolken/configuration_items.ts
@@ -9,6 +9,17 @@ export class ConfigurationItems extends WolkenConverter {
     return record?.record?.data?.ciId;
   }
 
+  toContextStorageRecord(record: AirbyteRecord, ctx: StreamContext) {
+    const configurationItem = record.record.data as ConfigurationItem;
+    const serviceIdFlexId = this.config(ctx).service_id_flex_id;
+    const serviceIdFlexField = WolkenConverter.getFlexField(
+      configurationItem,
+      serviceIdFlexId
+    );
+    const configItemCompact = serviceIdFlexField ? { flexFields: [serviceIdFlexField] } : {};
+    return AirbyteRecord.make(this.streamName.asString, configItemCompact);
+  }
+
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'compute_Application',
     'compute_ApplicationTag',

--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -879,7 +879,7 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
             const streamName = StreamName.fromString(stream).asString;
             const recordId = converter.id(unpacked);
             if (converterDependencies.has(streamName) && recordId) {
-              ctx.set(streamName, String(recordId), unpacked);
+              ctx.set(streamName, String(recordId), converter.toContextStorageRecord(unpacked, ctx));
               // Print stream context stats every so often
               if (stats.recordsProcessed % 1000 == 0) {
                 this.logger.info(`Stream context stats: ${ctx.stats()}`);


### PR DESCRIPTION
## Description

This helps with memory usage. For example, for Wolken, the [dependent stream](https://github.com/faros-ai/airbyte-connectors/blob/0d3c38c8f0e7c287d26d434e9882297e9e623c4a/destinations/airbyte-faros-destination/src/converters/wolken/incidents.ts#L133) only really needs the `serviceIdFlexField` from the input `ConfigurationItem`

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
