### PR TITLE
FAI-15199 | Files source support for reading S3 files in chunks

### DIFF
--- a/sources/files-source/resources/schemas/files.json
+++ b/sources/files-source/resources/schemas/files.json
@@ -8,6 +8,9 @@
     "fileName": {
       "type": "string"
     },
+    "chunkNumber": {
+      "type": "integer"
+    },
     "lastModified": {
       "type": "number"
     },

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -89,21 +89,26 @@
                   "type": "string"
                 },
                 "title": "Files",
-                "description": "List of files to process in the order given. If empty, all files in the path will be processed."
+                "description": "List of files to be filtered from the S3 path (they will also be processed in the indicated order). If empty, all files in the path will be processed.",
+                "examples": [
+                  "file1.csv",
+                  "file2.csv",
+                  "file3.csv"
+                ]
               },
               "max_request_length": {
                 "order": 8,
                 "type": "number",
                 "title": "Max Request Length (bytes)",
-                "description": "Used to split the file into smaller chunks when reading from S3.",
-                "default": 0
+                "description": "Used to split the file into smaller chunks when reading from S3. Default is 1MB",
+                "default": 1048576
               },
               "bytes_limit": {
                 "order": 9,
                 "type": "number",
                 "title": "Bytes Limit",
-                "description": "Used to limit the number of bytes to read from the file.",
-                "default": 0
+                "description": "Used to limit the number of bytes to read from the file. Default is 1GB",
+                "default": 1073741824
               }
             }
           }

--- a/sources/files-source/resources/spec.json
+++ b/sources/files-source/resources/spec.json
@@ -81,6 +81,29 @@
                   "PROCESS_ALL_FILES",
                   "IMMUTABLE_LEXICOGRAPHICAL_ORDER"
                 ]
+              },
+              "files": {
+                "order": 7,
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "title": "Files",
+                "description": "List of files to process in the order given. If empty, all files in the path will be processed."
+              },
+              "max_request_length": {
+                "order": 8,
+                "type": "number",
+                "title": "Max Request Length (bytes)",
+                "description": "Used to split the file into smaller chunks when reading from S3.",
+                "default": 0
+              },
+              "bytes_limit": {
+                "order": 9,
+                "type": "number",
+                "title": "Bytes Limit",
+                "description": "Used to limit the number of bytes to read from the file.",
+                "default": 0
               }
             }
           }

