### PR TITLE
FAI-15078 Fix circleci bucketing

### DIFF
--- a/sources/circleci-source/src/circleci/circleci.ts
+++ b/sources/circleci-source/src/circleci/circleci.ts
@@ -6,7 +6,6 @@ import axios, {
 } from 'axios';
 import {AirbyteConfig, AirbyteLogger, wrapApiError} from 'faros-airbyte-cdk';
 import {
-  bucket,
   RoundRobinConfig,
   validateBucketingConfig,
 } from 'faros-airbyte-common/common';
@@ -42,8 +41,6 @@ export class CircleCI {
   private static circleCI: CircleCI = undefined;
   private readonly cutoffDays: number;
   private readonly maxRetries: number;
-  private readonly bucketId: number;
-  private readonly bucketTotal: number;
 
   constructor(
     config: CircleCIConfig,
@@ -53,8 +50,6 @@ export class CircleCI {
   ) {
     this.cutoffDays = config.cutoff_days ?? DEFAULT_CUTOFF_DAYS;
     this.maxRetries = config.max_retries ?? DEFAULT_MAX_RETRIES;
-    this.bucketId = config.bucket_id ?? DEFAULT_BUCKET_ID;
-    this.bucketTotal = config.bucket_total ?? DEFAULT_BUCKET_TOTAL;
   }
 
   static instance(config: CircleCIConfig, logger: AirbyteLogger): CircleCI {
@@ -402,13 +397,6 @@ export class CircleCI {
           },
         }),
       (item: any) => item
-    );
-  }
-
-  isProjectInBucket(project: string): boolean {
-    return (
-      bucket('farosai/airbyte-circleci-source', project, this.bucketTotal) ===
-      this.bucketId
     );
   }
 }

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -116,11 +116,10 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
   }
 
   streams(config: CircleCIConfig): AirbyteStreamBase[] {
-    const circleCI = CircleCI.instance(config, this.logger);
     return [
-      new Projects(circleCI, config, this.logger),
-      new Pipelines(circleCI, config, this.logger),
-      new Tests(circleCI, config, this.logger),
+      new Projects(config, this.logger),
+      new Pipelines(config, this.logger),
+      new Tests(config, this.logger),
     ];
   }
 

--- a/sources/circleci-source/src/streams/common.ts
+++ b/sources/circleci-source/src/streams/common.ts
@@ -1,10 +1,10 @@
 import {AirbyteLogger, AirbyteStreamBase} from 'faros-airbyte-cdk';
+import {bucket} from 'faros-airbyte-common/common';
 
-import {CircleCI, CircleCIConfig} from '../circleci/circleci';
+import {CircleCIConfig} from '../circleci/circleci';
 
 export abstract class StreamWithProjectSlices extends AirbyteStreamBase {
   constructor(
-    protected readonly circleCI: CircleCI,
     protected readonly cfg: CircleCIConfig,
     protected readonly logger: AirbyteLogger
   ) {
@@ -13,10 +13,20 @@ export abstract class StreamWithProjectSlices extends AirbyteStreamBase {
 
   async *streamSlices(): AsyncGenerator<StreamSlice> {
     for (const projectSlug of this.cfg.project_slugs) {
-      if (this.circleCI.isProjectInBucket(projectSlug)) {
+      if (this.isProjectInBucket(projectSlug)) {
         yield {projectSlug};
       }
     }
+  }
+
+  isProjectInBucket(project: string): boolean {
+    return (
+      bucket(
+        'farosai/airbyte-circleci-source',
+        project,
+        this.cfg.bucket_total
+      ) === this.cfg.bucket_id
+    );
   }
 }
 

--- a/sources/circleci-source/src/streams/pipelines.ts
+++ b/sources/circleci-source/src/streams/pipelines.ts
@@ -1,6 +1,7 @@
 import {SyncMode} from 'faros-airbyte-cdk';
 import {Dictionary} from 'ts-essentials';
 
+import {CircleCI} from '../circleci/circleci';
 import {Pipeline} from '../circleci/types';
 import {StreamSlice, StreamWithProjectSlices} from './common';
 
@@ -25,11 +26,14 @@ export class Pipelines extends StreamWithProjectSlices {
     streamSlice?: StreamSlice,
     streamState?: PipelineState
   ): AsyncGenerator<Pipeline, any, unknown> {
+    const circleCI = CircleCI.instance(this.cfg, this.logger);
+
     const since =
       syncMode === SyncMode.INCREMENTAL
         ? streamState?.[streamSlice.projectSlug]?.lastUpdatedAt
         : undefined;
-    yield* this.circleCI.fetchPipelines(streamSlice.projectSlug, since);
+
+    yield* circleCI.fetchPipelines(streamSlice.projectSlug, since);
   }
 
   getUpdatedState(

--- a/sources/circleci-source/src/streams/projects.ts
+++ b/sources/circleci-source/src/streams/projects.ts
@@ -1,6 +1,7 @@
 import {SyncMode} from 'faros-airbyte-cdk';
 import {Dictionary} from 'ts-essentials';
 
+import {CircleCI} from '../circleci/circleci';
 import {Project} from '../circleci/types';
 import {StreamSlice, StreamWithProjectSlices} from './common';
 
@@ -18,6 +19,7 @@ export class Projects extends StreamWithProjectSlices {
     cursorField?: string[],
     streamSlice?: StreamSlice
   ): AsyncGenerator<Project, any, unknown> {
-    yield await this.circleCI.fetchProject(streamSlice.projectSlug);
+    const circleCI = CircleCI.instance(this.cfg, this.logger);
+    yield await circleCI.fetchProject(streamSlice.projectSlug);
   }
 }

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -1,6 +1,7 @@
 import {SyncMode} from 'faros-airbyte-cdk';
 import {Dictionary} from 'ts-essentials';
 
+import {CircleCI} from '../circleci/circleci';
 import {TestMetadata} from '../circleci/types';
 import {StreamSlice, StreamWithProjectSlices} from './common';
 
@@ -25,12 +26,13 @@ export class Tests extends StreamWithProjectSlices {
     streamSlice?: StreamSlice,
     streamState?: TestsState
   ): AsyncGenerator<TestMetadata, any, unknown> {
+    const circleCI = CircleCI.instance(this.cfg, this.logger);
     const since =
       syncMode === SyncMode.INCREMENTAL
         ? streamState?.[streamSlice.projectSlug]?.lastUpdatedAt
         : undefined;
 
-    for await (const pipeline of this.circleCI.fetchPipelines(
+    for await (const pipeline of circleCI.fetchPipelines(
       streamSlice.projectSlug,
       since
     )) {
@@ -51,7 +53,7 @@ export class Tests extends StreamWithProjectSlices {
           }
           seenJobs.add(jobNum);
 
-          const tests = this.circleCI.fetchTests(
+          const tests = circleCI.fetchTests(
             pipeline.project_slug,
             job.job_number
           );


### PR DESCRIPTION
## Description

The `CircleCI` singleton is created in [onBeforeRead](https://github.com/faros-ai/airbyte-connectors/blob/514d989c4ff01f0188b6beb3e165d2cff13e3b2d/sources/circleci-source/src/index.ts#L57) and it has the [bucketId and bucketTotal](https://github.com/faros-ai/airbyte-connectors/blob/main/sources/circleci-source/src/circleci/circleci.ts#L45-L46) as instance variables. So they're never updated (because of the singleton behavior) hence we only process the same bucket every time.

This PR moves the bucketing related vars out of the `CircleCI` class to avoid this issue.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
