### PR TITLE
FAI-16074: Fix jenkins class constructor initialization

### DIFF
--- a/sources/jenkins-source/src/jenkins.ts
+++ b/sources/jenkins-source/src/jenkins.ts
@@ -119,7 +119,8 @@ export class Jenkins {
       jenkinsUrl.password = config.token;
     }
 
-    const client = jenkinsClient({
+    // It should be 'JenkinsPromisifiedAPI' instead of any, but we could not make it work
+    const client = new (jenkinsClient as any)({
       baseUrl: jenkinsUrl.toString(),
       crumbIssuer: true,
       promisify: true,


### PR DESCRIPTION
## Description

Fix this since [upgrade to client version](https://github.com/faros-ai/airbyte-connectors/pull/1954)
```
Class constructor Jenkins cannot be invoked without 'new' Stack Trace: TypeError: Class constructor Jenkins cannot be invoked without 'new' at Jenkins.instance
```

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
