### PR TITLE
FAI-16144 | Workday allows to add Employee Tag for Vendor

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/workday/README.md
+++ b/destinations/airbyte-faros-destination/src/converters/workday/README.md
@@ -21,6 +21,7 @@ Expecting fields (? implies optional):
   Employee_Type?: string;
   Job_Title?: string;
   Parent_Team_ID?: string
+  Vendor?: string
 ```
 
 Source Specific Configs:

--- a/destinations/airbyte-faros-destination/src/converters/workday/customreports.ts
+++ b/destinations/airbyte-faros-destination/src/converters/workday/customreports.ts
@@ -451,6 +451,20 @@ export class Customreports extends Converter {
     return map;
   }
 
+  private cleanVendor(vendor: string): string {
+    // We only take the first line of many if it's a multiline string
+    // We take any grouping of more than one space and make it one space
+    // We remove any leading or trailing spaces
+    // We take away any non-alphanumeric characters (other than spaces)
+    // We lowercase the string
+
+    vendor = vendor.split('\n')[0];
+    vendor = vendor.replace(/\s+/g, ' ').trim();
+    vendor = vendor.replace(/[^a-zA-Z0-9\s]/g, '');
+    vendor = vendor.toLowerCase();
+    return vendor;
+  }
+
   private computeTeamToParentTeamMappingUsingParentIDField(
     ctx: StreamContext,
     teamIDToParentTeamID: Record<string, string>
@@ -796,14 +810,15 @@ export class Customreports extends Converter {
     );
     this.writtenEmployeeIds.add(employee_record.Employee_ID);
     if (employee_record.Vendor) {
-      const tagUid = `vendor__${employee_record.Vendor}`;
+      const vendor: string = this.cleanVendor(employee_record.Vendor);
+      const tagUid = `vendor__${vendor}`;
       records.push(
         {
           model: 'faros_Tag',
           record: {
             uid: tagUid,
             key: 'vendor',
-            value: employee_record.Vendor,
+            value: vendor,
           },
         },
         {

--- a/destinations/airbyte-faros-destination/src/converters/workday/customreports.ts
+++ b/destinations/airbyte-faros-destination/src/converters/workday/customreports.ts
@@ -453,14 +453,14 @@ export class Customreports extends Converter {
 
   private cleanVendor(vendor: string): string {
     // We only take the first line of many if it's a multiline string
+    // We take away any non-alphanumeric characters (other than spaces)
     // We take any grouping of more than one space and make it one space
     // We remove any leading or trailing spaces
-    // We take away any non-alphanumeric characters (other than spaces)
     // We lowercase the string
 
     vendor = vendor.split('\n')[0];
-    vendor = vendor.replace(/\s+/g, ' ').trim();
     vendor = vendor.replace(/[^a-zA-Z0-9\s]/g, '');
+    vendor = vendor.replace(/\s+/g, ' ').trim();
     vendor = vendor.toLowerCase();
     return vendor;
   }

--- a/destinations/airbyte-faros-destination/src/converters/workday/customreports.ts
+++ b/destinations/airbyte-faros-destination/src/converters/workday/customreports.ts
@@ -795,6 +795,26 @@ export class Customreports extends Converter {
       }
     );
     this.writtenEmployeeIds.add(employee_record.Employee_ID);
+    if (employee_record.Vendor) {
+      const tagUid = `vendor__${employee_record.Vendor}`;
+      records.push(
+        {
+          model: 'faros_Tag',
+          record: {
+            uid: tagUid,
+            key: 'vendor',
+            value: employee_record.Vendor,
+          },
+        },
+        {
+          model: 'org_EmployeeTag',
+          record: {
+            employee: {uid: employee_record.Employee_ID},
+            tag: {uid: tagUid},
+          },
+        }
+      );
+    }
 
     return records;
   }

--- a/destinations/airbyte-faros-destination/src/converters/workday/models.ts
+++ b/destinations/airbyte-faros-destination/src/converters/workday/models.ts
@@ -13,6 +13,7 @@ export declare type EmployeeRecord = {
   Employee_Type?: string;
   Job_Title?: string;
   Parent_Team_ID?: string;
+  Vendor?: string;
 };
 
 export declare type ManagerTimeRecord = {
@@ -37,5 +38,7 @@ export const recordKeyTyping = {
   location: 'Location',
   email: 'Email',
   employeetype: 'Employee_Type',
+  jobtitle: 'Job_Title',
   parentteamid: 'Parent_Team_ID',
+  vendor: 'Vendor',
 };


### PR DESCRIPTION
## Description
Adds org_EmployeeTag matching employee to vendor - if vendor is provided by Workday.
Can potentially filter them by an input or by some other method-

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change


