### PR TITLE
FAI-16732 Refactor: Centralize file reading utilities for tests

### DIFF
--- a/faros-airbyte-cdk/src/testing-tools.ts
+++ b/faros-airbyte-cdk/src/testing-tools.ts
@@ -23,6 +23,28 @@ export function readTestResourceAsJSON(fileName: string): any {
   return JSON.parse(readTestResourceFile(fileName));
 }
 
+export function readTestFile(fileName: string): string {
+  return fs.readFileSync(`test_files/${fileName}`, 'utf8');
+}
+
+/**
+ * Parse a test file into JSON
+ */
+export function readTestFileAsJSON(fileName: string): any {
+  return JSON.parse(readTestFile(fileName));
+}
+
+export function readResourceFile(fileName: string): string {
+  return fs.readFileSync(`resources/${fileName}`, 'utf8');
+}
+
+/**
+ * Parse a resource into JSON
+ */
+export function readResourceAsJSON(fileName: string): any {
+  return JSON.parse(readResourceFile(fileName));
+}
+
 export interface SourceCheckTestOptions {
   source: AirbyteSourceBase<AirbyteConfig>;
   configOrPath?: string | AirbyteConfig;

--- a/sources/agileaccelerator-source/test/index.test.ts
+++ b/sources/agileaccelerator-source/test/index.test.ts
@@ -3,9 +3,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {Agileaccelerator} from '../src/agileaccelerator/agileaccelerator';
@@ -16,14 +17,6 @@ const agileacceleratorInstance = Agileaccelerator.instance;
 jest.mock('axios');
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -43,7 +36,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.AgileacceleratorSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -116,7 +109,7 @@ describe('index', () => {
     const fnWorksFunc = jest.fn();
 
     Agileaccelerator.instance = jest.fn().mockImplementation(() => {
-      const worksResource: any[] = readTestResourceFile('works.json');
+      const worksResource: any[] = readTestFileAsJSON('works.json');
       return new Agileaccelerator(
         {
           get: fnWorksFunc.mockResolvedValue({
@@ -139,6 +132,6 @@ describe('index', () => {
     }
 
     expect(fnWorksFunc).toHaveBeenCalledTimes(1);
-    expect(works).toStrictEqual(readTestResourceFile('works.json'));
+    expect(works).toStrictEqual(readTestFileAsJSON('works.json'));
   });
 });

--- a/sources/asana-source/test/index.test.ts
+++ b/sources/asana-source/test/index.test.ts
@@ -2,9 +2,9 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import VError from 'verror';
 
 import {Asana} from '../src/asana';
@@ -22,7 +22,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -272,6 +272,3 @@ describe('index', () => {
   });
 });
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}

--- a/sources/aws-cloudwatch-metrics-source/test/index.test.ts
+++ b/sources/aws-cloudwatch-metrics-source/test/index.test.ts
@@ -2,9 +2,9 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import VError from 'verror';
 
 import {CloudWatch, Config} from '../src/cloudwatch';
@@ -37,7 +37,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -196,6 +196,3 @@ describe('index', () => {
   });
 });
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}

--- a/sources/azure-repos-source/test/index.test.ts
+++ b/sources/azure-repos-source/test/index.test.ts
@@ -2,11 +2,12 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   sourceCheckTest,
   SyncMode,
 } from 'faros-airbyte-cdk';
 import {AzureDevOpsClient} from 'faros-airbyte-common/azure-devops';
-import fs from 'fs-extra';
 import {omit} from 'lodash';
 
 import {AzureRepos} from '../src/azure-repos';
