### PR TITLE
FAI-16116 Stringify additionalInfo

### DIFF
--- a/sources/github-source/src/octokit.ts
+++ b/sources/github-source/src/octokit.ts
@@ -92,12 +92,17 @@ export function makeOctokitClient(
     timeout: {
       ms: cfg.timeout ?? DEFAULT_TIMEOUT_MS,
     },
-    log: {
-      info: logger.debug.bind(logger),
-      warn: logger.debug.bind(logger),
-      error: logger.debug.bind(logger),
-      debug: logger.debug.bind(logger),
-    },
+    log: (() => {
+      const logFn = (message: string, additionalInfo?: object) =>
+        logger.debug(message, additionalInfo ? JSON.stringify(additionalInfo) : undefined);
+
+      return {
+        info: logFn,
+        warn: logFn,
+        error: logFn,
+        debug: logFn,
+      };
+    })(),
   });
 
   kit.hook.before('request', (request) => {


### PR DESCRIPTION
## Description

`stack_trace` is a string in the Airbyte protocol [1](https://github.com/airbytehq/airbyte-protocol/blob/75443bd525c63faf814f4eee080cca1132bc0414/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml#L240) [2](https://github.com/faros-ai/airbyte-connectors/blob/b6f5dab728ee7a8fb0f69b17ede656e7f8b6a15c/faros-airbyte-cdk/src/protocol.ts#L153)

We were passing an object and that was making the deserializer throw here: [1](https://github.com/airbytehq/airbyte-platform/blob/34a31e95f54d83dd544b79611218ce9549efe416/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactory.java#L328) [2](https://github.com/airbytehq/airbyte-platform/blob/34a31e95f54d83dd544b79611218ce9549efe416/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java#L190).

See the new log where the object is stringified:
![Screenshot 2025-04-30 at 5 46 21 PM](https://github.com/user-attachments/assets/5191cbeb-7ab3-407d-823f-603da93ef977)


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
