### PR TITLE
FAI-15611 - Bump faros-js-client to v0.6.3

### DIFF
--- a/destinations/airbyte-faros-destination/package.json
+++ b/destinations/airbyte-faros-destination/package.json
@@ -38,7 +38,7 @@
     "date-format": "^4.0.6",
     "faros-airbyte-cdk": "*",
     "faros-airbyte-common": "*",
-    "faros-js-client": "^0.6.1",
+    "faros-js-client": "^0.6.3",
     "fs-extra": "^11.2.0",
     "git-url-parse": "^13.1.0",
     "graphql": "^16.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "date-format": "^4.0.6",
         "faros-airbyte-cdk": "*",
         "faros-airbyte-common": "*",
-        "faros-js-client": "^0.6.1",
+        "faros-js-client": "^0.6.3",
         "fs-extra": "^11.2.0",
         "git-url-parse": "^13.1.0",
         "graphql": "^16.8.1",
@@ -79,12 +79,132 @@
         "node": ">=18"
       }
     },
+    "destinations/airbyte-faros-destination/node_modules/faros-js-client": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/faros-js-client/-/faros-js-client-0.6.3.tgz",
+      "integrity": "sha512-B6a7x36jNSnSZGcEAfKgE0fyCiojD/2MtFT7WkE2GTSIpZ3XrcAqPQGnNXGA8E1O0Z9pD2mddJvoWWUPR4Y5Kw==",
+      "dependencies": {
+        "axios": "^1.6.5",
+        "axios-retry": "^4.0.0",
+        "commander": "^9.3.0",
+        "date-format": "^4.0.14",
+        "fs-extra": "^11.2.0",
+        "graphql": "^16.10.0",
+        "is-retry-allowed": "^2.2.0",
+        "json-to-graphql-query": "^2.3.0",
+        "lodash": "^4.17.21",
+        "luxon": "^3.1.1",
+        "p-limit": "6.2.0",
+        "pino": "^9.6.0",
+        "pluralize": "^8.0.0",
+        "toposort": "^2.0.2",
+        "traverse": "^0.6.10",
+        "ts-essentials": "^10.0.4",
+        "typescript-memoize": "^1.1.0",
+        "verror": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "destinations/airbyte-faros-destination/node_modules/graphql": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/pino": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
+      "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^4.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
+    },
+    "destinations/airbyte-faros-destination/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "destinations/airbyte-faros-destination/node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "destinations/airbyte-faros-destination/node_modules/uuid": {
@@ -97,6 +217,17 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "destinations/airbyte-faros-destination/node_modules/yocto-queue": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz",
+      "integrity": "sha512-KHBC7z61OJeaMGnF3wqNZj+GGNXOyypZviiKpQeiHirG5Ib1ImwcLBH70rbMSkKfSmUNBsdf2PwaEJtKvgmkNw==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "faros-airbyte-cdk": {


### PR DESCRIPTION
## Description

This client update has a fix where we will only delete models that match the initial deletion criteria.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
