### PR TITLE
FAI-15197 | Handle possible null requested reviewer on GitHub pull requests

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/github/faros_pull_requests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/faros_pull_requests.ts
@@ -247,6 +247,9 @@ export class FarosPullRequests extends GitHubConverter {
 
     reviewRequests.forEach((reviewRequest) => {
       const {requestedReviewer} = reviewRequest;
+      if (!requestedReviewer) {
+        return;
+      }
 
       if (
         requestedReviewer.type === 'Team' &&


### PR DESCRIPTION
## Description

Handle possible null requested reviewer on GitHub pull requests
Based on [GitHub gql schema](https://docs.github.com/en/graphql/reference/objects#reviewrequest), requestedReviewer is nullable and we experienced null read errors because of this. Haven't found a reason, documentation or proof on why this would happen (maybe the referenced user was deleted from the GitHub instance?)

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
