### PR TITLE
FAI-16627 - Use getOrigin() method

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/faros-org-import/teams.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-org-import/teams.ts
@@ -296,7 +296,7 @@ export class Teams extends FarosOrgImportConverter {
       TEAM_OWNERSHIP_QUERY,
       undefined,
       undefined,
-      new Map([['origin', ctx.config.origin]])
+      new Map([['origin', ctx.getOrigin()]])
     );
 
     for await (const team of teamsIter) {


### PR DESCRIPTION
## Description

Looking at existing code, it looks like this is the correct way to get the origin in the context of a converter?

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