--- a/sources/files-source/src/files-reader.ts
+++ b/sources/files-source/src/files-reader.ts
@@ -78,8 +78,8 @@ export class S3Reader {
     private readonly s3Client: S3Client,
     private readonly bucketName: string,
     private readonly prefix: string,
-    private readonly maxRequestLength: number,
-    private readonly bytesLimit: number
+    private readonly maxRequestLength?: number,
+    private readonly bytesLimit?: number
   ) {}
 
   static async instance(

--- a/sources/files-source/src/files-reader.ts
+++ b/sources/files-source/src/files-reader.ts
@@ -1,4 +1,5 @@
 import {
+  _Object,
   GetObjectCommand,
   ListObjectsV2Command,
   S3Client,
@@ -19,11 +20,15 @@ type S3 = {
   aws_secret_access_key: string;
   aws_session_token?: string;
   file_processing_strategy?: FileProcessingStrategy;
+  files?: string[];
+  max_request_length?: number;
+  bytes_limit?: number;
 };
 
 export interface OutputRecord {
   filesSource: string;
   fileName: string;
+  chunkNumber: number;
   lastModified: number;
   contents: string;
 }
@@ -125,6 +130,7 @@ export class S3Reader {
   ): AsyncGenerator<OutputRecord> {
     let isTruncated = true;
     let continuationToken: string;
+    const contents: _Object[] = [];
     while (isTruncated) {
       const {Contents, IsTruncated, NextContinuationToken} =
         await this.s3Client.send(
@@ -135,25 +141,87 @@ export class S3Reader {
             ...(lastFileName && {StartAfter: lastFileName}),
           })
         );
+      contents.push(...Contents);
+      isTruncated = IsTruncated;
+      continuationToken = NextContinuationToken;
+    }
 
-      for (const object of Contents || []) {
-        if (object.Key.slice(-1) === '/') continue;
-        logger?.info(`Reading file: ${object.Key}`);
-
-        const res = await this.s3Client.send(
-          new GetObjectCommand({Bucket: this.bucketName, Key: object.Key})
+    const sortedContents =
+      contents?.sort((a, b) => {
+        if (!this.config.files_source.files?.length) return 0;
+        const aIndex = this.config.files_source.files.indexOf(
+          a.Key.split('/').pop()
         );
+        const bIndex = this.config.files_source.files.indexOf(
+          b.Key.split('/').pop()
+        );
+        return aIndex - bIndex;
+      }) || [];
+
+    const maxRequestLength = this.config.files_source.max_request_length;
+    for (const object of sortedContents) {
+      if (object.Key.slice(-1) === '/') continue;
+
+      const fileName = object.Key.split('/').pop();
+      if (
+        this.config.files_source.files?.length &&
+        !this.config.files_source.files.includes(fileName)
+      ) {
+        logger?.info(
+          `Skipping File: ${object.Key} - Size: ${object.Size} - Last Modified: ${object.LastModified}`
+        );
+        continue;
+      }
+      logger?.info(
+        `Reading File: ${object.Key} - Size: ${object.Size} - Last Modified: ${object.LastModified}`
+      );
+      let currentByte = 0;
+      let chunkNumber = 0;
+      while (currentByte < object.Size) {
+        if (
+          this.config.files_source.bytes_limit &&
+          currentByte >= this.config.files_source.bytes_limit
+        ) {
+          if (currentByte != object.Size) {
+            logger?.warn(
+              `File ${object.Key} surpassed the configured bytes limit of ${this.config.files_source.bytes_limit}. Skipping remaining bytes.`
+            );
+          }
+          break;
+        }
+        const range =
+          maxRequestLength > 0
+            ? `bytes=${currentByte}-${Math.min(currentByte + maxRequestLength, object.Size) - 1}`
+            : undefined;
+        const res = await this.s3Client.send(
+          new GetObjectCommand({
+            Bucket: this.bucketName,
+            Key: object.Key,
+            IfMatch: object.ETag, // make sure file has not been modified since the beginning of the sync
+            ...(range && {Range: range}),
+          })
+        );
+        logger?.debug(
+          `Range: ${range} - Content Length: ${res.ContentLength} - Content Range: ${res.ContentRange}`
+        );
+        if (
+          res.ContentLength !== maxRequestLength &&
+          res.ContentLength + currentByte !== object.Size
+        ) {
+          throw new Error(
+            'Content Length does not match with the expected value'
+          );
+        }
+        currentByte += res.ContentLength;
         const contents = await res.Body.transformToString('base64');
         yield {
           filesSource: 'S3',
           fileName: object.Key,
+          chunkNumber: ++chunkNumber,
           lastModified: object.LastModified.getTime(),
           contents,
         };
       }
-
-      isTruncated = IsTruncated;
-      continuationToken = NextContinuationToken;
     }
   }
 

--- a/sources/files-source/src/streams/files.ts
+++ b/sources/files-source/src/streams/files.ts
@@ -36,7 +36,7 @@ export class Files extends AirbyteStreamBase {
   }
 
   get primaryKey(): StreamKey {
-    return undefined;
+    return ['fileName', 'chunkNumber'];
   }
 
   get cursorField(): string | string[] {

--- a/sources/files-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/files-source/test/__snapshots__/index.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`index files full 1`] = `
 [
   {
+    "chunkNumber": 1,
     "contents": "test",
     "fileName": "your-path/1.json",
     "filesSource": "S3",

--- a/sources/files-source/test/index.test.ts
+++ b/sources/files-source/test/index.test.ts
@@ -156,6 +156,7 @@ describe('index', () => {
         {
           Key: 'your-path/1.json',
           LastModified: new Date('2023-12-03T01:18:03.000Z'),
+          Size: 100,
         },
       ],
       IsTruncated: false,


### PR DESCRIPTION
## Description

- Files source support for reading S3 files in chunks
- Allow filtering and provide order to read specific files

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
