### PR TITLE
FAI-16744 Refactor: Centralize VCS filtering logic for reusability

### DIFF
--- a/faros-airbyte-common/src/common/index.ts
+++ b/faros-airbyte-common/src/common/index.ts
@@ -13,6 +13,15 @@ export {
   RoundRobinConfig,
 } from './bucketing';
 
+export {
+  VCSFilter,
+  VCSFilterConfig,
+  VCSConfigFields,
+  VCSEntityNames,
+  VCSAdapter,
+  RepoInclusion,
+} from './vcs-filter';
+
 // TODO: Try https://www.npmjs.com/package/diff
 export interface FileDiff {
   deletions: number;

--- a/faros-airbyte-common/src/common/vcs-filter.ts
+++ b/faros-airbyte-common/src/common/vcs-filter.ts
@@ -9,7 +9,7 @@ import {collectReposByOrg, getFarosOptions} from './index';
 /**
  * Configuration for VCS entity filtering
  */
-export interface VCSFilterConfig<TConfig> {
+export interface VCSFilterConfig<TConfig, TOrg, TRepo> {
   /** Configuration object containing entity filter arrays */
   config: TConfig;
   /** Logger instance for debug/warning messages */
@@ -21,7 +21,7 @@ export interface VCSFilterConfig<TConfig> {
   /** Entity type names for logging and API calls */
   entityNames: VCSEntityNames;
   /** VCS-specific adapter for API operations */
-  vcsAdapter: VCSAdapter<any>;
+  vcsAdapter: VCSAdapter<TOrg, TRepo>;
   /** Graph name for Faros integration (optional) */
   defaultGraph?: string;
   /** Whether to use Faros graph for repo selection */
@@ -65,11 +65,11 @@ export interface VCSEntityNames {
 /**
  * VCS-specific adapter interface for API operations
  */
-export interface VCSAdapter<TRepo> {
+export interface VCSAdapter<TOrg, TRepo> {
   /** Get all visible organization-level entities */
   getOrgs(): Promise<string[]>;
   /** Get a specific organization-level entity by name */
-  getOrg(orgName: string): Promise<any>;
+  getOrg(orgName: string): Promise<TOrg>;
   /** Get all repositories for an organization */
   getRepos(orgName: string): Promise<TRepo[]>;
   /** Extract repository name from repository object */
@@ -153,14 +153,14 @@ type FilterConfig = {
  * });
  * ```
  */
-export class VCSFilter<TConfig extends Record<string, any>, TRepo> {
+export class VCSFilter<TConfig extends Record<string, any>, TOrg, TRepo> {
   private readonly filterConfig: FilterConfig;
   private readonly useFarosGraphReposSelection: boolean;
   private orgs?: Set<string>;
   private reposByOrg: Map<string, Map<string, RepoInclusion<TRepo>>> = new Map();
   private loadedSelectedRepos: boolean = false;
 
-  constructor(private readonly options: VCSFilterConfig<TConfig>) {
+  constructor(private readonly options: VCSFilterConfig<TConfig, TOrg, TRepo>) {
     const {config, logger, configFields, entityNames} = options;
 
     this.useFarosGraphReposSelection = 

--- a/faros-airbyte-common/src/common/vcs-filter.ts
+++ b/faros-airbyte-common/src/common/vcs-filter.ts
@@ -1,0 +1,430 @@
+import {AirbyteLogger} from 'faros-airbyte-cdk';
+import {FarosClient} from 'faros-js-client';
+import {toLower} from 'lodash';
+import {Memoize} from 'typescript-memoize';
+import VError from 'verror';
+
+import {collectReposByOrg, getFarosOptions} from './index';
+
+/**
+ * Configuration for VCS entity filtering
+ */
+export interface VCSFilterConfig<TConfig> {
+  /** Configuration object containing entity filter arrays */
+  config: TConfig;
+  /** Logger instance for debug/warning messages */
+  logger: AirbyteLogger;
+  /** Optional Faros client for graph-based filtering */
+  farosClient?: FarosClient;
+  /** Configuration field names mapping */
+  configFields: VCSConfigFields;
+  /** Entity type names for logging and API calls */
+  entityNames: VCSEntityNames;
+  /** VCS-specific adapter for API operations */
+  vcsAdapter: VCSAdapter<any>;
+  /** Graph name for Faros integration (optional) */
+  defaultGraph?: string;
+  /** Whether to use Faros graph for repo selection */
+  useFarosGraphReposSelection?: boolean;
+}
+
+/**
+ * Maps configuration field names to their corresponding arrays
+ */
+export interface VCSConfigFields {
+  /** Field name for organization/group/workspace entities (e.g., 'organizations', 'groups', 'workspaces') */
+  orgs: string;
+  /** Field name for excluded organization/group/workspace entities */
+  excludedOrgs: string;
+  /** Field name for repository entities */
+  repos: string;
+  /** Field name for excluded repository entities */
+  excludedRepos: string;
+  /** Field name for Faros graph repos selection flag */
+  useFarosGraphReposSelection?: string;
+  /** Field name for Faros graph name */
+  graph?: string;
+}
+
+/**
+ * Entity names for logging and display purposes
+ */
+export interface VCSEntityNames {
+  /** Singular name of organization-level entity (e.g., 'organization', 'group', 'workspace') */
+  org: string;
+  /** Plural name of organization-level entity */
+  orgs: string;
+  /** Singular name of repository entity */
+  repo: string;
+  /** Plural name of repository entities */
+  repos: string;
+  /** VCS platform name (e.g., 'GitHub', 'GitLab', 'Bitbucket') */
+  platform: string;
+}
+
+/**
+ * VCS-specific adapter interface for API operations
+ */
+export interface VCSAdapter<TRepo> {
+  /** Get all visible organization-level entities */
+  getOrgs(): Promise<string[]>;
+  /** Get a specific organization-level entity by name */
+  getOrg(orgName: string): Promise<any>;
+  /** Get all repositories for an organization */
+  getRepos(orgName: string): Promise<TRepo[]>;
+  /** Extract repository name from repository object */
+  getRepoName(repo: TRepo): string;
+}
+
+/**
+ * Repository inclusion result
+ */
+export type RepoInclusion<TRepo> = {
+  repo: TRepo;
+  syncRepoData: boolean;
+};
+
+/**
+ * Internal filter configuration
+ */
+type FilterConfig = {
+  orgs?: Set<string>;
+  excludedOrgs?: Set<string>;
+  reposByOrg?: Map<string, Set<string>>;
+  excludedReposByOrg?: Map<string, Set<string>>;
+};
+
+/**
+ * Generic VCS organization/repository filter
+ * 
+ * This class provides a reusable filtering mechanism for VCS sources that follow
+ * a two-level hierarchy (organization/group/workspace → repository). It supports:
+ * 
+ * - Include/exclude patterns for both levels
+ * - Case-insensitive filtering
+ * - Faros Graph integration for dynamic repository selection
+ * - Configurable entity names and field mappings
+ * - Comprehensive validation and error handling
+ * 
+ * @example
+ * ```typescript
+ * // GitHub usage
+ * const filter = new VCSFilter({
+ *   config: githubConfig,
+ *   logger: logger,
+ *   farosClient: farosClient,
+ *   configFields: {
+ *     orgs: 'organizations',
+ *     excludedOrgs: 'excluded_organizations',
+ *     repos: 'repositories', 
+ *     excludedRepos: 'excluded_repositories',
+ *     useFarosGraphReposSelection: 'use_faros_graph_repos_selection',
+ *     graph: 'graph'
+ *   },
+ *   entityNames: {
+ *     org: 'organization',
+ *     orgs: 'organizations',
+ *     repo: 'repository',
+ *     repos: 'repositories',
+ *     platform: 'GitHub'
+ *   },
+ *   vcsAdapter: new GitHubAdapter(githubClient),
+ *   defaultGraph: 'default-graph'
+ * });
+ * 
+ * // GitLab usage
+ * const filter = new VCSFilter({
+ *   config: gitlabConfig,
+ *   logger: logger,
+ *   configFields: {
+ *     orgs: 'groups',
+ *     excludedOrgs: 'excluded_groups',
+ *     repos: 'repositories',
+ *     excludedRepos: 'excluded_repositories'
+ *   },
+ *   entityNames: {
+ *     org: 'group',
+ *     orgs: 'groups', 
+ *     repo: 'repository',
+ *     repos: 'repositories',
+ *     platform: 'GitLab'
+ *   },
+ *   vcsAdapter: new GitLabAdapter(gitlabClient)
+ * });
+ * ```
+ */
+export class VCSFilter<TConfig extends Record<string, any>, TRepo> {
+  private readonly filterConfig: FilterConfig;
+  private readonly useFarosGraphReposSelection: boolean;
+  private orgs?: Set<string>;
+  private reposByOrg: Map<string, Map<string, RepoInclusion<TRepo>>> = new Map();
+  private loadedSelectedRepos: boolean = false;
+
+  constructor(private readonly options: VCSFilterConfig<TConfig>) {
+    const {config, logger, configFields, entityNames} = options;
+
+    this.useFarosGraphReposSelection = 
+      config[configFields.useFarosGraphReposSelection || 'use_faros_graph_repos_selection'] ?? false;
+
+    const orgs = config[configFields.orgs] as string[] | undefined;
+    const repos = config[configFields.repos] as string[] | undefined;
+    const excludedRepos = config[configFields.excludedRepos] as string[] | undefined;
+    let excludedOrgs = config[configFields.excludedOrgs] as string[] | undefined;
+
+    if (orgs?.length && excludedOrgs?.length) {
+      logger.warn(
+        `Both ${configFields.orgs} and ${configFields.excludedOrgs} are specified, ${configFields.excludedOrgs} will be ignored.`
+      );
+      excludedOrgs = undefined;
+    }
+
+    let reposByOrg: Map<string, Set<string>>;
+    let excludedReposByOrg: Map<string, Set<string>>;
+    if (!this.useFarosGraphReposSelection) {
+      ({reposByOrg, excludedReposByOrg} = this.getSelectedReposByOrg(
+        repos,
+        excludedRepos
+      ));
+      this.loadedSelectedRepos = true;
+    } else {
+      if (!this.hasFarosClient()) {
+        throw new VError(
+          `Faros credentials are required when using Faros Graph for ${entityNames.repos} selection`
+        );
+      }
+      if (repos?.length || excludedRepos?.length) {
+        logger.warn(
+          `Using Faros Graph for ${entityNames.repos} selection but ${configFields.repos} and/or ${configFields.excludedRepos} are specified, both will be ignored.`
+        );
+      }
+    }
+
+    this.filterConfig = {
+      orgs: orgs?.length ? new Set(orgs) : undefined,
+      excludedOrgs: excludedOrgs?.length ? new Set(excludedOrgs) : undefined,
+      reposByOrg,
+      excludedReposByOrg,
+    };
+  }
+
+  /**
+   * Get all filtered organization names
+   */
+  @Memoize()
+  async getOrgs(): Promise<ReadonlyArray<string>> {
+    if (!this.orgs) {
+      const {vcsAdapter, logger, entityNames} = this.options;
+      const visibleOrgs = new Set(
+        (await vcsAdapter.getOrgs()).map((o) => toLower(o))
+      );
+
+      if (!visibleOrgs.size) {
+        logger.warn(`No visible ${entityNames.orgs} found`);
+      }
+
+      this.orgs = await this.filterOrgs(visibleOrgs);
+    }
+
+    if (this.orgs.size === 0) {
+      throw new VError(
+        `No visible ${this.options.entityNames.orgs} remain after applying inclusion and exclusion filters`
+      );
+    }
+
+    return Array.from(this.orgs);
+  }
+
+  /**
+   * Get all filtered repositories for an organization
+   */
+  @Memoize()
+  async getRepos(org: string): Promise<ReadonlyArray<RepoInclusion<TRepo>>> {
+    const lowerOrg = toLower(org);
+
+    await this.loadSelectedRepos();
+
+    if (!this.reposByOrg.has(lowerOrg)) {
+      const repos = new Map<string, RepoInclusion<TRepo>>();
+      const {vcsAdapter, logger, entityNames} = this.options;
+      const visibleRepos = await vcsAdapter.getRepos(lowerOrg);
+      
+      if (!visibleRepos.length) {
+        logger.warn(
+          `No visible ${entityNames.repos} found for ${entityNames.org} ${lowerOrg}`
+        );
+      }
+      
+      for (const repo of visibleRepos) {
+        const lowerRepoName = toLower(vcsAdapter.getRepoName(repo));
+        const {included, syncRepoData} = await this.getRepoInclusion(
+          lowerOrg,
+          lowerRepoName
+        );
+        if (included) {
+          repos.set(lowerRepoName, {repo, syncRepoData});
+        }
+      }
+      this.reposByOrg.set(lowerOrg, repos);
+    }
+    return Array.from(this.reposByOrg.get(lowerOrg).values());
+  }
+
+  /**
+   * Check if a specific repository should be included and synced
+   */
+  async getRepoInclusion(
+    org: string,
+    repo: string
+  ): Promise<{
+    included: boolean;
+    syncRepoData: boolean;
+  }> {
+    await this.loadSelectedRepos();
+    const {reposByOrg, excludedReposByOrg} = this.filterConfig;
+    const repos = reposByOrg?.get(org);
+    const excludedRepos = excludedReposByOrg?.get(org);
+
+    if (this.useFarosGraphReposSelection) {
+      const included = true;
+      const syncRepoData =
+        (!repos?.size || repos.has(repo)) && !excludedRepos?.has(repo);
+      return {included, syncRepoData};
+    }
+
+    if (repos?.size) {
+      const included = repos.has(repo);
+      return {included, syncRepoData: included};
+    }
+
+    if (excludedRepos?.size) {
+      const included = !excludedRepos.has(repo);
+      return {included, syncRepoData: included};
+    }
+    return {included: true, syncRepoData: true};
+  }
+
+  /**
+   * Get a specific repository object by org and name
+   */
+  getRepository(org: string, name: string): TRepo {
+    const lowerOrg = toLower(org);
+    const lowerRepoName = toLower(name);
+    const {repo} = this.reposByOrg.get(lowerOrg)?.get(lowerRepoName) ?? {};
+    if (!repo) {
+      throw new VError(
+        `${this.options.entityNames.repo} not found: %s/%s`, 
+        lowerOrg, 
+        lowerRepoName
+      );
+    }
+    return repo;
+  }
+
+  private async filterOrgs(visibleOrgs: Set<string>): Promise<Set<string>> {
+    const orgs = new Set<string>();
+    const {vcsAdapter, logger, entityNames} = this.options;
+
+    if (!this.filterConfig.orgs) {
+      for (const org of visibleOrgs) {
+        const lowerOrg = toLower(org);
+        if (!this.filterConfig.excludedOrgs?.has(lowerOrg)) {
+          orgs.add(lowerOrg);
+        } else {
+          logger.info(`Skipping excluded ${entityNames.org} ${lowerOrg}`);
+        }
+      }
+    } else {
+      for (const org of this.filterConfig.orgs) {
+        const lowerOrg = toLower(org);
+        if (await this.isVisibleOrg(visibleOrgs, lowerOrg)) {
+          orgs.add(lowerOrg);
+        }
+      }
+    }
+
+    return orgs;
+  }
+
+  private async isVisibleOrg(
+    visibleOrgs: Set<string>,
+    lowerOrg: string
+  ): Promise<boolean> {
+    if (visibleOrgs.has(lowerOrg)) {
+      return true;
+    }
+
+    const {vcsAdapter, logger, entityNames} = this.options;
+    
+    try {
+      await vcsAdapter.getOrg(lowerOrg);
+      return true;
+    } catch (error: any) {
+      logger.warn(
+        `Fetching ${entityNames.org} ${lowerOrg} failed with error: ` +
+          `${error.status} - ${error.message}. Skipping.`
+      );
+      return false;
+    }
+  }
+
+  private async loadSelectedRepos(): Promise<void> {
+    if (this.loadedSelectedRepos) {
+      return;
+    }
+    
+    if (this.useFarosGraphReposSelection) {
+      const {farosClient, config, configFields, entityNames, defaultGraph} = this.options;
+      const graphName = config[configFields.graph || 'graph'] ?? defaultGraph;
+      
+      const farosOptions = await getFarosOptions(
+        'repository',
+        entityNames.platform,
+        farosClient,
+        graphName
+      );
+      
+      const {included: repositories, excluded: excludedRepositories} = farosOptions;
+      const {reposByOrg, excludedReposByOrg} = this.getSelectedReposByOrg(
+        Array.from(repositories),
+        Array.from(excludedRepositories)
+      );
+      this.filterConfig.reposByOrg = reposByOrg;
+      this.filterConfig.excludedReposByOrg = excludedReposByOrg;
+    }
+    this.loadedSelectedRepos = true;
+  }
+
+  private getSelectedReposByOrg(
+    repositories: ReadonlyArray<string> | undefined,
+    excludedRepositories: ReadonlyArray<string> | undefined
+  ): {
+    reposByOrg: Map<string, Set<string>>;
+    excludedReposByOrg: Map<string, Set<string>>;
+  } {
+    const reposByOrg = new Map<string, Set<string>>();
+    const excludedReposByOrg = new Map<string, Set<string>>();
+    const {logger, entityNames} = this.options;
+    
+    if (repositories?.length) {
+      collectReposByOrg(reposByOrg, repositories);
+    }
+    if (excludedRepositories?.length) {
+      collectReposByOrg(excludedReposByOrg, excludedRepositories);
+    }
+    
+    for (const org of reposByOrg.keys()) {
+      if (excludedReposByOrg.has(org)) {
+        logger.warn(
+          `Both ${this.options.configFields.repos} and ${this.options.configFields.excludedRepos} are specified for ${entityNames.org} ${org}, ${this.options.configFields.excludedRepos} for ${entityNames.org} ${org} will be ignored.`
+        );
+        excludedReposByOrg.delete(org);
+      }
+    }
+    
+    return {reposByOrg, excludedReposByOrg};
+  }
+
+  private hasFarosClient(): boolean {
+    return Boolean(this.options.farosClient);
+  }
+}

--- a/faros-airbyte-common/src/common/vcs-filter.ts
+++ b/faros-airbyte-common/src/common/vcs-filter.ts
@@ -227,6 +227,11 @@ export class VCSFilter<TConfig extends Record<string, any>, TOrg, TRepo> {
 
     if (this.orgs.size === 0) {
       throw new VError(
+        {
+          info: {
+            code: 'NO_VISIBLE_ORGS'
+          }
+        },
         `No visible ${this.options.entityNames.orgs} remain after applying inclusion and exclusion filters`
       );
     }

--- a/sources/github-source/src/org-repo-filter.ts
+++ b/sources/github-source/src/org-repo-filter.ts
@@ -1,6 +1,6 @@
 import {AirbyteLogger} from 'faros-airbyte-cdk';
 import {VCSFilter, VCSAdapter, RepoInclusion} from 'faros-airbyte-common/common';
-import {Repository} from 'faros-airbyte-common/github';
+import {Organization, Repository} from 'faros-airbyte-common/github';
 import {FarosClient} from 'faros-js-client';
 import {Memoize} from 'typescript-memoize';
 import VError from 'verror';
@@ -12,7 +12,7 @@ import {GitHubConfig} from './types';
 /**
  * GitHub VCS adapter implementation
  */
-class GitHubVCSAdapter implements VCSAdapter<Repository> {
+class GitHubVCSAdapter implements VCSAdapter<Organization, Repository> {
   constructor(
     private readonly config: GitHubConfig,
     private readonly logger: AirbyteLogger
@@ -23,7 +23,7 @@ class GitHubVCSAdapter implements VCSAdapter<Repository> {
     return Array.from(await github.getOrganizations());
   }
 
-  async getOrg(orgName: string): Promise<any> {
+  async getOrg(orgName: string): Promise<Organization> {
     const github = await GitHub.instance(this.config, this.logger);
     return github.getOrganization(orgName);
   }
@@ -39,7 +39,7 @@ class GitHubVCSAdapter implements VCSAdapter<Repository> {
 }
 
 export class OrgRepoFilter {
-  private readonly vcsFilter: VCSFilter<GitHubConfig, Repository>;
+  private readonly vcsFilter: VCSFilter<GitHubConfig, Organization, Repository>;
   private static _instance: OrgRepoFilter;
   
   static instance(

--- a/sources/github-source/src/org-repo-filter.ts
+++ b/sources/github-source/src/org-repo-filter.ts
@@ -1,8 +1,7 @@
 import {AirbyteLogger} from 'faros-airbyte-cdk';
-import {collectReposByOrg, getFarosOptions} from 'faros-airbyte-common/common';
+import {VCSFilter, VCSAdapter, RepoInclusion} from 'faros-airbyte-common/common';
 import {Repository} from 'faros-airbyte-common/github';
 import {FarosClient} from 'faros-js-client';
-import {toLower} from 'lodash';
 import {Memoize} from 'typescript-memoize';
 import VError from 'verror';
 
@@ -10,26 +9,39 @@ import {DEFAULT_FAROS_GRAPH, GitHub} from './github';
 import {RunMode} from './streams/common';
 import {GitHubConfig} from './types';
 
-type RepoInclusion = {
-  repo: Repository;
-  syncRepoData: boolean;
-};
+/**
+ * GitHub VCS adapter implementation
+ */
+class GitHubVCSAdapter implements VCSAdapter<Repository> {
+  constructor(
+    private readonly config: GitHubConfig,
+    private readonly logger: AirbyteLogger
+  ) {}
 
-type FilterConfig = {
-  organizations?: Set<string>;
-  excludedOrganizations?: Set<string>;
-  reposByOrg?: Map<string, Set<string>>;
-  excludedReposByOrg?: Map<string, Set<string>>;
-};
+  async getOrgs(): Promise<string[]> {
+    const github = await GitHub.instance(this.config, this.logger);
+    return Array.from(await github.getOrganizations());
+  }
+
+  async getOrg(orgName: string): Promise<any> {
+    const github = await GitHub.instance(this.config, this.logger);
+    return github.getOrganization(orgName);
+  }
+
+  async getRepos(orgName: string): Promise<Repository[]> {
+    const github = await GitHub.instance(this.config, this.logger);
+    return Array.from(await github.getRepositories(orgName));
+  }
+
+  getRepoName(repo: Repository): string {
+    return repo.name;
+  }
+}
 
 export class OrgRepoFilter {
-  private readonly filterConfig: FilterConfig;
-  private readonly useFarosGraphReposSelection: boolean;
-  private organizations?: Set<string>;
-  private reposByOrg: Map<string, Map<string, RepoInclusion>> = new Map();
-  private loadedSelectedRepos: boolean = false;
-
+  private readonly vcsFilter: VCSFilter<GitHubConfig, Repository>;
   private static _instance: OrgRepoFilter;
+  
   static instance(
     config: GitHubConfig,
     logger: AirbyteLogger,
@@ -46,155 +58,54 @@ export class OrgRepoFilter {
     private readonly logger: AirbyteLogger,
     private readonly farosClient?: FarosClient
   ) {
-    this.useFarosGraphReposSelection =
-      config.use_faros_graph_repos_selection ?? false;
-
-    const {organizations, repositories, excluded_repositories} = this.config;
-    let {excluded_organizations} = this.config;
-
-    if (organizations?.length && excluded_organizations?.length) {
-      this.logger.warn(
-        'Both organizations and excluded_organizations are specified, excluded_organizations will be ignored.'
-      );
-      excluded_organizations = undefined;
-    }
-
-    let reposByOrg: Map<string, Set<string>>;
-    let excludedReposByOrg: Map<string, Set<string>>;
-    if (!this.useFarosGraphReposSelection) {
-      ({reposByOrg, excludedReposByOrg} = this.getSelectedReposByOrg(
-        repositories,
-        excluded_repositories
-      ));
-      this.loadedSelectedRepos = true;
-    } else {
-      if (!this.hasFarosClient()) {
-        throw new VError(
-          'Faros credentials are required when using Faros Graph for boards selection'
-        );
-      }
-      if (repositories?.length || excluded_repositories?.length) {
-        logger.warn(
-          'Using Faros Graph for repositories selection but repositories and/or excluded_repositories are specified, both will be ignored.'
-        );
-      }
-    }
-
-    this.filterConfig = {
-      organizations: organizations?.length ? new Set(organizations) : undefined,
-      excludedOrganizations: excluded_organizations?.length
-        ? new Set(excluded_organizations)
-        : undefined,
-      reposByOrg,
-      excludedReposByOrg,
-    };
+    // Initialize the VCS filter with GitHub-specific configuration
+    this.vcsFilter = new VCSFilter({
+      config,
+      logger,
+      farosClient,
+      configFields: {
+        orgs: 'organizations',
+        excludedOrgs: 'excluded_organizations',
+        repos: 'repositories',
+        excludedRepos: 'excluded_repositories',
+        useFarosGraphReposSelection: 'use_faros_graph_repos_selection',
+        graph: 'graph'
+      },
+      entityNames: {
+        org: 'organization',
+        orgs: 'organizations',
+        repo: 'repository',
+        repos: 'repositories',
+        platform: 'GitHub'
+      },
+      vcsAdapter: new GitHubVCSAdapter(config, logger),
+      defaultGraph: DEFAULT_FAROS_GRAPH,
+      useFarosGraphReposSelection: config.use_faros_graph_repos_selection ?? false
+    });
   }
 
   @Memoize()
   async getOrganizations(): Promise<ReadonlyArray<string>> {
-    if (!this.organizations) {
-      const github = await GitHub.instance(this.config, this.logger);
-      const visibleOrgs = new Set(
-        (await github.getOrganizations()).map((o) => toLower(o))
-      );
-
-      if (!visibleOrgs.size) {
-        this.logger.warn('No visible organizations found');
-      }
-
-      this.organizations = await this.filterOrganizations(visibleOrgs, github);
-    }
-
-    if (
-      this.config.run_mode !== RunMode.EnterpriseCopilotOnly &&
-      this.organizations.size === 0
-    ) {
-      throw new VError(
-        'No visible organizations remain after applying inclusion and exclusion filters'
-      );
-    }
-
-    return Array.from(this.organizations);
-  }
-
-  private async filterOrganizations(
-    visibleOrgs: Set<string>,
-    github: GitHub
-  ): Promise<Set<string>> {
-    const organizations = new Set<string>();
-
-    if (!this.filterConfig.organizations) {
-      for (const org of visibleOrgs) {
-        const lowerOrg = toLower(org);
-        if (!this.filterConfig.excludedOrganizations?.has(lowerOrg)) {
-          organizations.add(lowerOrg);
-        } else {
-          this.logger.info(`Skipping excluded organization ${lowerOrg}`);
-        }
-      }
-    } else {
-      for (const organization of this.filterConfig.organizations) {
-        const lowerOrg = toLower(organization);
-        if (await this.isVisibleOrganization(visibleOrgs, lowerOrg, github)) {
-          organizations.add(lowerOrg);
-        }
-      }
-    }
-
-    return organizations;
-  }
-
-  private async isVisibleOrganization(
-    visibleOrgs: Set<string>,
-    lowerOrg: string,
-    github: GitHub
-  ): Promise<boolean> {
-    if (visibleOrgs.has(lowerOrg)) {
-      return true;
-    }
-
-    // Attempt direct organization lookup if not in visibleOrgs
     try {
-      await github.getOrganization(lowerOrg);
-      return true;
-    } catch (error: any) {
-      this.logger.warn(
-        `Fetching organization ${lowerOrg} failed with error: ` +
-          `${error.status} - ${error.message}. Skipping.`
-      );
-      return false;
+      return await this.vcsFilter.getOrgs();
+    } catch (error) {
+      // If in EnterpriseCopilotOnly mode and no orgs are found, return empty array
+      if (
+        this.config.run_mode === RunMode.EnterpriseCopilotOnly &&
+        error instanceof VError &&
+        error.message.includes('No visible organizations remain after applying inclusion and exclusion filters')
+      ) {
+        return [];
+      }
+      // Re-throw the error for other cases
+      throw error;
     }
   }
+
 
   @Memoize()
-  async getRepositories(org: string): Promise<ReadonlyArray<RepoInclusion>> {
-    const lowerOrg = toLower(org);
-
-    // Ensure included / excluded repositories are loaded
-    await this.loadSelectedRepos();
-
-    if (!this.reposByOrg.has(lowerOrg)) {
-      const repos = new Map<string, RepoInclusion>();
-      const github = await GitHub.instance(this.config, this.logger);
-      const visibleRepos = await github.getRepositories(lowerOrg);
-      if (!visibleRepos.length) {
-        this.logger.warn(
-          `No visible repositories found for organization ${lowerOrg}`
-        );
-      }
-      for (const repo of visibleRepos) {
-        const lowerRepoName = toLower(repo.name);
-        const {included, syncRepoData} = await this.getRepoInclusion(
-          lowerOrg,
-          lowerRepoName
-        );
-        if (included) {
-          repos.set(lowerRepoName, {repo, syncRepoData});
-        }
-      }
-      this.reposByOrg.set(lowerOrg, repos);
-    }
-    return Array.from(this.reposByOrg.get(lowerOrg).values());
+  async getRepositories(org: string): Promise<ReadonlyArray<RepoInclusion<Repository>>> {
+    return this.vcsFilter.getRepos(org);
   }
 
   async getRepoInclusion(
@@ -204,91 +115,10 @@ export class OrgRepoFilter {
     included: boolean;
     syncRepoData: boolean;
   }> {
-    await this.loadSelectedRepos();
-    const {reposByOrg, excludedReposByOrg} = this.filterConfig;
-    const repos = reposByOrg.get(org);
-    const excludedRepos = excludedReposByOrg.get(org);
-
-    if (this.useFarosGraphReposSelection) {
-      const included = true;
-
-      const syncRepoData =
-        (!repos?.size || repos.has(repo)) && !excludedRepos?.has(repo);
-      return {included, syncRepoData};
-    }
-
-    if (repos?.size) {
-      const included = repos.has(repo);
-      return {included, syncRepoData: included};
-    }
-
-    if (excludedRepos?.size) {
-      const included = !excludedRepos.has(repo);
-      return {included, syncRepoData: included};
-    }
-    return {included: true, syncRepoData: true};
+    return this.vcsFilter.getRepoInclusion(org, repo);
   }
 
   getRepository(org: string, name: string): Repository {
-    const lowerOrg = toLower(org);
-    const lowerRepoName = toLower(name);
-    const {repo} = this.reposByOrg.get(lowerOrg)?.get(lowerRepoName) ?? {};
-    if (!repo) {
-      throw new VError('Repository not found: %s/%s', lowerOrg, lowerRepoName);
-    }
-    return repo;
-  }
-
-  private async loadSelectedRepos(): Promise<void> {
-    if (this.loadedSelectedRepos) {
-      return;
-    }
-    if (this.useFarosGraphReposSelection) {
-      const farosOptions = await getFarosOptions(
-        'repository',
-        'GitHub',
-        this.farosClient,
-        this.config.graph ?? DEFAULT_FAROS_GRAPH
-      );
-      const {included: repositories, excluded: excludedRepositories} =
-        farosOptions;
-      const {reposByOrg, excludedReposByOrg} = this.getSelectedReposByOrg(
-        Array.from(repositories),
-        Array.from(excludedRepositories)
-      );
-      this.filterConfig.reposByOrg = reposByOrg;
-      this.filterConfig.excludedReposByOrg = excludedReposByOrg;
-    }
-    this.loadedSelectedRepos = true;
-  }
-
-  private getSelectedReposByOrg(
-    repositories: ReadonlyArray<string>,
-    excludedRepositories: ReadonlyArray<string>
-  ): {
-    reposByOrg: Map<string, Set<string>>;
-    excludedReposByOrg: Map<string, Set<string>>;
-  } {
-    const reposByOrg = new Map<string, Set<string>>();
-    const excludedReposByOrg = new Map<string, Set<string>>();
-    if (repositories?.length) {
-      collectReposByOrg(reposByOrg, repositories);
-    }
-    if (excludedRepositories?.length) {
-      collectReposByOrg(excludedReposByOrg, excludedRepositories);
-    }
-    for (const org of reposByOrg.keys()) {
-      if (excludedReposByOrg.has(org)) {
-        this.logger.warn(
-          `Both repositories and excluded_repositories are specified for organization ${org}, excluded_repositories for organization ${org} will be ignored.`
-        );
-        excludedReposByOrg.delete(org);
-      }
-    }
-    return {reposByOrg, excludedReposByOrg};
-  }
-
-  private hasFarosClient(): boolean {
-    return Boolean(this.farosClient);
+    return this.vcsFilter.getRepository(org, name);
   }
 }

--- a/sources/github-source/src/org-repo-filter.ts
+++ b/sources/github-source/src/org-repo-filter.ts
@@ -93,7 +93,7 @@ export class OrgRepoFilter {
       if (
         this.config.run_mode === RunMode.EnterpriseCopilotOnly &&
         error instanceof VError &&
-        error.message.includes('No visible organizations remain after applying inclusion and exclusion filters')
+        VError.info(error)?.code === 'NO_VISIBLE_ORGS'
       ) {
         return [];
       }

--- a/sources/github-source/src/org-repo-filter.ts
+++ b/sources/github-source/src/org-repo-filter.ts
@@ -38,6 +38,19 @@ class GitHubVCSAdapter implements VCSAdapter<Organization, Repository> {
   }
 }
 
+/**
+ * Type-safe configuration field mapping for GitHub
+ * This ensures that the values in configFields are actual keys of GitHubConfig
+ */
+type GitHubConfigFields = {
+  orgs: keyof GitHubConfig & 'organizations';
+  excludedOrgs: keyof GitHubConfig & 'excluded_organizations';
+  repos: keyof GitHubConfig & 'repositories';
+  excludedRepos: keyof GitHubConfig & 'excluded_repositories';
+  useFarosGraphReposSelection: keyof GitHubConfig & 'use_faros_graph_repos_selection';
+  graph: keyof GitHubConfig & 'graph';
+};
+
 export class OrgRepoFilter {
   private readonly vcsFilter: VCSFilter<GitHubConfig, Organization, Repository>;
   private static _instance: OrgRepoFilter;
@@ -59,18 +72,20 @@ export class OrgRepoFilter {
     private readonly farosClient?: FarosClient
   ) {
     // Initialize the VCS filter with GitHub-specific configuration
+    const configFields: GitHubConfigFields = {
+      orgs: 'organizations',
+      excludedOrgs: 'excluded_organizations',
+      repos: 'repositories',
+      excludedRepos: 'excluded_repositories',
+      useFarosGraphReposSelection: 'use_faros_graph_repos_selection',
+      graph: 'graph'
+    };
+
     this.vcsFilter = new VCSFilter({
       config,
       logger,
       farosClient,
-      configFields: {
-        orgs: 'organizations',
-        excludedOrgs: 'excluded_organizations',
-        repos: 'repositories',
-        excludedRepos: 'excluded_repositories',
-        useFarosGraphReposSelection: 'use_faros_graph_repos_selection',
-        graph: 'graph'
-      },
+      configFields,
       entityNames: {
         org: 'organization',
         orgs: 'organizations',


### PR DESCRIPTION
## Summary
• Extract common VCS filtering logic from GitHub source into reusable VCS filter utility
• Refactor GitHub org-repo filtering to use the new shared VCS filter class  
• Enable consistent filtering patterns across different VCS source connectors

## Test plan
- [X] Verify GitHub source connector still functions correctly with existing filtering behavior
- [X] Run existing GitHub source tests to ensure no regressions
- [X] Test org/repo inclusion/exclusion logic works as expected
- [X] Validate Faros graph-based repository selection continues to work

## Manual testing done by carbon-based lifeform (@ypc-faros )
![Screenshot 2025-05-22 at 2 03 46 PM](https://github.com/user-attachments/assets/c74fb58a-6264-4fa2-a867-41ff61da9ca8)
![Screenshot 2025-05-22 at 2 09 04 PM](https://github.com/user-attachments/assets/f329703a-d5f0-48f1-809f-ad34843c638d)
![Screenshot 2025-05-22 at 2 10 01 PM](https://github.com/user-attachments/assets/b3d4b517-8847-4eec-b144-610b7ba7c04f)
![Screenshot 2025-05-22 at 6 15 56 PM](https://github.com/user-attachments/assets/29668bff-aea4-41c1-87c0-056c8bb08c9b)
![Screenshot 2025-05-22 at 6 16 04 PM](https://github.com/user-attachments/assets/9cd2ef64-185b-4adb-9b85-4593371cd46e)
![Screenshot 2025-05-22 at 6 20 08 PM](https://github.com/user-attachments/assets/4a6b9b7c-08c7-4246-9ac9-5ce28e26aad4)
![Screenshot 2025-05-22 at 6 20 42 PM](https://github.com/user-attachments/assets/5024aca7-4415-4e02-865f-d6284b708bd4)




🤖 Generated with [Claude Code](https://claude.ai/code)