### PR TITLE
FAI-16059: AzureDevOps add support for generic REST API

### DIFF
--- a/faros-airbyte-common/src/azure-devops/types.ts
+++ b/faros-airbyte-common/src/azure-devops/types.ts
@@ -5,12 +5,16 @@ import {IGitApi} from 'azure-devops-node-api/GitApi';
 import {
   Build as BaseBuild,
   BuildArtifact,
+  BuildRepository,
   TimelineRecord as BaseTimelineRecord,
 } from 'azure-devops-node-api/interfaces/BuildInterfaces';
 import {IdentityRef} from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
 import * as GitInterfaces from 'azure-devops-node-api/interfaces/GitInterfaces';
 import {GraphUser} from 'azure-devops-node-api/interfaces/GraphInterfaces';
-import {Pipeline as BasePipeline} from 'azure-devops-node-api/interfaces/PipelinesInterfaces';
+import {
+  Pipeline as BasePipeline,
+  Run as BaseRun,
+} from 'azure-devops-node-api/interfaces/PipelinesInterfaces';
 import {ProjectReference} from 'azure-devops-node-api/interfaces/ReleaseInterfaces';
 import {CodeCoverageStatistics} from 'azure-devops-node-api/interfaces/TestInterfaces';
 import {WorkItem} from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
@@ -47,7 +51,7 @@ export interface AzureDevOpsClient {
   readonly pipelines: IPipelinesApi;
   readonly release: IReleaseApi;
   readonly test: ITestApi;
-  readonly graph?: AxiosInstance;
+  readonly rest: AxiosInstance;
 }
 
 export type User = GraphUser | IdentityRef;
@@ -68,6 +72,28 @@ export interface Build extends Omit<BaseBuild, 'reason' | 'status' | 'result'> {
   reason: string;
   status: string;
   result: string;
+}
+
+// Ensure enums are strings
+export interface Run extends Omit<BaseRun, 'result' | 'state'> {
+  project: ProjectReference;
+  result: string;
+  state: string;
+
+  // Enherited from Build interface
+  artifacts: BuildArtifact[];
+  coverageStats: CodeCoverageStatistics[];
+  jobs: TimelineRecord[];
+  stages: TimelineRecord[];
+  queueTime?: Date;
+  repository: BuildRepository;
+  reason: string;
+  sourceBranch?: string;
+  sourceVersion: string;
+  tags: string[];
+  triggerInfo?: {
+    [key: string]: string;
+  };
 }
 
 export interface TimelineRecord

--- a/faros-airbyte-common/test/azure-devops/azure-devops.test.ts
+++ b/faros-airbyte-common/test/azure-devops/azure-devops.test.ts
@@ -243,6 +243,7 @@ describe('client', () => {
               .mockResolvedValueOnce(readTestResourceAsJSON('projects.json')),
           },
         } as unknown as AzureDevOpsClient,
+        'cloud',
         90,
         100,
         logger
@@ -263,6 +264,7 @@ describe('client', () => {
               .mockResolvedValueOnce(readTestResourceAsJSON('projects.json')),
           },
         } as unknown as AzureDevOpsClient,
+        'cloud',
         90,
         100,
         logger
@@ -285,6 +287,7 @@ describe('client', () => {
               .mockResolvedValueOnce(projects.at(1)),
           },
         } as unknown as AzureDevOpsClient,
+        'cloud',
         90,
         100,
         logger
@@ -309,6 +312,7 @@ describe('client', () => {
               .mockResolvedValueOnce(undefined),
           },
         } as unknown as AzureDevOpsClient,
+        'cloud',
         90,
         100,
         logger

