### PR TITLE
PagerDuty incidents schema update to contain new fields

### DIFF
--- a/sources/pagerduty-source/resources/schemas/incidents.json
+++ b/sources/pagerduty-source/resources/schemas/incidents.json
@@ -66,6 +66,9 @@
     "created_at": {
       "type": "string"
     },
+    "updated_at": {
+      "type": "string"
+    },
     "service": {
       "type": "object",
       "properties": {
@@ -145,6 +148,9 @@
     },
     "last_status_change_at": {
       "type": "string"
+    },
+    "resolved_at": {
+      "type": "string"
     }
   },
   "required": [
@@ -160,8 +166,10 @@
     "urgency",
     "title",
     "created_at",
+    "updated_at",
     "service",
     "assignments",
-    "last_status_change_at"
+    "last_status_change_at",
+    "resolved_at"
   ]
 }


### PR DESCRIPTION
## Description

Following PR #1934 to include `resolved_at` and `updated_at` fields for PagerDuty **incidents** stream, the new fields still don't appear in the Airbyte schema using connector version [v0.13.15](https://github.com/faros-ai/airbyte-connectors/releases/tag/v0.13.15). This change is meant to fix this by updating `incidents.json` to include both new fields.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

Extends [#1921]. 

## Extra info

Please review if further changes are necessary for the PagerDuty Airbyte source to expose the 2 new fields in its schema.