### PR TITLE
FAI-14708 Fix initialization bug

### DIFF
--- a/destinations/airbyte-faros-destination/src/destination.ts
+++ b/destinations/airbyte-faros-destination/src/destination.ts
@@ -820,7 +820,7 @@ export class FarosDestination extends AirbyteDestination<DestinationConfig> {
               if (sourceModeOrType === 'mock-data-feed') {
                 this.logger.info('Running a mock data feed sync. Resetting all models before writing records.');
                 ctx.markAllStreamsForReset();
-                await resetData?.(isResetSync);
+                await resetData?.(false);
               }
 
               await updateLocalAccount?.(msg);


### PR DESCRIPTION
## Description

Fixes `Cannot access 'isResetSync' before initialization`

It's safe to assume `isResetSync => false` since the [definition](https://github.com/faros-ai/airbyte-connectors/blob/fc9f84feb3be6109b513ba9c59ad27dd7ec55d1d/destinations/airbyte-faros-destination/src/destination.ts#L949) has `!sourceConfigReceived` as one of its conditions. And `sourceConfigReceived` is set to `true` in the same [code path](https://github.com/faros-ai/airbyte-connectors/blob/fc9f84feb3be6109b513ba9c59ad27dd7ec55d1d/destinations/airbyte-faros-destination/src/destination.ts#L814).

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