--- a/sources/azure-repos-source/src/azure-repos.ts
+++ b/sources/azure-repos-source/src/azure-repos.ts
@@ -37,6 +37,7 @@ export class AzureRepos extends AzureDevOps {
   private readonly repositoriesByProject: Map<string, Set<string>>;
   constructor(
     protected readonly client: AzureDevOpsClient,
+    protected readonly instanceType: 'cloud' | 'server',
     protected readonly cutoffDays: number = DEFAULT_CUTOFF_DAYS,
     protected readonly top: number = DEFAULT_PAGE_SIZE,
     protected readonly logger: AirbyteLogger,
@@ -45,7 +46,7 @@ export class AzureRepos extends AzureDevOps {
     fetchTags: boolean = false,
     fetchBranchCommits: boolean = false
   ) {
-    super(client, cutoffDays, top, logger);
+    super(client, instanceType, cutoffDays, top, logger);
     this.branchPattern = new RegExp(branchPattern || DEFAULT_BRANCH_PATTERN);
     this.logger.debug(
       `Fetching commits and pull requests from branches matching pattern: ` +

--- a/sources/azure-repos-source/test/index.test.ts
+++ b/sources/azure-repos-source/test/index.test.ts
@@ -26,6 +26,7 @@ describe('index', () => {
 
   const cutoffDays = 3;
   const top = 100;
+  const instanceType = 'cloud';
   const config = {
     access_token: 'token',
     organization: 'organization',
@@ -67,12 +68,13 @@ describe('index', () => {
             getBranches: jest.fn().mockResolvedValue([]),
             getRefs: jest.fn().mockResolvedValue([]),
           },
-          graph: {
+          rest: {
             get: jest.fn().mockResolvedValue({
               data: {value: usersResource},
             }),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -95,6 +97,7 @@ describe('index', () => {
             getProject: jest.fn().mockResolvedValue(null),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -124,6 +127,7 @@ describe('index', () => {
               .mockRejectedValue(new Error('Failed to fetch repositories')),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -149,6 +153,7 @@ describe('index', () => {
             getCommits: jest.fn().mockResolvedValueOnce(commits),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -192,6 +197,7 @@ describe('index', () => {
             getBranches: jest.fn().mockResolvedValueOnce(branches),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -233,6 +239,7 @@ describe('index', () => {
               .mockResolvedValueOnce(threads[1]),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -282,6 +289,7 @@ describe('index', () => {
             getAnnotatedTag: jest.fn().mockResolvedValue(tagResult.commit),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -333,6 +341,7 @@ describe('index', () => {
             getAnnotatedTag: jest.fn().mockResolvedValue(tagResult.commit),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,
@@ -371,6 +380,7 @@ describe('index', () => {
             getBranches: jest.fn().mockResolvedValue(reposResource[0].branches),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger,

--- a/sources/azure-workitems-source/src/azure-workitems.ts
+++ b/sources/azure-workitems-source/src/azure-workitems.ts
@@ -35,12 +35,13 @@ export class AzureWorkitems extends types.AzureDevOps {
   private additionalFieldReferences: Map<string, string>;
   constructor(
     protected readonly client: types.AzureDevOpsClient,
+    protected readonly instanceType: 'cloud' | 'server',
     protected readonly cutoffDays: number,
     protected readonly top: number,
     protected readonly logger: AirbyteLogger,
     private readonly additionalFields?: ReadonlyArray<string>
   ) {
-    super(client, cutoffDays, top, logger);
+    super(client, instanceType, cutoffDays, top, logger);
     this.additionalFields = additionalFields;
   }
 

--- a/sources/azure-workitems-source/test/index.test.ts
+++ b/sources/azure-workitems-source/test/index.test.ts
@@ -22,6 +22,7 @@ describe('index', () => {
       ? AirbyteLogLevel.DEBUG
       : AirbyteLogLevel.INFO
   );
+  const instanceType = 'cloud';
 
   const source = new sut.AzureWorkitemsSource(logger);
 
@@ -55,6 +56,7 @@ describe('index', () => {
             }),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         null,
         null,
         logger
@@ -98,6 +100,7 @@ describe('index', () => {
               ]),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         null,
         100,
         logger
@@ -163,6 +166,7 @@ describe('index', () => {
             ),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         90,
         100,
         logger,
@@ -236,6 +240,7 @@ describe('index', () => {
             ),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         null,
         100,
         logger,

--- a/sources/azurepipeline-source/test/index.test.ts
+++ b/sources/azurepipeline-source/test/index.test.ts
@@ -38,6 +38,7 @@ describe('index', () => {
   const WATERMARK = '2023-03-03T18:18:11.592Z';
   const cutoffDays = 365;
   const top = 100;
+  const instanceType = 'cloud';
   const project = {id: '1', name: 'proj1'};
 
   beforeEach(() => (AzurePipelines.instance = azurePipelines));
@@ -74,6 +75,7 @@ describe('index', () => {
               .mockResolvedValue(readTestResourceFile('pipelines.json')),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger
@@ -117,6 +119,7 @@ describe('index', () => {
               .mockResolvedValueOnce(jobs[2]),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger
@@ -171,6 +174,7 @@ describe('index', () => {
             getCodeCoverageSummary: jest.fn().mockResolvedValue(coverage),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger
@@ -201,6 +205,7 @@ describe('index', () => {
             getReleases: jest.fn().mockResolvedValue(releasesData),
           },
         } as unknown as AzureDevOpsClient,
+        instanceType,
         cutoffDays,
         top,
         logger


### PR DESCRIPTION
## Description

- AzureDevOps add support for generic REST api to fallback when the client azure-devops-node-api doesn't work as expected, e.g. for listRuns for AzureDevOp Server 2020.
- Follow-up PR to use rest to azurepipeline-source

## Type of change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
