### PR TITLE
Fix Faros destination and common packages release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           cd faros-airbyte-cdk && \
           npm i && \
+          npm run build && \
           npm version ${{ env.TAG_VERSION }} && \
           npm publish --access public --tag latest
         env:
@@ -54,6 +55,7 @@ jobs:
         run: |
           cd faros-airbyte-common && \
           npm i && \
+          npm run build && \
           npm version ${{ env.TAG_VERSION }} && \
           npm publish --access public --tag latest
         env:
@@ -65,6 +67,7 @@ jobs:
           cat package.json | jq --arg V "${{ env.TAG_VERSION }}" '(.dependencies."faros-airbyte-cdk",.dependencies."faros-airbyte-common") = $V' > package.tmp && \
           mv package.tmp package.json && \
           npm i && \
+          npm run build && \
           npm version ${{ env.TAG_VERSION }} && \
           npm publish --access public --tag latest
         env:

--- a/faros-airbyte-cdk/package.json
+++ b/faros-airbyte-cdk/package.json
@@ -31,7 +31,6 @@
     "clean": "rm -rf lib node_modules out",
     "fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts' && npm run lint -- --fix",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
-    "prepare": "npm run build",
     "test": "jest --verbose --color",
     "test-cov": "jest --coverage --verbose --color",
     "watch": "tsc -b -w src test"


### PR DESCRIPTION
## Description

[airbyte-faros-destination](https://www.npmjs.com/package/airbyte-faros-destination/v/0.11.0?activeTab=code) and [faros-airbyte-common](https://www.npmjs.com/package/faros-airbyte-common/v/0.14.1?activeTab=code) packages have been missing their code on their npm packages since [0.11.0](https://github.com/faros-ai/airbyte-connectors/compare/v0.10.87...v0.11.0) and [0.14.1](https://github.com/faros-ai/airbyte-connectors/compare/v0.14.0...v0.14.1) respectively. On those releases prepare script was removed on their packages to avoid dependency errors on npm install. As a result the release workflow doesn't build those packages on install.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

## Migration notes

## Extra info