@@ -37,24 +38,17 @@ describe('index', () => {
     AzureRepos.instance = azureRepo;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
-
-  function readTestResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-  }
 
   test('spec', async () => {
     const source = new sut.AzureRepoSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
   test('check connection', async () => {
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const usersResource: any[] = readTestResourceFile('users.json');
+      const usersResource: any[] = readTestFileAsJSON('users.json');
       const project = {id: 'project', name: 'Project'};
       return new AzureRepos(
         {
@@ -143,10 +137,10 @@ describe('index', () => {
   });
 
   test('streams - commits, use full_refresh sync mode', async () => {
-    const repos = readTestResourceFile('repositories.json');
+    const repos = readTestFileAsJSON('repositories.json');
     const repo = {...repos[0], project: {id: 'project', name: 'project'}};
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const commits = readTestResourceFile('commits.json');
+      const commits = readTestFileAsJSON('commits.json');
       return new AzureRepos(
         {
           git: {
@@ -178,12 +172,12 @@ describe('index', () => {
 
   test('streams - commits, fetch branch commits', async () => {
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const reposResource = readTestResourceFile('repositories.json');
+      const reposResource = readTestFileAsJSON('repositories.json');
       const repos = reposResource.map((repo) =>
         omit(repo, ['branches', 'tags'])
       );
-      const commits = readTestResourceFile('commits.json');
-      const branches = readTestResourceFile('branches.json');
+      const commits = readTestFileAsJSON('commits.json');
+      const branches = readTestFileAsJSON('branches.json');
       return new AzureRepos(
         {
           core: {
@@ -223,10 +217,10 @@ describe('index', () => {
   });
 
   test('streams - pullrequests, use full_refresh sync mode', async () => {
-    const repos = readTestResourceFile('repositories.json');
+    const repos = readTestFileAsJSON('repositories.json');
     const repo = {...repos[0], project: {id: 'project', name: 'project'}};
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const rawPullrequests: any[] = readTestResourceFile('pullrequests.json');
+      const rawPullrequests: any[] = readTestFileAsJSON('pullrequests.json');
       const pullrequests = rawPullrequests.map((p) => omit(p, 'threads'));
       const threads = rawPullrequests.map((r) => r.threads);
       return new AzureRepos(
@@ -265,7 +259,7 @@ describe('index', () => {
 
   test('streams - repositories, use full_refresh sync mode', async () => {
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const reposResource = readTestResourceFile('repositories.json');
+      const reposResource = readTestFileAsJSON('repositories.json');
       const repos = reposResource.map((repo) =>
         omit(repo, ['branches', 'tags'])
       );
@@ -317,7 +311,7 @@ describe('index', () => {
 
   test('streams - repositories, filter by repository', async () => {
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const reposResource = readTestResourceFile('repositories.json');
+      const reposResource = readTestFileAsJSON('repositories.json');
       const repos = reposResource.map((repo) =>
         omit(repo, ['branches', 'tags'])
       );
@@ -368,7 +362,7 @@ describe('index', () => {
 
   test('streams - repositories, tags disabled', async () => {
     AzureRepos.instance = jest.fn().mockImplementation(() => {
-      const reposResource = readTestResourceFile('repositories.json');
+      const reposResource = readTestFileAsJSON('repositories.json');
       const repos = reposResource.map((repo) =>
         omit(repo, ['branches', 'tags'])
       );

--- a/sources/azure-workitems-source/test/index.test.ts
+++ b/sources/azure-workitems-source/test/index.test.ts
@@ -2,11 +2,12 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   sourceCheckTest,
   SyncMode,
 } from 'faros-airbyte-cdk';
 import {AzureDevOpsClient} from 'faros-airbyte-common/azure-devops';
-import fs from 'fs-extra';
 
 import {AzureWorkitems} from '../src/azure-workitems';
 import * as sut from '../src/index';
@@ -30,24 +31,17 @@ describe('index', () => {
     AzureWorkitems.instance = azureWorkitem;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
-
-  function readTestResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-  }
 
   test('spec', async () => {
     const source = new sut.AzureWorkitemsSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
   test('check connection - valid config', async () => {
     AzureWorkitems.instance = jest.fn().mockImplementation(() => {
-      const projectsResource: any[] = readTestResourceFile('projects.json');
+      const projectsResource: any[] = readTestFileAsJSON('projects.json');
       return new AzureWorkitems(
         {
           core: {
@@ -92,11 +86,11 @@ describe('index', () => {
           wit: {
             getClassificationNode: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('iterations_root.json')),
+              .mockResolvedValue(readTestFileAsJSON('iterations_root.json')),
             getClassificationNodes: jest
               .fn()
               .mockResolvedValueOnce([
-                readTestResourceFile('iterations_node_3.json'),
+                readTestFileAsJSON('iterations_node_3.json'),
               ]),
           },
         } as unknown as AzureDevOpsClient,
@@ -150,19 +144,19 @@ describe('index', () => {
             getFields: jest.fn().mockResolvedValue(fieldReferences),
             getWorkItems: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('workitems.json').value),
+              .mockResolvedValue(readTestFileAsJSON('workitems.json').value),
             getWorkItemTypeStates: jest
               .fn()
               .mockResolvedValue(
-                readTestResourceFile('workitem_states.json').value
+                readTestFileAsJSON('workitem_states.json').value
               ),
             getUpdates: jest
               .fn()
               .mockResolvedValue(
-                readTestResourceFile('workitem_updates.json').value
+                readTestFileAsJSON('workitem_updates.json').value
               ),
             queryByWiql: workitemIdsFunc.mockResolvedValue(
-              readTestResourceFile('workitem_ids.json')
+              readTestFileAsJSON('workitem_ids.json')
             ),
           },
         } as unknown as AzureDevOpsClient,
@@ -224,19 +218,19 @@ describe('index', () => {
             getFields: jest.fn().mockResolvedValue(fieldReferences),
             getWorkItems: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('workitems.json').value),
+              .mockResolvedValue(readTestFileAsJSON('workitems.json').value),
             getWorkItemTypeStates: jest
               .fn()
               .mockResolvedValue(
-                readTestResourceFile('workitem_states.json').value
+                readTestFileAsJSON('workitem_states.json').value
               ),
             getUpdates: jest
               .fn()
               .mockResolvedValue(
-                readTestResourceFile('workitem_updates.json').value
+                readTestFileAsJSON('workitem_updates.json').value
               ),
             queryByWiql: workitemIdsFunc.mockResolvedValue(
-              readTestResourceFile('workitem_ids.json')
+              readTestFileAsJSON('workitem_ids.json')
             ),
           },
         } as unknown as AzureDevOpsClient,

--- a/sources/azureactivedirectory-source/test/index.test.ts
+++ b/sources/azureactivedirectory-source/test/index.test.ts
@@ -1,10 +1,11 @@
 import {
+  readResourceAsJSON,
+  readTestFileAsJSON,
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {AzureActiveDirectory} from '../src/azureactivedirectory';
@@ -26,18 +27,12 @@ describe('index', () => {
     AzureActiveDirectory.instance = azureActiveDirectoryInstance;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
 
-  function readTestResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-  }
 
   test('spec', async () => {
     const source = new sut.AzureActiveDirectorySource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -55,7 +50,7 @@ describe('index', () => {
   });
 
   test('filters groups stream when fetch_teams is false', async () => {
-    const catalog = readTestResourceFile('full_configured_catalog.json');
+    const catalog = readTestFileAsJSON('full_configured_catalog.json');
     const {catalog: newCatalog} = await source.onBeforeRead(
       {fetch_teams: false} as any,
       catalog
@@ -73,7 +68,7 @@ describe('index', () => {
     const fnUsersFunc = jest.fn();
 
     AzureActiveDirectory.instance = jest.fn().mockImplementation(() => {
-      const usersResource: any[] = readTestResourceFile('users.json');
+      const usersResource: any[] = readTestFileAsJSON('users.json');
       return new AzureActiveDirectory(
         {
           get: fnUsersFunc.mockResolvedValue({
@@ -93,14 +88,14 @@ describe('index', () => {
     }
 
     expect(fnUsersFunc).toHaveBeenCalledTimes(3);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 
   test('streams - groups, use full_refresh sync mode', async () => {
     const fnGroupsFunc = jest.fn();
 
     AzureActiveDirectory.instance = jest.fn().mockImplementation(() => {
-      const groupsResource: any[] = readTestResourceFile('groups.json');
+      const groupsResource: any[] = readTestFileAsJSON('groups.json');
       return new AzureActiveDirectory(
         {
           get: fnGroupsFunc.mockResolvedValue({
@@ -120,6 +115,6 @@ describe('index', () => {
     }
 
     expect(fnGroupsFunc).toHaveBeenCalledTimes(3);
-    expect(groups).toStrictEqual(readTestResourceFile('groups.json'));
+    expect(groups).toStrictEqual(readTestFileAsJSON('groups.json'));
   });
 });

--- a/sources/azurepipeline-source/test/index.test.ts
+++ b/sources/azurepipeline-source/test/index.test.ts
@@ -1,4 +1,6 @@
 import {
+  readResourceAsJSON,
+  readTestFileAsJSON,
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
@@ -6,7 +8,6 @@ import {
   SyncMode,
 } from 'faros-airbyte-cdk';
 import {AzureDevOpsClient} from 'faros-airbyte-common/azure-devops';
-import fs from 'fs-extra';
 import {omit} from 'lodash';
 import {DateTime} from 'luxon';
 
@@ -48,7 +49,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -71,7 +72,7 @@ describe('index', () => {
           pipelines: {
             listPipelines: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('pipelines.json')),
+              .mockResolvedValue(readTestFileAsJSON('pipelines.json')),
           },
         } as unknown as AzureDevOpsClient,
         instanceType,
@@ -105,7 +106,7 @@ describe('index', () => {
       );
 
     AzurePipelines.instance = jest.fn().mockImplementation(() => {
-      const buildsResource: any[] = readTestResourceFile('builds.json');
+      const buildsResource: any[] = readTestFileAsJSON('builds.json');
       const rawBuilds = buildsResource.map((b) =>
         omit(b, ['artifacts', 'jobs'])
       );
@@ -133,7 +134,7 @@ describe('index', () => {
           pipelines: {
             listRuns: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('runs.json')),
+              .mockResolvedValue(readTestFileAsJSON('runs.json')),
           },
         } as unknown as AzureDevOpsClient,
         instanceType,
@@ -166,8 +167,8 @@ describe('index', () => {
       );
 
     AzurePipelines.instance = jest.fn().mockImplementation(() => {
-      const runs = [readTestResourceFile('runs.json')[0]];
-      const buildsResource: any[] = readTestResourceFile(
+      const runs = [readTestFileAsJSON('runs.json')[0]];
+      const buildsResource: any[] = readTestFileAsJSON(
         'builds_eligible_for_coverage.json'
       );
       const rawBuilds = buildsResource.map((b) =>
@@ -185,7 +186,7 @@ describe('index', () => {
           test: {
             getCodeCoverageSummary: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('builds_coverage.json')),
+              .mockResolvedValue(readTestFileAsJSON('builds_coverage.json')),
           },
           pipelines: {
             listRuns: jest.fn().mockResolvedValue(runs),
@@ -212,7 +213,7 @@ describe('index', () => {
   });
 
   test('streams - releases', async () => {
-    const releasesData = readTestResourceFile('releases.json');
+    const releasesData = readTestFileAsJSON('releases.json');
     AzurePipelines.instance = jest.fn().mockImplementation(() => {
       return new AzurePipelines(
         {
@@ -242,11 +243,3 @@ describe('index', () => {
     expect(releases).toMatchSnapshot();
   });
 });
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}

--- a/sources/backlog-source/test/index.test.ts
+++ b/sources/backlog-source/test/index.test.ts
@@ -2,9 +2,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {Backlog, BacklogConfig} from '../src/backlog';
@@ -32,18 +33,11 @@ describe('index', () => {
     Backlog.instance = backlogInstance;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
-
-  function readTestResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-  }
 
   test('spec', async () => {
     const source = new sut.BacklogSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -63,7 +57,7 @@ describe('index', () => {
     const fnIssuesFunc = jest.fn();
 
     Backlog.instance = jest.fn().mockImplementation(() => {
-      const issuesResource: any[] = readTestResourceFile('issues.json');
+      const issuesResource: any[] = readTestFileAsJSON('issues.json');
       return new Backlog(
         {
           get: fnIssuesFunc.mockResolvedValue({
@@ -85,18 +79,18 @@ describe('index', () => {
     }
 
     expect(fnIssuesFunc).toHaveBeenCalledTimes(4);
-    expect(issues).toStrictEqual(readTestResourceFile('issues.json'));
+    expect(issues).toStrictEqual(readTestFileAsJSON('issues.json'));
   });
 
   test('streams - projects, use full_refresh sync mode', async () => {
     const fnProjectsFunc = jest.fn();
 
     Backlog.instance = jest.fn().mockImplementation(() => {
-      const projecjtsResource: any[] = readTestResourceFile('projects.json');
+      const projectsResource: any[] = readTestFileAsJSON('projects.json');
       return new Backlog(
         {
           get: fnProjectsFunc.mockResolvedValue({
-            data: projecjtsResource,
+            data: projectsResource,
           }),
         } as any,
         {} as BacklogConfig,
@@ -114,14 +108,14 @@ describe('index', () => {
     }
 
     expect(fnProjectsFunc).toHaveBeenCalledTimes(2);
-    expect(projects).toStrictEqual(readTestResourceFile('projects.json'));
+    expect(projects).toStrictEqual(readTestFileAsJSON('projects.json'));
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
     const fnUsersFunc = jest.fn();
 
     Backlog.instance = jest.fn().mockImplementation(() => {
-      const usersResource: any[] = readTestResourceFile('users.json');
+      const usersResource: any[] = readTestFileAsJSON('users.json');
       return new Backlog(
         {
           get: fnUsersFunc.mockResolvedValue({
@@ -143,6 +137,6 @@ describe('index', () => {
     }
 
     expect(fnUsersFunc).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 });

--- a/sources/bamboohr-source/test/index.test.ts
+++ b/sources/bamboohr-source/test/index.test.ts
@@ -2,9 +2,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {BambooHR} from '../src/bamboohr';
@@ -26,24 +27,17 @@ describe('index', () => {
     BambooHR.instance = bambooHRInstance;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
 
-  function readTestResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-  }
-
-  const fieldsResource: any[] = readTestResourceFile('fields_input.json');
-  const usersResource: any = readTestResourceFile('users_input.json');
-  const userDetailsResource: any[] = readTestResourceFile(
+  const fieldsResource: any[] = readTestFileAsJSON('fields_input.json');
+  const usersResource: any = readTestFileAsJSON('users_input.json');
+  const userDetailsResource: any[] = readTestFileAsJSON(
     'user_details_input.json'
   );
 
   test('spec', async () => {
     const source = new sut.BambooHRSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/bitbucket-server-source/test/index.test.ts
+++ b/sources/bitbucket-server-source/test/index.test.ts
@@ -2,18 +2,15 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {BitbucketServer} from '../src/bitbucket-server';
 import {Prefix as MEP} from '../src/bitbucket-server/more-endpoint-methods';
 import * as sut from '../src/index';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -26,7 +23,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.BitbucketServerSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/bitbucket-source/test/index.test.ts
+++ b/sources/bitbucket-source/test/index.test.ts
@@ -3,11 +3,12 @@ import {
   AirbyteSourceLogger,
   AirbyteSpec,
   customStreamsTest,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   readTestResourceAsJSON,
   sourceReadTest,
   sourceSchemaTest,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {Bitbucket} from '../src/bitbucket';
@@ -17,9 +18,6 @@ import {setupBitbucketInstance} from './utils';
 
 const bitbucketInstance = Bitbucket.instance;
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -37,7 +35,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/buildkite-source/test/index.test.ts
+++ b/sources/buildkite-source/test/index.test.ts
@@ -3,20 +3,14 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import {Buildkite} from '../src/buildkite/buildkite';
 import * as sut from '../src/index';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -37,7 +31,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.BuildkiteSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -82,7 +76,7 @@ describe('index', () => {
         null,
         {
           get: fnOrganizationsList.mockResolvedValue({
-            data: readTestResourceFile('organizations.json'),
+            data: readTestFileAsJSON('organizations.json'),
           }),
         } as any,
         new Date('2010-03-27T14:03:51-0800')
@@ -101,7 +95,7 @@ describe('index', () => {
     }
     expect(fnOrganizationsList).toHaveBeenCalledTimes(1);
     expect(organizations).toStrictEqual(
-      readTestResourceFile('organizations.json')
+      readTestFileAsJSON('organizations.json')
     );
   });
   test('streams - pipelines, use full_refresh sync mode', async () => {
@@ -112,7 +106,7 @@ describe('index', () => {
           request: fnPipelinesList.mockResolvedValue({
             organization: {
               pipelines: {
-                edges: readTestResourceFile('pipelines_input.json'),
+                edges: readTestFileAsJSON('pipelines_input.json'),
                 pageInfo: {
                   endCursor: undefined,
                 },
@@ -136,7 +130,7 @@ describe('index', () => {
       pipelines.push(pipeline);
     }
     expect(fnPipelinesList).toHaveBeenCalledTimes(1);
-    expect(pipelines).toStrictEqual(readTestResourceFile('pipelines.json'));
+    expect(pipelines).toStrictEqual(readTestFileAsJSON('pipelines.json'));
   });
   test('streams - builds, use full_refresh sync mode', async () => {
     const fnBuildsList = jest.fn();
@@ -147,7 +141,7 @@ describe('index', () => {
             .mockResolvedValueOnce({
               organization: {
                 pipelines: {
-                  edges: readTestResourceFile('pipelines_input.json'),
+                  edges: readTestFileAsJSON('pipelines_input.json'),
                   pageInfo: {
                     endCursor: undefined,
                   },
@@ -157,7 +151,7 @@ describe('index', () => {
             .mockResolvedValueOnce({
               pipeline: {
                 builds: {
-                  edges: readTestResourceFile('builds_input.json'),
+                  edges: readTestFileAsJSON('builds_input.json'),
                   pageInfo: {
                     endCursor: undefined,
                   },
@@ -181,6 +175,6 @@ describe('index', () => {
       builds.push(build);
     }
     expect(fnBuildsList).toHaveBeenCalledTimes(2);
-    expect(builds).toStrictEqual(readTestResourceFile('builds.json'));
+    expect(builds).toStrictEqual(readTestFileAsJSON('builds.json'));
   });
 });

--- a/sources/circleci-source/test/index.test.ts
+++ b/sources/circleci-source/test/index.test.ts
@@ -3,21 +3,16 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {Dictionary} from 'ts-essentials';
 
 import {CircleCI, CircleCIConfig} from '../src/circleci/circleci';
 import * as sut from '../src/index';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -50,7 +45,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.CircleCISource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -85,7 +80,7 @@ describe('index', () => {
     CircleCI.instance = jest.fn().mockImplementation(() => {
       return new CircleCI(sourceConfig, logger, null, {
         get: fnProjectsList.mockResolvedValue({
-          data: readTestResourceFile('projects.json'),
+          data: readTestFileAsJSON('projects.json'),
           status: 200,
         }),
       } as any);
@@ -103,7 +98,7 @@ describe('index', () => {
       projects.push(project);
     }
     expect(fnProjectsList).toHaveBeenCalledTimes(1);
-    expect(projects).toStrictEqual([readTestResourceFile('projects.json')]);
+    expect(projects).toStrictEqual([readTestFileAsJSON('projects.json')]);
   });
 
   test('streams - pipelines, use full_refresh sync mode', async () => {
@@ -112,7 +107,7 @@ describe('index', () => {
       get: fnPipelinesList
         .mockResolvedValueOnce({
           data: {
-            items: readTestResourceFile('pipelines_input.json'),
+            items: readTestFileAsJSON('pipelines_input.json'),
             next_page_token: null,
           },
           status: 200,
@@ -143,8 +138,8 @@ describe('index', () => {
       state = pipelinesStream.getUpdatedState(state, pipeline);
     }
     expect(fnPipelinesList).toHaveBeenCalledTimes(5); // fetchPipelines once + 1 fetchWorkflows per pipeline
-    expect(pipelines).toStrictEqual(readTestResourceFile('pipelines.json'));
-    expect(state).toStrictEqual(readTestResourceFile('pipelines_state.json'));
+    expect(pipelines).toStrictEqual(readTestFileAsJSON('pipelines.json'));
+    expect(state).toStrictEqual(readTestFileAsJSON('pipelines_state.json'));
   });
 
   test('streams - tests, use full_refresh sync mode', async () => {
@@ -154,28 +149,28 @@ describe('index', () => {
         get: fnTestsList
           .mockResolvedValueOnce({
             data: {
-              items: readTestResourceFile('pipeline_input.json'),
+              items: readTestFileAsJSON('pipeline_input.json'),
               next_page_token: null,
             },
             status: 200,
           })
           .mockResolvedValueOnce({
             data: {
-              items: readTestResourceFile('workflows_input.json'),
+              items: readTestFileAsJSON('workflows_input.json'),
               next_page_token: null,
             },
             status: 200,
           })
           .mockResolvedValueOnce({
             data: {
-              items: readTestResourceFile('jobs_input.json'),
+              items: readTestFileAsJSON('jobs_input.json'),
               next_page_token: null,
             },
             status: 200,
           })
           .mockResolvedValueOnce({
             data: {
-              items: readTestResourceFile('tests_input.json'),
+              items: readTestFileAsJSON('tests_input.json'),
               next_page_token: null,
             },
             status: 200,
@@ -195,7 +190,7 @@ describe('index', () => {
       tests.push(test);
     }
     expect(fnTestsList).toHaveBeenCalledTimes(4);
-    expect(tests).toStrictEqual(readTestResourceFile('tests.json'));
+    expect(tests).toStrictEqual(readTestFileAsJSON('tests.json'));
   });
 
   test('filter projects', () => {

--- a/sources/clickup-source/test/index.test.ts
+++ b/sources/clickup-source/test/index.test.ts
@@ -3,17 +3,14 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {ClickUp} from '../src/clickup';
 import * as sut from '../src/index';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -26,7 +23,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.ClickUpSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/customer-io-source/test/index.test.ts
+++ b/sources/customer-io-source/test/index.test.ts
@@ -4,16 +4,13 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs';
 import {VError} from 'verror';
 
 import {CustomerIOSource} from '../src';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   let source: CustomerIOSource;
@@ -36,7 +33,7 @@ describe('index', () => {
   describe('spec', () => {
     it('matches the spec', async () => {
       await expect(source.spec()).resolves.toStrictEqual(
-        new AirbyteSpec(readResourceFile('spec.json'))
+        new AirbyteSpec(readResourceAsJSON('spec.json'))
       );
     });
   });

--- a/sources/datadog-source/test/index.test.ts
+++ b/sources/datadog-source/test/index.test.ts
@@ -4,22 +4,16 @@ import {
   AirbyteSourceLogger,
   AirbyteSpec,
   customStreamsTest,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   sourceCheckTest,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {Datadog, DatadogClient, DatadogConfig} from '../src/datadog';
 import * as sut from '../src/index';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -32,7 +26,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -79,7 +73,7 @@ describe('index', () => {
   });
 
   test('streams - incidents, use full_refresh sync mode', async () => {
-    const res = readTestResourceFile('incidents.json');
+    const res = readTestFileAsJSON('incidents.json');
     const pagination = new v2.IncidentResponseMetaPagination();
     Object.assign(pagination, res.meta.pagination);
     const incidents = {...res, meta: {pagination}};
@@ -108,7 +102,7 @@ describe('index', () => {
   });
 
   test('streams - incidents, use incremental sync mode', async () => {
-    const res = readTestResourceFile('incidents.json');
+    const res = readTestFileAsJSON('incidents.json');
     const pagination = new v2.IncidentResponseMetaPagination();
     Object.assign(pagination, res.meta.pagination);
     const incidents = {...res, meta: {pagination}};
@@ -142,7 +136,7 @@ describe('index', () => {
   });
 
   test('streams - metrics, use full_refresh sync mode', async () => {
-    const metricsResponse = readTestResourceFile('metrics.json');
+    const metricsResponse = readTestFileAsJSON('metrics.json');
     Datadog.instance = jest.fn().mockReturnValue(
       new Datadog(
         {
@@ -187,7 +181,7 @@ describe('index', () => {
   });
 
   test('streams - metrics, use incremental sync mode', async () => {
-    const metricsResponse = readTestResourceFile('metrics.json');
+    const metricsResponse = readTestFileAsJSON('metrics.json');
     Datadog.instance = jest.fn().mockReturnValue(
       new Datadog(
         {
@@ -237,7 +231,7 @@ describe('index', () => {
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
-    const users = readTestResourceFile('users.json');
+    const users = readTestFileAsJSON('users.json');
     Datadog.instance = jest.fn().mockReturnValue(
       new Datadog(
         {
@@ -263,7 +257,7 @@ describe('index', () => {
   });
 
   test('streams - users, use incremental sync mode', async () => {
-    const users = readTestResourceFile('users.json');
+    const users = readTestFileAsJSON('users.json');
     Datadog.instance = jest.fn().mockReturnValue(
       new Datadog(
         {
@@ -294,7 +288,7 @@ describe('index', () => {
   });
 
   test('streams - slos', async () => {
-    const res = readTestResourceFile('slos.json');
+    const res = readTestFileAsJSON('slos.json');
     const pagination = new v1.SearchSLOResponseMetaPage();
     Object.assign(pagination, res.meta.pagination);
     const slos = {...res, meta: {pagination}};

--- a/sources/docker-source/test/index.test.ts
+++ b/sources/docker-source/test/index.test.ts
@@ -1,10 +1,11 @@
 import {
+  readResourceAsJSON,
+  readTestFileAsJSON,
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {Docker} from '../src/docker';
@@ -12,13 +13,7 @@ import * as sut from '../src/index';
 
 const dockerInstance = Docker.instance;
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -35,7 +30,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.DockerSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -112,7 +107,7 @@ describe('index', () => {
           undefined
         ),
         getTags: fnTagsFunc.mockImplementation(async function () {
-          return readTestResourceFile('tags.json');
+          return readTestFileAsJSON('tags.json');
         }),
       };
     });
@@ -135,6 +130,6 @@ describe('index', () => {
     }
 
     expect(fnTagsFunc).toHaveBeenCalledTimes(1);
-    expect(tags).toStrictEqual(readTestResourceFile('tags.json'));
+    expect(tags).toStrictEqual(readTestFileAsJSON('tags.json'));
   });
 });

--- a/sources/faros-graphdoctor-source/test/index.test.ts
+++ b/sources/faros-graphdoctor-source/test/index.test.ts
@@ -1,9 +1,9 @@
 import {
+  readResourceAsJSON,
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
 import {DataQualityTests} from '../src/streams/data-quality-tests';
@@ -95,9 +95,6 @@ function getQueryResponse(query: string): Record<string, any> | null {
   return res;
 }
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -117,7 +114,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.FarosGraphDoctorSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/files-source/test/index.test.ts
+++ b/sources/files-source/test/index.test.ts
@@ -2,9 +2,9 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import {FilesConfig, S3Reader} from '../lib/files-reader';
@@ -35,15 +35,12 @@ describe('index', () => {
     FilesReader.instance = files;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
 
   const source = new sut.FilesSource(logger);
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/firehydrant-source/test/index.test.ts
+++ b/sources/firehydrant-source/test/index.test.ts
@@ -3,20 +3,14 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import {FireHydrant} from '../src/firehydrant/firehydrant';
 import * as sut from '../src/index';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -37,7 +31,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.FireHydrantSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -81,7 +75,7 @@ describe('index', () => {
         {
           get: fnIncidentsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('incidents.json'),
+              data: readTestFileAsJSON('incidents.json'),
               pagination: {
                 next: null,
               },
@@ -101,7 +95,7 @@ describe('index', () => {
       incidents.push(incident);
     }
     expect(fnIncidentsList).toHaveBeenCalledTimes(4);
-    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+    expect(incidents).toStrictEqual(readTestFileAsJSON('incidents.json'));
   });
 
   test('streams - teams, use full_refresh sync mode', async () => {
@@ -111,7 +105,7 @@ describe('index', () => {
         {
           get: fnTeamsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('teams.json'),
+              data: readTestFileAsJSON('teams.json'),
               pagination: {
                 next: null,
               },
@@ -131,7 +125,7 @@ describe('index', () => {
       teams.push(team);
     }
     expect(fnTeamsList).toHaveBeenCalledTimes(1);
-    expect(teams).toStrictEqual(readTestResourceFile('teams.json'));
+    expect(teams).toStrictEqual(readTestFileAsJSON('teams.json'));
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
@@ -141,7 +135,7 @@ describe('index', () => {
         {
           get: fnUsersList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('users.json'),
+              data: readTestFileAsJSON('users.json'),
               pagination: {
                 next: null,
               },
@@ -161,6 +155,6 @@ describe('index', () => {
       users.push(user);
     }
     expect(fnUsersList).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 });

--- a/sources/github-source/test/index.test.ts
+++ b/sources/github-source/test/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  readResourceAsJSON,
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
@@ -22,9 +23,6 @@ import {
   setupGitHubInstance,
 } from './utils';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -44,7 +42,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/gitlab-ci-source/test/index.test.ts
+++ b/sources/gitlab-ci-source/test/index.test.ts
@@ -2,9 +2,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import {Gitlab} from '../src/gitlab';
 import * as sut from '../src/index';
@@ -17,13 +18,6 @@ const config = {
 
 const gitlabInstance = Gitlab.instance;
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -40,7 +34,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.GitlabCiSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -77,7 +71,7 @@ describe('index', () => {
         {
           Groups: {
             show: fnGroupFunc.mockResolvedValue(
-              readTestResourceFile('groups.json')
+              readTestFileAsJSON('groups.json')
             ),
           },
         },
@@ -96,7 +90,7 @@ describe('index', () => {
 
     expect(fnGroupFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(groups))).toStrictEqual(
-      readTestResourceFile('groups-response.json')
+      readTestFileAsJSON('groups-response.json')
     );
   });
   test('streams - projects, use full_refresh sync mode', async () => {
@@ -107,13 +101,13 @@ describe('index', () => {
         {
           Projects: {
             show: fnProjectsFunc.mockResolvedValue(
-              readTestResourceFile('projects.json')
+              readTestFileAsJSON('projects.json')
             ),
           },
           Groups: {
             show: jest
               .fn()
-              .mockResolvedValue(readTestResourceFile('groups.json')),
+              .mockResolvedValue(readTestFileAsJSON('groups.json')),
           },
         },
         config
@@ -131,7 +125,7 @@ describe('index', () => {
 
     expect(fnProjectsFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(projects))).toStrictEqual(
-      readTestResourceFile('projects-response.json')
+      readTestFileAsJSON('projects-response.json')
     );
   });
   test('streams - pipelines, use full_refresh sync mode', async () => {
@@ -142,7 +136,7 @@ describe('index', () => {
         {
           Pipelines: {
             all: fnPipelinesFunc.mockResolvedValue({
-              data: readTestResourceFile('pipelines.json'),
+              data: readTestFileAsJSON('pipelines.json'),
             }),
           },
         },
@@ -165,7 +159,7 @@ describe('index', () => {
 
     expect(fnPipelinesFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(pipelines))).toStrictEqual(
-      readTestResourceFile('pipelines-response.json')
+      readTestFileAsJSON('pipelines-response.json')
     );
   });
   test('streams - pipelines, use incremental sync mode', async () => {
@@ -176,7 +170,7 @@ describe('index', () => {
         {
           Pipelines: {
             all: fnPipelinesFunc.mockResolvedValue({
-              data: readTestResourceFile('pipelines.json'),
+              data: readTestFileAsJSON('pipelines.json'),
             }),
           },
         },
@@ -201,7 +195,7 @@ describe('index', () => {
 
     expect(fnPipelinesFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(pipelines))).toStrictEqual(
-      readTestResourceFile('pipelines-response.json')
+      readTestFileAsJSON('pipelines-response.json')
     );
     expect(
       pipelinesStream.getUpdatedState(pipelinesState, {
@@ -219,7 +213,7 @@ describe('index', () => {
         {
           Jobs: {
             showPipelineJobs: fnJobsFunc.mockResolvedValue({
-              data: readTestResourceFile('jobs.json'),
+              data: readTestFileAsJSON('jobs.json'),
             }),
           },
         },
@@ -241,7 +235,7 @@ describe('index', () => {
 
     expect(fnJobsFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(jobs))).toStrictEqual(
-      readTestResourceFile('jobs-response.json')
+      readTestFileAsJSON('jobs-response.json')
     );
   });
 });

--- a/sources/jenkins-source/test/index.test.ts
+++ b/sources/jenkins-source/test/index.test.ts
@@ -1,10 +1,11 @@
 import {
+  readResourceAsJSON,
+  readTestFileAsJSON,
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import jenkinsClient from 'jenkins';
 import {mocked} from 'jest-mock';
 import {VError} from 'verror';
@@ -13,13 +14,7 @@ import * as sut from '../src/index';
 
 jest.mock('jenkins');
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -32,7 +27,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.JenkinsSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -82,7 +77,7 @@ describe('index', () => {
       info: jest.fn().mockResolvedValue({}),
       job: {
         list: fnJobList.mockImplementation(async () =>
-          readTestResourceFile('jobs.json')
+          readTestFileAsJSON('jobs.json')
         ),
       },
     } as any);
@@ -157,7 +152,7 @@ describe('index', () => {
       job: {
         list: jest
           .fn()
-          .mockImplementation(async () => readTestResourceFile('jobs.json')),
+          .mockImplementation(async () => readTestFileAsJSON('jobs.json')),
       },
     } as any);
     const source = new sut.JenkinsSource(logger);
@@ -212,7 +207,7 @@ describe('index', () => {
       job: {
         list: jest
           .fn()
-          .mockImplementation(async () => readTestResourceFile('jobs.json')),
+          .mockImplementation(async () => readTestFileAsJSON('jobs.json')),
       },
     } as any);
     const source = new sut.JenkinsSource(logger);

--- a/sources/jira-source/test/index.test.ts
+++ b/sources/jira-source/test/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  readResourceAsJSON,
   AirbyteLogger,
   AirbyteLogLevel,
   AirbyteSpec,
@@ -18,9 +19,6 @@ import {CustomStreamNames, RunMode} from '../src/streams/common';
 import {FarosIssuePullRequests} from '../src/streams/faros_issue_pull_requests';
 import {paginate, setupJiraInstance} from './utils/test-utils';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 afterEach(() => {
   jest.useRealTimers();
@@ -42,7 +40,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/opsgenie-source/test/index.test.ts
+++ b/sources/opsgenie-source/test/index.test.ts
@@ -3,20 +3,13 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
 import {OpsGenie} from '../src/opsgenie/opsgenie';
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -37,7 +30,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.OpsGenieSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -82,7 +75,7 @@ describe('index', () => {
         {
           get: fnIncidentsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('incidents.json'),
+              data: readTestFileAsJSON('incidents.json'),
               totalCount: 3,
             },
           }),
@@ -102,7 +95,7 @@ describe('index', () => {
       incidents.push(incident);
     }
     expect(fnIncidentsList).toHaveBeenCalledTimes(4);
-    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+    expect(incidents).toStrictEqual(readTestFileAsJSON('incidents.json'));
   });
 
   test('streams - incidents, paginate', async () => {
@@ -112,7 +105,7 @@ describe('index', () => {
         {
           get: fnIncidentsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('incidents.json'),
+              data: readTestFileAsJSON('incidents.json'),
               totalCount: 2,
             },
           }),
@@ -141,7 +134,7 @@ describe('index', () => {
         {
           get: fnTeamsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('teams.json'),
+              data: readTestFileAsJSON('teams.json'),
             },
           }),
         } as any,
@@ -160,7 +153,7 @@ describe('index', () => {
       teams.push(team);
     }
     expect(fnTeamsList).toHaveBeenCalledTimes(1);
-    expect(teams).toStrictEqual(readTestResourceFile('teams.json'));
+    expect(teams).toStrictEqual(readTestFileAsJSON('teams.json'));
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
@@ -170,7 +163,7 @@ describe('index', () => {
         {
           get: fnUsersList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('users.json'),
+              data: readTestFileAsJSON('users.json'),
               totalCount: 1,
             },
           }),
@@ -190,7 +183,7 @@ describe('index', () => {
       users.push(user);
     }
     expect(fnUsersList).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 
   test('streams - users, paginate', async () => {
@@ -200,7 +193,7 @@ describe('index', () => {
         {
           get: fnUsersList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('users.json'),
+              data: readTestFileAsJSON('users.json'),
               totalCount: 2,
             },
           }),
@@ -229,7 +222,7 @@ describe('index', () => {
         {
           get: fnAlertsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('alerts.json'),
+              data: readTestFileAsJSON('alerts.json'),
               totalCount: 2,
             },
           }),
@@ -249,7 +242,7 @@ describe('index', () => {
       alerts.push(alert);
     }
     expect(fnAlertsList).toHaveBeenCalledTimes(1);
-    expect(alerts).toStrictEqual(readTestResourceFile('alerts.json'));
+    expect(alerts).toStrictEqual(readTestFileAsJSON('alerts.json'));
   });
 
   test('streams - alerts, paginate', async () => {
@@ -259,7 +252,7 @@ describe('index', () => {
         {
           get: fnAlertsList.mockResolvedValue({
             data: {
-              data: readTestResourceFile('alerts.json'),
+              data: readTestFileAsJSON('alerts.json'),
               totalCount: 2,
             },
           }),

--- a/sources/pagerduty-source/test/index.test.ts
+++ b/sources/pagerduty-source/test/index.test.ts
@@ -3,21 +3,15 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import * as sut from '../src/index';
 import {Incident, Pagerduty} from '../src/pagerduty';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -38,7 +32,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.PagerdutySource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -83,7 +77,7 @@ describe('index', () => {
   test('streams - incidentLogEntries, use full_refresh sync mode', async () => {
     const fnIncidentLogEntriesList = jest.fn();
 
-    const expectedEntries = readTestResourceFile('incidentLogEntries.json').map(
+    const expectedEntries = readTestFileAsJSON('incidentLogEntries.json').map(
       (entry) => {
         return {...entry, created_at: new Date().toISOString()};
       }
@@ -125,7 +119,7 @@ describe('index', () => {
         {
           get: fnIncidentsList
             .mockResolvedValueOnce({
-              resource: readTestResourceFile('incidents.json'),
+              resource: readTestFileAsJSON('incidents.json'),
             })
             .mockResolvedValue({resource: []}),
         } as unknown as PartialCall,
@@ -145,7 +139,7 @@ describe('index', () => {
     }
 
     expect(fnIncidentsList).toHaveBeenCalledTimes(90);
-    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+    expect(incidents).toStrictEqual(readTestFileAsJSON('incidents.json'));
   });
 
   test('streams - incidents, exclude services', async () => {
@@ -168,14 +162,14 @@ describe('index', () => {
               returnedIncidents = true;
               return {
                 resource: (
-                  readTestResourceFile('incidents.json') as Incident[]
+                  readTestFileAsJSON('incidents.json') as Incident[]
                 ).filter((i) => includeServices.includes(i.service.id)),
               };
             }
             const servicesPathMatch = path.match(/^\/services/);
             if (servicesPathMatch) {
               return {
-                resource: readTestResourceFile('services.json'),
+                resource: readTestFileAsJSON('services.json'),
               };
             }
           }),
@@ -198,7 +192,7 @@ describe('index', () => {
 
     expect(fnList).toHaveBeenCalledTimes(91); // list services once + 90 days
     expect(incidents).toStrictEqual(
-      (readTestResourceFile('incidents.json') as Incident[]).filter(
+      (readTestFileAsJSON('incidents.json') as Incident[]).filter(
         (i) => i.service.summary !== 'Service2'
       )
     );
@@ -215,7 +209,7 @@ describe('index', () => {
               const isPathMatch = path.match(/^\/priorities/);
               if (isPathMatch) {
                 return {
-                  resource: readTestResourceFile('prioritiesResource.json'),
+                  resource: readTestFileAsJSON('prioritiesResource.json'),
                   response: {
                     ok: true,
                   },
@@ -243,7 +237,7 @@ describe('index', () => {
 
     expect(fnPrioritiesResourceList).toHaveBeenCalledTimes(1);
     expect(priorities).toStrictEqual(
-      readTestResourceFile('prioritiesResource.json')
+      readTestFileAsJSON('prioritiesResource.json')
     );
   });
 
@@ -257,7 +251,7 @@ describe('index', () => {
             const isPathMatch = path.match(/^\/services/);
             if (isPathMatch) {
               return {
-                resource: readTestResourceFile('services.json'),
+                resource: readTestFileAsJSON('services.json'),
                 response: {
                   ok: true,
                 },
@@ -281,7 +275,7 @@ describe('index', () => {
     }
 
     expect(fnServicesList).toHaveBeenCalledTimes(1);
-    expect(service).toStrictEqual(readTestResourceFile('services.json'));
+    expect(service).toStrictEqual(readTestFileAsJSON('services.json'));
   });
 
   test('streams - teams, use full_refresh sync mode', async () => {
@@ -294,7 +288,7 @@ describe('index', () => {
             const isPathMatch = path.match(/^\/teams/);
             if (isPathMatch) {
               return {
-                resource: readTestResourceFile('teams.json'),
+                resource: readTestFileAsJSON('teams.json'),
                 response: {
                   ok: true,
                 },
@@ -318,7 +312,7 @@ describe('index', () => {
     }
 
     expect(fnTeamsList).toHaveBeenCalledTimes(1);
-    expect(priorities).toStrictEqual(readTestResourceFile('teams.json'));
+    expect(priorities).toStrictEqual(readTestFileAsJSON('teams.json'));
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
@@ -331,7 +325,7 @@ describe('index', () => {
             const isPathMatch = path.match(/^\/users/);
             if (isPathMatch) {
               return {
-                resource: readTestResourceFile('users.json'),
+                resource: readTestFileAsJSON('users.json'),
               };
             }
           }),
@@ -351,6 +345,6 @@ describe('index', () => {
       users.push(user);
     }
     expect(fnUsersList).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 });

--- a/sources/phabricator-source/test/index.test.ts
+++ b/sources/phabricator-source/test/index.test.ts
@@ -2,22 +2,16 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {DateTime} from 'luxon';
 import VError from 'verror';
 
 import * as sut from '../src/index';
 import {Phabricator} from '../src/phabricator';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -30,7 +24,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.PhabricatorSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -83,7 +77,7 @@ describe('index', () => {
   });
 
   test('streams - repositories', async () => {
-    const repos = readTestResourceFile('repositories.json');
+    const repos = readTestFileAsJSON('repositories.json');
     Phabricator.instance = jest.fn().mockImplementation(() => {
       return new Phabricator(
         undefined,
@@ -120,8 +114,8 @@ describe('index', () => {
   });
 
   test('streams - revisions', async () => {
-    const repos = readTestResourceFile('repositories.json');
-    const revisions = readTestResourceFile('revisions.json');
+    const repos = readTestFileAsJSON('repositories.json');
+    const revisions = readTestFileAsJSON('revisions.json');
     Phabricator.instance = jest.fn().mockImplementation(() => {
       return new Phabricator(
         undefined,
@@ -161,13 +155,13 @@ describe('index', () => {
   });
 
   test('streams - revision_diffs', async () => {
-    const repos = readTestResourceFile('repositories.json');
-    const revisions = readTestResourceFile('revisions.json');
-    const revisionDiffs = readTestResourceFile('revision_diffs.json');
-    const revisionDiffsRecords = readTestResourceFile(
+    const repos = readTestFileAsJSON('repositories.json');
+    const revisions = readTestFileAsJSON('revisions.json');
+    const revisionDiffs = readTestFileAsJSON('revision_diffs.json');
+    const revisionDiffsRecords = readTestFileAsJSON(
       'revision_diffs_records.json'
     );
-    const rawDiff = readTestResourceFile('raw_diff.json');
+    const rawDiff = readTestFileAsJSON('raw_diff.json');
     Phabricator.instance = jest.fn().mockImplementation(() => {
       return new Phabricator(
         undefined,

--- a/sources/semaphoreci-source/test/index.test.ts
+++ b/sources/semaphoreci-source/test/index.test.ts
@@ -3,9 +3,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import * as sut from '../src/index';
@@ -15,13 +16,6 @@ import {
   UNAUTHORIZED_ERROR_MESSAGE,
 } from '../src/semaphoreci/semaphoreci';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 function generateLinkHeaders(first = 1, next = 0, last = 1): any {
   const baseLinkHeader = `<http://mock.com/api/v1alpha/pipelines?page=${first}>; rel="first", <http://mock.com/api/v1alpha/pipelines?page=${last}>; rel="last"`;
@@ -81,7 +75,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.SemaphoreCISource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -95,7 +89,7 @@ describe('index', () => {
 
       const source = new sut.SemaphoreCISource(logger);
       await expect(
-        source.checkConnection(readTestResourceFile('config.json'))
+        source.checkConnection(readTestFileAsJSON('config.json'))
       ).resolves.toStrictEqual([true, undefined]);
     });
 
@@ -108,7 +102,7 @@ describe('index', () => {
 
       const source = new sut.SemaphoreCISource(logger);
       await expect(
-        source.checkConnection(readTestResourceFile('invalid_config.json'))
+        source.checkConnection(readTestFileAsJSON('invalid_config.json'))
       ).resolves.toStrictEqual([false, new VError(UNAUTHORIZED_ERROR_MESSAGE)]);
     });
 
@@ -121,7 +115,7 @@ describe('index', () => {
 
       const source = new sut.SemaphoreCISource(logger);
       await expect(
-        source.checkConnection(readTestResourceFile('invalid_config.json'))
+        source.checkConnection(readTestFileAsJSON('invalid_config.json'))
       ).resolves.toStrictEqual([
         false,
         new VError(MISSING_OR_INVISIBLE_RESOURCE_ERROR_MESSAGE),
@@ -137,7 +131,7 @@ describe('index', () => {
 
       const source = new sut.SemaphoreCISource(logger);
       await expect(
-        source.checkConnection(readTestResourceFile('invalid_config.json'))
+        source.checkConnection(readTestFileAsJSON('invalid_config.json'))
       ).resolves.toStrictEqual([
         false,
         new VError('SemaphoreCI API request failed: Error Message'),
@@ -153,12 +147,12 @@ describe('index', () => {
         SemaphoreCI.instance = jest.fn().mockImplementation(() =>
           makeSemaphoreCI({
             get: restClient.mockResolvedValue({
-              data: readTestResourceFile('projects.json'),
+              data: readTestFileAsJSON('projects.json'),
             }),
           })
         );
         const source = new sut.SemaphoreCISource(logger);
-        const streams = source.streams(readTestResourceFile('config.json'));
+        const streams = source.streams(readTestFileAsJSON('config.json'));
 
         const projectsStreams = streams[0];
         const projectsIter = projectsStreams.readRecords(SyncMode.FULL_REFRESH);
@@ -169,7 +163,7 @@ describe('index', () => {
 
         expect(restClient).toHaveBeenCalledTimes(1);
         expect(JSON.parse(JSON.stringify(projects))).toStrictEqual(
-          readTestResourceFile('projects.json')
+          readTestFileAsJSON('projects.json')
         );
       });
 
@@ -180,14 +174,14 @@ describe('index', () => {
           makeSemaphoreCI(
             {
               get: restClient.mockResolvedValue({
-                data: readTestResourceFile('projects.json'),
+                data: readTestFileAsJSON('projects.json'),
               }),
             },
             ['8c3aa2ea-8c59-4b10-83f5-d078cf788adb']
           )
         );
         const source = new sut.SemaphoreCISource(logger);
-        const streams = source.streams(readTestResourceFile('config.json'));
+        const streams = source.streams(readTestFileAsJSON('config.json'));
 
         const projectsStreams = streams[0];
         const projectsIter = projectsStreams.readRecords(SyncMode.FULL_REFRESH);
@@ -198,7 +192,7 @@ describe('index', () => {
 
         expect(restClient).toHaveBeenCalledTimes(1);
         expect(JSON.parse(JSON.stringify(projects))).toStrictEqual(
-          readTestResourceFile('projects-filtered.json')
+          readTestFileAsJSON('projects-filtered.json')
         );
       });
     });
@@ -211,50 +205,50 @@ describe('index', () => {
           makeSemaphoreCI({
             get: restClient
               .mockResolvedValueOnce({
-                data: readTestResourceFile('projects.json'),
+                data: readTestFileAsJSON('projects.json'),
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('pipelines.json'),
+                data: readTestFileAsJSON('pipelines.json'),
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('pipelines-detailed.json'),
+                data: readTestFileAsJSON('pipelines-detailed.json'),
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[0],
+                data: readTestFileAsJSON('jobs-detailed.json')[0],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[1],
+                data: readTestFileAsJSON('jobs-detailed.json')[1],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[2],
+                data: readTestFileAsJSON('jobs-detailed.json')[2],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('pipelines-detailed.json'),
+                data: readTestFileAsJSON('pipelines-detailed.json'),
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[0],
+                data: readTestFileAsJSON('jobs-detailed.json')[0],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[1],
+                data: readTestFileAsJSON('jobs-detailed.json')[1],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[2],
+                data: readTestFileAsJSON('jobs-detailed.json')[2],
                 headers: generateLinkHeaders(),
               }),
           })
         );
 
         const source = new sut.SemaphoreCISource(logger);
-        const streams = source.streams(readTestResourceFile('config.json'));
+        const streams = source.streams(readTestFileAsJSON('config.json'));
 
         const pipelinesStreams = streams[1];
         const pipelineIter = pipelinesStreams.readRecords(
@@ -275,7 +269,7 @@ describe('index', () => {
           'pipelines?page=1&project_id=bea7e6ed-911e-4172-80f8-7ab58b541a86'
         );
         expect(pipelines).toStrictEqual(
-          readTestResourceFile('pipelines-converted.json')
+          readTestFileAsJSON('pipelines-converted.json')
         );
       });
 
@@ -287,27 +281,27 @@ describe('index', () => {
             {
               get: restClient
                 .mockResolvedValueOnce({
-                  data: readTestResourceFile('projects.json'),
+                  data: readTestFileAsJSON('projects.json'),
                   headers: generateLinkHeaders(),
                 })
                 .mockResolvedValueOnce({
-                  data: readTestResourceFile('pipelines.json'),
+                  data: readTestFileAsJSON('pipelines.json'),
                   headers: generateLinkHeaders(),
                 })
                 .mockResolvedValueOnce({
-                  data: readTestResourceFile('pipelines-detailed.json'),
+                  data: readTestFileAsJSON('pipelines-detailed.json'),
                   headers: generateLinkHeaders(),
                 })
                 .mockResolvedValueOnce({
-                  data: readTestResourceFile('jobs-detailed.json')[0],
+                  data: readTestFileAsJSON('jobs-detailed.json')[0],
                   headers: generateLinkHeaders(),
                 })
                 .mockResolvedValueOnce({
-                  data: readTestResourceFile('jobs-detailed.json')[1],
+                  data: readTestFileAsJSON('jobs-detailed.json')[1],
                   headers: generateLinkHeaders(),
                 })
                 .mockResolvedValueOnce({
-                  data: readTestResourceFile('jobs-detailed.json')[2],
+                  data: readTestFileAsJSON('jobs-detailed.json')[2],
                   headers: generateLinkHeaders(),
                 }),
             },
@@ -317,7 +311,7 @@ describe('index', () => {
         );
 
         const source = new sut.SemaphoreCISource(logger);
-        const streams = source.streams(readTestResourceFile('config.json'));
+        const streams = source.streams(readTestFileAsJSON('config.json'));
 
         const pipelinesStreams = streams[1];
         const pipelineIter = pipelinesStreams.readRecords(
@@ -338,7 +332,7 @@ describe('index', () => {
           'pipelines?page=1&project_id=bea7e6ed-911e-4172-80f8-7ab58b541a86'
         );
         expect(pipelines).toStrictEqual([
-          readTestResourceFile('pipelines-converted.json')[0],
+          readTestFileAsJSON('pipelines-converted.json')[0],
         ]);
       });
 
@@ -349,34 +343,34 @@ describe('index', () => {
           makeSemaphoreCI({
             get: restClient
               .mockResolvedValueOnce({
-                data: readTestResourceFile('projects.json'),
+                data: readTestFileAsJSON('projects.json'),
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: [readTestResourceFile('pipelines.json')[0]],
+                data: [readTestFileAsJSON('pipelines.json')[0]],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('pipelines-detailed.json'),
+                data: readTestFileAsJSON('pipelines-detailed.json'),
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[0],
+                data: readTestFileAsJSON('jobs-detailed.json')[0],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[1],
+                data: readTestFileAsJSON('jobs-detailed.json')[1],
                 headers: generateLinkHeaders(),
               })
               .mockResolvedValueOnce({
-                data: readTestResourceFile('jobs-detailed.json')[2],
+                data: readTestFileAsJSON('jobs-detailed.json')[2],
                 headers: generateLinkHeaders(),
               }),
           })
         );
 
         const source = new sut.SemaphoreCISource(logger);
-        const streams = source.streams(readTestResourceFile('config.json'));
+        const streams = source.streams(readTestFileAsJSON('config.json'));
 
         const pipelinesStreams = streams[1];
         const pipelineIter = pipelinesStreams.readRecords(
@@ -397,7 +391,7 @@ describe('index', () => {
           'pipelines?page=1&project_id=bea7e6ed-911e-4172-80f8-7ab58b541a86&branch_name=main'
         );
         expect(pipelines).toStrictEqual([
-          readTestResourceFile('pipelines-converted.json')[0],
+          readTestFileAsJSON('pipelines-converted.json')[0],
         ]);
       });
 
@@ -405,79 +399,79 @@ describe('index', () => {
         const restClient = jest.fn();
         const mockGet = restClient
           .mockResolvedValueOnce({
-            data: readTestResourceFile('projects.json'),
+            data: readTestFileAsJSON('projects.json'),
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('pipelines.json'),
+            data: readTestFileAsJSON('pipelines.json'),
             headers: generateLinkHeaders(1, 2, 2),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('pipelines.json'),
+            data: readTestFileAsJSON('pipelines.json'),
             headers: generateLinkHeaders(1, 0, 2),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('pipelines-detailed.json'),
+            data: readTestFileAsJSON('pipelines-detailed.json'),
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[0],
+            data: readTestFileAsJSON('jobs-detailed.json')[0],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[1],
+            data: readTestFileAsJSON('jobs-detailed.json')[1],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[2],
+            data: readTestFileAsJSON('jobs-detailed.json')[2],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('pipelines-detailed.json'),
+            data: readTestFileAsJSON('pipelines-detailed.json'),
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[0],
+            data: readTestFileAsJSON('jobs-detailed.json')[0],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[1],
+            data: readTestFileAsJSON('jobs-detailed.json')[1],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[2],
+            data: readTestFileAsJSON('jobs-detailed.json')[2],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('pipelines-detailed.json'),
+            data: readTestFileAsJSON('pipelines-detailed.json'),
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[0],
+            data: readTestFileAsJSON('jobs-detailed.json')[0],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[1],
+            data: readTestFileAsJSON('jobs-detailed.json')[1],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[2],
+            data: readTestFileAsJSON('jobs-detailed.json')[2],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('pipelines-detailed.json'),
+            data: readTestFileAsJSON('pipelines-detailed.json'),
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[0],
+            data: readTestFileAsJSON('jobs-detailed.json')[0],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[1],
+            data: readTestFileAsJSON('jobs-detailed.json')[1],
             headers: generateLinkHeaders(),
           })
           .mockResolvedValueOnce({
-            data: readTestResourceFile('jobs-detailed.json')[2],
+            data: readTestFileAsJSON('jobs-detailed.json')[2],
             headers: generateLinkHeaders(),
           });
 
@@ -488,7 +482,7 @@ describe('index', () => {
         );
 
         const source = new sut.SemaphoreCISource(logger);
-        const streams = source.streams(readTestResourceFile('config.json'));
+        const streams = source.streams(readTestFileAsJSON('config.json'));
 
         const pipelinesStreams = streams[1];
         const pipelineIter = pipelinesStreams.readRecords(
@@ -514,8 +508,8 @@ describe('index', () => {
           'pipelines?page=2&project_id=bea7e6ed-911e-4172-80f8-7ab58b541a86'
         );
         expect(pipelines).toStrictEqual([
-          ...readTestResourceFile('pipelines-converted.json'),
-          ...readTestResourceFile('pipelines-converted.json'),
+          ...readTestFileAsJSON('pipelines-converted.json'),
+          ...readTestFileAsJSON('pipelines-converted.json'),
         ]);
       });
     });

--- a/sources/servicenow-source/test/index.test.ts
+++ b/sources/servicenow-source/test/index.test.ts
@@ -2,9 +2,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import * as sut from '../src/index';
@@ -14,13 +15,6 @@ import {
   ServiceNowConfig,
 } from '../src/servicenow/servicenow';
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -30,9 +24,9 @@ describe('index', () => {
       : AirbyteLogLevel.FATAL
   );
 
-  const incidents = readTestResourceFile('incidents.json');
-  const incidentsRest = readTestResourceFile('incidentsRest.json');
-  const users = readTestResourceFile('users.json');
+  const incidents = readTestFileAsJSON('incidents.json');
+  const incidentsRest = readTestFileAsJSON('incidentsRest.json');
+  const users = readTestFileAsJSON('users.json');
   const listIncidents = jest.fn();
   const listUsers = jest.fn();
   const getCmdbCi = jest.fn();
@@ -72,7 +66,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.ServiceNowSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/sheets-source/test/index.test.ts
+++ b/sources/sheets-source/test/index.test.ts
@@ -2,9 +2,9 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import path from 'path';
 import {VError} from 'verror';
 
@@ -25,14 +25,11 @@ describe('index', () => {
     SheetsReader.instance = sheets;
   });
 
-  function readResourceFile(fileName: string): any {
-    return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-  }
 
   test('spec', async () => {
     const source = new sut.SheetsSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/shortcut-source/test/index.test.ts
+++ b/sources/shortcut-source/test/index.test.ts
@@ -2,22 +2,15 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
 import {Shortcut, ShortcutConfig} from '../src/shortcut';
 
 const shortcutInstance = Shortcut.instance;
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -34,7 +27,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.ShortcutSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -45,7 +38,7 @@ describe('index', () => {
         {} as ShortcutConfig,
         {
           listProjects: fnProjectsFunc.mockResolvedValue({
-            data: readTestResourceFile('projects.json'),
+            data: readTestFileAsJSON('projects.json'),
           }),
           hasNextPage: jest.fn(),
         } as any
@@ -74,7 +67,7 @@ describe('index', () => {
         } as ShortcutConfig,
         {
           listProjects: fnProjectsFunc.mockResolvedValue(
-            readTestResourceFile('projects.json')
+            readTestFileAsJSON('projects.json')
           ),
           hasNextPage: jest.fn(),
         } as any
@@ -95,7 +88,7 @@ describe('index', () => {
     }
     expect(fnProjectsFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(projects))).toStrictEqual(
-      readTestResourceFile('projects.json')
+      readTestFileAsJSON('projects.json')
     );
   });
 
@@ -111,7 +104,7 @@ describe('index', () => {
         } as ShortcutConfig,
         {
           listIterations: fnIterationsFunc.mockResolvedValue(
-            readTestResourceFile('iterations.json')
+            readTestFileAsJSON('iterations.json')
           ),
           hasNextPage: jest.fn(),
         } as any
@@ -132,7 +125,7 @@ describe('index', () => {
     }
     expect(fnIterationsFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(iterations))).toStrictEqual(
-      readTestResourceFile('iterations.json')
+      readTestFileAsJSON('iterations.json')
     );
   });
 
@@ -149,7 +142,7 @@ describe('index', () => {
         } as ShortcutConfig,
         {
           listEpics: fnEpicsFunc.mockResolvedValue(
-            readTestResourceFile('epics.json')
+            readTestFileAsJSON('epics.json')
           ),
           hasNextPage: jest.fn(),
         } as any
@@ -171,7 +164,7 @@ describe('index', () => {
     }
     expect(fnEpicsFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(epics))).toStrictEqual(
-      readTestResourceFile('epics.json')
+      readTestFileAsJSON('epics.json')
     );
   });
 
@@ -187,7 +180,7 @@ describe('index', () => {
         } as ShortcutConfig,
         {
           listMembers: fnMembersFunc.mockResolvedValue(
-            readTestResourceFile('members.json')
+            readTestFileAsJSON('members.json')
           ),
           hasNextPage: jest.fn(),
         } as any
@@ -208,7 +201,7 @@ describe('index', () => {
     }
     expect(fnMembersFunc).toHaveBeenCalledTimes(1);
     expect(JSON.parse(JSON.stringify(members))).toStrictEqual(
-      readTestResourceFile('members.json')
+      readTestFileAsJSON('members.json')
     );
   });
 });

--- a/sources/squadcast-source/test/index.test.ts
+++ b/sources/squadcast-source/test/index.test.ts
@@ -2,9 +2,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
+  readTestFileAsJSON,
   SyncMode,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import nock from 'nock';
 import {VError} from 'verror';
 
@@ -13,13 +14,6 @@ import {AUTH_URL, Squadcast} from '../src/squadcast';
 
 const SquadcastInstance = Squadcast.instance;
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -36,7 +30,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.SquadcastSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -100,9 +94,9 @@ describe('index', () => {
               data: {data: {events: []}, incidents: []},
             };
             if (isPathMatchEvents)
-              res.data.data.events = readTestResourceFile('events.json');
+              res.data.data.events = readTestFileAsJSON('events.json');
             if (isPathMatchIncidents)
-              res.data.incidents = readTestResourceFile('incidents.json');
+              res.data.incidents = readTestFileAsJSON('incidents.json');
             if (isPathMatchTeams) res.data.data = [{id: 'test-team-id'}];
 
             return res;
@@ -123,7 +117,7 @@ describe('index', () => {
     }
 
     expect(fnEventsFunc).toHaveBeenCalledTimes(6);
-    expect(events).toStrictEqual(readTestResourceFile('events.json'));
+    expect(events).toStrictEqual(readTestFileAsJSON('events.json'));
   });
 
   test('streams - incidents, use full_refresh sync mode', async () => {
@@ -136,7 +130,7 @@ describe('index', () => {
             const isPathMatch = /^incidents\/export/.test(path);
             if (isPathMatch) {
               return {
-                data: {incidents: readTestResourceFile('incidents.json')},
+                data: {incidents: readTestFileAsJSON('incidents.json')},
               };
             }
           }),
@@ -157,7 +151,7 @@ describe('index', () => {
     }
 
     expect(fnIncidentsFunc).toHaveBeenCalledTimes(1);
-    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+    expect(incidents).toStrictEqual(readTestFileAsJSON('incidents.json'));
   });
 
   test('streams - services, use full_refresh sync mode', async () => {
@@ -167,7 +161,7 @@ describe('index', () => {
       return new Squadcast(
         {
           get: fnServicesFunc.mockResolvedValue({
-            data: {data: readTestResourceFile('services.json')},
+            data: {data: readTestFileAsJSON('services.json')},
           }),
         } as any,
         new Date('2010-03-27T14:03:51-0800'),
@@ -186,7 +180,7 @@ describe('index', () => {
     }
 
     expect(fnServicesFunc).toHaveBeenCalledTimes(1);
-    expect(services).toStrictEqual(readTestResourceFile('services.json'));
+    expect(services).toStrictEqual(readTestFileAsJSON('services.json'));
   });
 
   test('streams - services filtered', async () => {
@@ -196,7 +190,7 @@ describe('index', () => {
       return new Squadcast(
         {
           get: fnServicesFunc.mockResolvedValue({
-            data: {data: readTestResourceFile('services.json')},
+            data: {data: readTestFileAsJSON('services.json')},
           }),
         } as any,
         new Date('2010-03-27T14:03:51-0800'),
@@ -215,7 +209,7 @@ describe('index', () => {
     }
 
     expect(fnServicesFunc).toHaveBeenCalledTimes(1);
-    expect(services).toStrictEqual(readTestResourceFile('services.json'));
+    expect(services).toStrictEqual(readTestFileAsJSON('services.json'));
   });
 
   test('streams - services all filtered out', async () => {
@@ -225,7 +219,7 @@ describe('index', () => {
       return new Squadcast(
         {
           get: fnServicesFunc.mockResolvedValue({
-            data: {data: readTestResourceFile('services.json')},
+            data: {data: readTestFileAsJSON('services.json')},
           }),
         } as any,
         new Date('2010-03-27T14:03:51-0800'),
@@ -254,7 +248,7 @@ describe('index', () => {
       return new Squadcast(
         {
           get: fnUsersFunc.mockResolvedValue({
-            data: {data: readTestResourceFile('users.json')},
+            data: {data: readTestFileAsJSON('users.json')},
           }),
         } as any,
         new Date('2010-03-27T14:03:51-0800'),
@@ -273,6 +267,6 @@ describe('index', () => {
     }
 
     expect(fnUsersFunc).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 });

--- a/sources/statuspage-source/test/index.test.ts
+++ b/sources/statuspage-source/test/index.test.ts
@@ -3,8 +3,9 @@ import {
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
+  readResourceAsJSON,
+  readTestFileAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import * as sut from '../src/index';
@@ -12,14 +13,6 @@ import {Statuspage} from '../src/statuspage';
 import {Component, ComponentGroup, Page} from '../src/types';
 
 const statusPageInstance = Statuspage.instance;
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -41,7 +34,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.StatuspageSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -116,7 +109,7 @@ describe('index', () => {
 
   test('streams - component groups, use full_refresh sync mode', async () => {
     const fnComponentGroupsFunc = jest.fn();
-    const expectedData: ReadonlyArray<ComponentGroup> = readTestResourceFile(
+    const expectedData: ReadonlyArray<ComponentGroup> = readTestFileAsJSON(
       'component_groups.json'
     );
     const sp = new Statuspage(
@@ -153,7 +146,7 @@ describe('index', () => {
   test('streams - components, use full_refresh sync mode', async () => {
     const fnComponentsFunc = jest.fn();
     const expectedData: ReadonlyArray<Component> =
-      readTestResourceFile('components.json');
+      readTestFileAsJSON('components.json');
     const sp = new Statuspage(
       {
         get: fnComponentsFunc
@@ -187,7 +180,7 @@ describe('index', () => {
 
   test('streams - incidents, use full_refresh sync mode', async () => {
     const fnIncidentsFunc = jest.fn();
-    const inputIncidents: any[] = readTestResourceFile('incidents.json');
+    const inputIncidents: any[] = readTestFileAsJSON('incidents.json');
     Statuspage.instance = jest.fn().mockImplementation(() => {
       let idx = 0;
       return new Statuspage(
@@ -218,7 +211,7 @@ describe('index', () => {
     }
 
     expect(fnIncidentsFunc).toHaveBeenCalledTimes(4);
-    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+    expect(incidents).toStrictEqual(readTestFileAsJSON('incidents.json'));
   });
 
   test('streams - pages, use full_refresh sync mode', async () => {
@@ -228,7 +221,7 @@ describe('index', () => {
       return new Statuspage(
         {
           get: fnPagesFunc.mockResolvedValue({
-            data: readTestResourceFile('pages.json'),
+            data: readTestFileAsJSON('pages.json'),
           }),
         } as any,
         new Date('1970-01-01T00:00:00-0000'),
@@ -246,7 +239,7 @@ describe('index', () => {
     }
 
     expect(fnPagesFunc).toHaveBeenCalledTimes(1);
-    expect(pages).toStrictEqual(readTestResourceFile('pages.json'));
+    expect(pages).toStrictEqual(readTestFileAsJSON('pages.json'));
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
@@ -254,7 +247,7 @@ describe('index', () => {
     const sp = new Statuspage(
       {
         get: fnUsersFunc.mockResolvedValueOnce({
-          data: readTestResourceFile('users.json'),
+          data: readTestFileAsJSON('users.json'),
         }),
       } as any,
       new Date('1970-01-01T00:00:00-0000'),
@@ -272,12 +265,12 @@ describe('index', () => {
     }
 
     expect(fnUsersFunc).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 
   test('streams - component uptimes, use full_refresh sync mode', async () => {
     const fnComponentUptimesFunc = jest.fn();
-    const componentUptime = readTestResourceFile('component_uptimes.json');
+    const componentUptime = readTestFileAsJSON('component_uptimes.json');
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 3);
     Statuspage.instance = jest.fn().mockImplementation(() => {
@@ -316,7 +309,7 @@ describe('index', () => {
 
   test('streams - component uptimes, use incremental sync mode', async () => {
     const fnComponentUptimesFunc = jest.fn();
-    const componentUptime = readTestResourceFile('component_uptimes.json');
+    const componentUptime = readTestFileAsJSON('component_uptimes.json');
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 90);
     Statuspage.instance = jest.fn().mockImplementation(() => {
@@ -389,7 +382,7 @@ describe('index', () => {
 
   test('streams - component uptimes, fetch max 90 days', async () => {
     const fnComponentUptimesFunc = jest.fn();
-    const componentUptime = readTestResourceFile('component_uptimes.json');
+    const componentUptime = readTestFileAsJSON('component_uptimes.json');
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 1000);
     Statuspage.instance = jest.fn().mockImplementation(() => {
@@ -428,7 +421,7 @@ describe('index', () => {
 
   test('streams - component uptimes, use component start date', async () => {
     const fnComponentUptimesFunc = jest.fn();
-    const componentUptime = readTestResourceFile('component_uptimes.json');
+    const componentUptime = readTestFileAsJSON('component_uptimes.json');
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 1000);
     Statuspage.instance = jest.fn().mockImplementation(() => {
@@ -474,9 +467,9 @@ describe('index', () => {
 
   test('streams - component showcase disabled', async () => {
     const fnStreamSlicesFunc = jest.fn();
-    const pages: ReadonlyArray<Page> = readTestResourceFile('pages.json');
+    const pages: ReadonlyArray<Page> = readTestFileAsJSON('pages.json');
     const components: ReadonlyArray<Component> =
-      readTestResourceFile('components.json');
+      readTestFileAsJSON('components.json');
 
     Statuspage.instance = jest.fn().mockImplementation(() => {
       return new Statuspage(
@@ -516,7 +509,7 @@ describe('index', () => {
 
   test('streams - component uptimes, sub-components', async () => {
     const fnComponentUptimesFunc = jest.fn();
-    const componentUptime = readTestResourceFile('component_uptimes.json');
+    const componentUptime = readTestFileAsJSON('component_uptimes.json');
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 1);
     Statuspage.instance = jest.fn().mockImplementation(() => {

--- a/sources/trello-source/test/index.test.ts
+++ b/sources/trello-source/test/index.test.ts
@@ -3,8 +3,8 @@ import {
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
+  readResourceAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import VError from 'verror';
 
 import * as sut from '../src/index';
@@ -22,7 +22,7 @@ describe('index', () => {
 
   test('spec', async () => {
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -108,6 +108,3 @@ describe('index', () => {
   });
 });
 
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}

--- a/sources/tromzo-source/test/index.test.ts
+++ b/sources/tromzo-source/test/index.test.ts
@@ -2,18 +2,14 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import VError from 'verror';
 
 import * as sut from '../src/index';
 import {Findings} from '../src/streams/findings';
 import {Tromzo} from '../src/tromzo';
 import {TromzoConfig} from '../src/types';
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -31,7 +27,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.TromzoSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/tromzo-source/test/streams.test.ts
+++ b/sources/tromzo-source/test/streams.test.ts
@@ -1,17 +1,14 @@
+import fs from 'fs';
 import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   SyncMode,
+  readTestFileAsJSON,
 } from 'faros-airbyte-cdk';
 import {Utils} from 'faros-js-client';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
 import {Tromzo} from '../src/tromzo';
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 function readQueryFile(fileName: string): string {
   return fs.readFileSync(`resources/queries/${fileName}`, 'utf8');
@@ -38,7 +35,7 @@ describe('streams', () => {
     syncMode: SyncMode = SyncMode.FULL_REFRESH
   ): Promise<void> {
     const postFn = jest.fn().mockResolvedValue({
-      data: readTestResourceFile('findings.json'),
+      data: readTestFileAsJSON('findings.json'),
     });
 
     Tromzo.instance = jest.fn().mockImplementation(() => {

--- a/sources/vanta-source/test/index.test.ts
+++ b/sources/vanta-source/test/index.test.ts
@@ -6,31 +6,24 @@ import {
   sourceCheckTest,
   sourceReadTest,
   sourceSchemaTest,
+  readResourceAsJSON,
+  readTestResourceAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
 import {Vanta} from '../src/vanta';
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test/resources/${fileName}`, 'utf8'));
-}
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 jest.mock('axios');
 
 function getResponseByPath(url: any): any {
   if (url.includes('vulnerabilities')) {
-    return readTestResourceFile('vulnerabilities_response.json');
+    return readTestResourceAsJSON('vulnerabilities_response.json');
   }
   if (url.includes('vulnerability-remediations')) {
-    return readTestResourceFile('vulnerability_remediations_response.json');
+    return readTestResourceAsJSON('vulnerability_remediations_response.json');
   }
   if (url.includes('vulnerable-assets')) {
-    return readTestResourceFile('vulnerable_assets_response.json');
+    return readTestResourceAsJSON('vulnerable_assets_response.json');
   }
 }
 
@@ -66,7 +59,7 @@ describe('index', () => {
       : AirbyteLogLevel.FATAL
   );
 
-  const sampleConfig = readTestResourceFile('sample_cfg.json');
+  const sampleConfig = readTestResourceAsJSON('sample_cfg.json');
   const source = new sut.VantaSource(logger);
 
   beforeEach(() => {
@@ -80,7 +73,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.VantaSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/victorops-source/test/index.test.ts
+++ b/sources/victorops-source/test/index.test.ts
@@ -3,8 +3,9 @@ import {
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
+  readResourceAsJSON,
+  readTestFileAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import * as sut from '../src/index';
@@ -12,14 +13,6 @@ import {Incident} from '../src/victorops';
 import {Victorops} from '../src/victorops';
 
 jest.mock('axios-retry');
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -40,7 +33,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.VictoropsSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -107,7 +100,7 @@ describe('index', () => {
         {
           reporting: {
             getIncidentHistory: fnIncidentsList.mockResolvedValue({
-              incidents: readTestResourceFile('incidents.json'),
+              incidents: readTestFileAsJSON('incidents.json'),
             }),
           },
         } as any,
@@ -127,7 +120,7 @@ describe('index', () => {
       incidents.push(incident);
     }
     expect(fnIncidentsList).toHaveBeenCalledTimes(1);
-    expect(incidents).toStrictEqual(readTestResourceFile('incidents.json'));
+    expect(incidents).toStrictEqual(readTestFileAsJSON('incidents.json'));
   });
 
   test('streams - incidents, use incremental sync mode', async () => {
@@ -140,7 +133,7 @@ describe('index', () => {
             getIncidentHistory: fnIncidentsList.mockImplementation(
               ({startedAfter}: {startedAfter: Date}) => {
                 const incidentsFile: Incident[] =
-                  readTestResourceFile('incidents.json');
+                  readTestFileAsJSON('incidents.json');
 
                 return {
                   incidents: incidentsFile.filter(
@@ -183,7 +176,7 @@ describe('index', () => {
         {
           teams: {
             getTeams: fnTeamsList.mockResolvedValue(
-              readTestResourceFile('teams.json')
+              readTestFileAsJSON('teams.json')
             ),
           },
         } as any,
@@ -203,7 +196,7 @@ describe('index', () => {
       teams.push(team);
     }
     expect(fnTeamsList).toHaveBeenCalledTimes(1);
-    expect(teams).toStrictEqual(readTestResourceFile('teams.json'));
+    expect(teams).toStrictEqual(readTestFileAsJSON('teams.json'));
   });
 
   test('streams - users, use full_refresh sync mode', async () => {
@@ -214,7 +207,7 @@ describe('index', () => {
         {
           users: {
             getUsers: fnUsersList.mockResolvedValue({
-              users: {flat: () => readTestResourceFile('users.json')},
+              users: {flat: () => readTestFileAsJSON('users.json')},
             }),
           },
         } as any,
@@ -234,6 +227,6 @@ describe('index', () => {
       users.push(user);
     }
     expect(fnUsersList).toHaveBeenCalledTimes(1);
-    expect(users).toStrictEqual(readTestResourceFile('users.json'));
+    expect(users).toStrictEqual(readTestFileAsJSON('users.json'));
   });
 });

--- a/sources/workday-source/test/index.test.ts
+++ b/sources/workday-source/test/index.test.ts
@@ -3,20 +3,13 @@ import {
   AirbyteSourceLogger,
   AirbyteSpec,
   SyncMode,
+  readResourceAsJSON,
+  readTestFileAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import {VError} from 'verror';
 
 import * as sut from '../src/index';
 import {Workday} from '../src/workday';
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 const test_base_url = 'https://testurl.com';
 
@@ -39,9 +32,9 @@ describe('index', () => {
       : AirbyteLogLevel.FATAL
   );
 
-  const config_tkn = readTestResourceFile('config_tokens.json');
-  const config_unpw = readTestResourceFile('config_unpw.json');
-  const config_unpw_csv = readTestResourceFile('config_unpw_csv.json');
+  const config_tkn = readTestFileAsJSON('config_tokens.json');
+  const config_unpw = readTestFileAsJSON('config_unpw.json');
+  const config_unpw_csv = readTestFileAsJSON('config_unpw_csv.json');
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -54,7 +47,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.WorkdaySource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 
@@ -83,7 +76,7 @@ describe('index', () => {
         logger,
         {
           get: jest.fn().mockResolvedValue({
-            data: readTestResourceFile('workers.json'),
+            data: readTestFileAsJSON('workers.json'),
           }),
         } as any,
         20
@@ -102,7 +95,7 @@ describe('index', () => {
         logger,
         {
           get: jest.fn().mockResolvedValue({
-            data: readTestResourceFile('workers.json'),
+            data: readTestFileAsJSON('workers.json'),
           }),
         } as any,
         20
@@ -117,7 +110,7 @@ describe('index', () => {
 
   test('streams - orgs', async () => {
     const fnListOrgs = jest.fn();
-    const expected = readTestResourceFile('orgs.json');
+    const expected = readTestFileAsJSON('orgs.json');
     const limit = 2;
 
     Workday.instance = jest.fn().mockImplementation(() => {
@@ -143,7 +136,7 @@ describe('index', () => {
 
   test('streams - people', async () => {
     const fnListOrgs = jest.fn();
-    const expected = readTestResourceFile('people.json');
+    const expected = readTestFileAsJSON('people.json');
     const limit = 2;
 
     Workday.instance = jest.fn().mockImplementation(() => {
@@ -169,7 +162,7 @@ describe('index', () => {
 
   test('streams - workers', async () => {
     const fnListOrgs = jest.fn();
-    const expected = readTestResourceFile('workers.json');
+    const expected = readTestFileAsJSON('workers.json');
     const limit = 2;
 
     Workday.instance = jest.fn().mockImplementation(() => {
@@ -194,7 +187,7 @@ describe('index', () => {
   });
   test('streams - customReports (json)', async () => {
     const fnCustomreports = jest.fn();
-    const expected = readTestResourceFile('customreports.json');
+    const expected = readTestFileAsJSON('customreports.json');
 
     Workday.instance = jest.fn().mockImplementation(() => {
       return new Workday(
@@ -222,8 +215,8 @@ describe('index', () => {
 
   test('streams - customReports (csv)', async () => {
     const fnCustomreports = jest.fn();
-    const expected = readTestResourceFile('customreports.json');
-    const csv_data = readTestResourceFile('customreports_csv.json');
+    const expected = readTestFileAsJSON('customreports.json');
+    const csv_data = readTestFileAsJSON('customreports_csv.json');
 
     Workday.instance = jest.fn().mockImplementation(() => {
       return new Workday(

--- a/sources/xray-source/test/index.test.ts
+++ b/sources/xray-source/test/index.test.ts
@@ -2,16 +2,12 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 import VError from 'verror';
 
 import * as sut from '../src/index';
 import {Xray} from '../src/xray';
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -29,7 +25,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.XraySource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 

--- a/sources/xray-source/test/streams.test.ts
+++ b/sources/xray-source/test/streams.test.ts
@@ -2,15 +2,11 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   SyncMode,
+  readTestFileAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
 import {Xray} from '../src/xray';
-
-function readTestResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`test_files/${fileName}`, 'utf8'));
-}
 
 describe('streams', () => {
   const logger = new AirbyteSourceLogger(
@@ -32,7 +28,7 @@ describe('streams', () => {
     const postFn =
       typeof responseFileOrFn === 'string'
         ? jest.fn().mockResolvedValue({
-            data: {data: readTestResourceFile(responseFileOrFn)},
+            data: {data: readTestFileAsJSON(responseFileOrFn)},
           })
         : responseFileOrFn;
 
@@ -66,10 +62,10 @@ describe('streams', () => {
     const mockFn = jest
       .fn()
       .mockResolvedValueOnce({
-        data: {data: readTestResourceFile('getPlans.json')},
+        data: {data: readTestFileAsJSON('getPlans.json')},
       })
       .mockResolvedValue({
-        data: {data: readTestResourceFile('getTestPlanTests.json')},
+        data: {data: readTestFileAsJSON('getTestPlanTests.json')},
       });
     await testStream(2, mockFn);
   });

--- a/sources/zephyr-source/test/index.test.ts
+++ b/sources/zephyr-source/test/index.test.ts
@@ -2,14 +2,10 @@ import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
   AirbyteSpec,
+  readResourceAsJSON,
 } from 'faros-airbyte-cdk';
-import fs from 'fs-extra';
 
 import * as sut from '../src/index';
-
-function readResourceFile(fileName: string): any {
-  return JSON.parse(fs.readFileSync(`resources/${fileName}`, 'utf8'));
-}
 
 describe('index', () => {
   const logger = new AirbyteSourceLogger(
@@ -22,7 +18,7 @@ describe('index', () => {
   test('spec', async () => {
     const source = new sut.ZephyrScaleSource(logger);
     await expect(source.spec()).resolves.toStrictEqual(
-      new AirbyteSpec(readResourceFile('spec.json'))
+      new AirbyteSpec(readResourceAsJSON('spec.json'))
     );
   });
 });


### PR DESCRIPTION
## Summary
- Added standardized utility functions for reading test and resource files to the CDK's testing-tools module
- Updated all connector test files to use these centralized utilities instead of local implementations
- Reduced code duplication and standardized file reading approaches across connectors

## Test plan
- All existing tests should continue to pass
- No functionality changes, only refactoring common test utility code

🤖 Generated with [Claude Code](https://claude.ai/code)