### PR TITLE
FAI-16813 - faros-org-import to allow processing duplicate employee rows

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/faros-org-import/employees.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-org-import/employees.ts
@@ -133,6 +133,7 @@ export class Employees extends FarosOrgImportConverter {
       }
     }
 
+    // Create identity and employee only if empId has not been seen before
     if (!this.seenEmployees.has(empId)) {
       models.push({
         model: 'identity_Identity',

--- a/destinations/airbyte-faros-destination/src/converters/faros-org-import/employees.ts
+++ b/destinations/airbyte-faros-destination/src/converters/faros-org-import/employees.ts
@@ -57,9 +57,15 @@ export class Employees extends FarosOrgImportConverter {
       ctx?.config?.source_specific_configs?.faros_org_import?.source ?? {};
 
     const empId = row.employeeId;
-    if (!empId || this.seenEmployees.has(empId)) {
-      ctx.logger?.warn('Duplicate employeeId: ' + empId);
+    if (!empId) {
+      ctx.logger?.warn('Missing employeeId in record: ' + JSON.stringify(row));
       return models;
+    }
+    if (this.seenEmployees.has(empId)) {
+      // Only warn if we have seen this employeeId before, don't skip the record.
+      // This can happen if the same employeeId is used in multiple rows
+      // to pass more than one team or identity.
+      ctx.logger?.warn('Duplicate employeeId: ' + empId);
     }
     this.seenEmployees.add(empId);
 


### PR DESCRIPTION
## Description

Allow processing of duplicate employee records so that multiple team and user information can be passed across multiple rows. Employee information will only be processed for the first record that is seen for each `employeeId`.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
