### PR TITLE
FAI-16855 Add GitLab users stream support

### DIFF
--- a/faros-airbyte-common/src/gitlab/types.ts
+++ b/faros-airbyte-common/src/gitlab/types.ts
@@ -3,6 +3,17 @@ export type GitLabToken = {
   personal_access_token: string;
 };
 
+export interface User {
+  id: number;
+  username: string;
+  name?: string;
+  email?: string;
+  state: string;
+  web_url: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
 export interface Group {
   id: string;
   parent_id: string | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -371,7 +371,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "faros-airbyte-cdk": "file:../faros-airbyte-cdk",
+        "faros-airbyte-cdk": "*",
         "mockttp": "^3.9.2",
         "pino": "^8.14.1",
         "pino-pretty": "^10.0.0",

--- a/sources/gitlab-source/resources/schemas/farosUsers.json
+++ b/sources/gitlab-source/resources/schemas/farosUsers.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "group": {
+      "type": "string"
+    },
+    "username": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "web_url": {
+      "type": "string"
+    }
+  }
+}

--- a/sources/gitlab-source/src/index.ts
+++ b/sources/gitlab-source/src/index.ts
@@ -24,6 +24,7 @@ import {
 import {RunMode, RunModeStreams} from './streams/common';
 import {FarosGroups} from './streams/faros_groups';
 import {FarosProjects} from './streams/faros_projects';
+import {FarosUsers} from './streams/faros_users';
 import {GitLabConfig} from './types';
 
 export function mainCommand(): Command {
@@ -67,6 +68,7 @@ export class GitLabSource extends AirbyteSourceBase<GitLabConfig> {
     return [
       new FarosGroups(config, this.logger, farosClient),
       new FarosProjects(config, this.logger, farosClient),
+      new FarosUsers(config, this.logger, farosClient),
     ];
   }
 

--- a/sources/gitlab-source/src/streams/common.ts
+++ b/sources/gitlab-source/src/streams/common.ts
@@ -27,10 +27,18 @@ export enum RunMode {
 
 export const MinimumStreamNames = ['faros_groups'];
 
-export const FullStreamNames = ['faros_groups', 'faros_projects'];
+export const FullStreamNames = [
+  'faros_groups',
+  'faros_projects',
+  'faros_users',
+];
 
 // fill as streams are developed
-export const CustomStreamNames = ['faros_groups', 'faros_projects'];
+export const CustomStreamNames = [
+  'faros_groups',
+  'faros_projects',
+  'faros_users',
+];
 
 export const RunModeStreams: {
   [key in RunMode]: string[];

--- a/sources/gitlab-source/src/streams/faros_users.ts
+++ b/sources/gitlab-source/src/streams/faros_users.ts
@@ -1,0 +1,44 @@
+import {StreamKey, SyncMode} from 'faros-airbyte-cdk';
+import {User} from 'faros-airbyte-common/gitlab';
+import {Dictionary} from 'ts-essentials';
+
+import {GitLab} from '../gitlab';
+import {GroupStreamSlice, StreamWithGroupSlices} from './common';
+
+export class FarosUsers extends StreamWithGroupSlices {
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/farosUsers.json');
+  }
+
+  get primaryKey(): StreamKey {
+    return ['group', 'username'];
+  }
+
+  // Although not actually an incremental stream, we run it in incremental mode
+  // to avoid deleting the users that are written by other incremental streams.
+  get supportsIncremental(): boolean {
+    return true;
+  }
+
+  // Not used, but necessary to pass Airbyte UI validation check
+  get cursorField(): string | string[] {
+    return 'web_url';
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: GroupStreamSlice
+  ): AsyncGenerator<User & {group: string}> {
+    const group = streamSlice?.group;
+    const gitlab = await GitLab.instance(this.config, this.logger);
+    const members = await gitlab.getGroupMembers(group);
+
+    for (const member of members) {
+      yield {
+        ...member,
+        group,
+      };
+    }
+  }
+}

--- a/sources/gitlab-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/gitlab-source/test/__snapshots__/index.test.ts.snap
@@ -99,3 +99,30 @@ exports[`index streams - faros projects 1`] = `
   },
 ]
 `;
+
+exports[`index streams - faros users 1`] = `
+[
+  {
+    "created_at": "2021-01-01T00:00:00Z",
+    "email": "user1@example.com",
+    "group": "test-group",
+    "id": 1,
+    "name": "Test User 1",
+    "state": "active",
+    "updated_at": "2021-01-01T00:00:00Z",
+    "username": "user1",
+    "web_url": "https://gitlab.com/user1",
+  },
+  {
+    "created_at": "2021-02-01T00:00:00Z",
+    "email": "user2@example.com",
+    "group": "test-group",
+    "id": 2,
+    "name": "Test User 2",
+    "state": "active",
+    "updated_at": "2021-02-01T00:00:00Z",
+    "username": "user2",
+    "web_url": "https://gitlab.com/user2",
+  },
+]
+`;

--- a/sources/gitlab-source/test/index.test.ts
+++ b/sources/gitlab-source/test/index.test.ts
@@ -1,13 +1,13 @@
 import {
   AirbyteLogLevel,
   AirbyteSourceLogger,
-  AirbyteSpec
+  AirbyteSpec,
 } from 'faros-airbyte-cdk';
 import {
   readTestResourceAsJSON,
   sourceCheckTest,
   sourceReadTest,
-  sourceSchemaTest
+  sourceSchemaTest,
 } from 'faros-airbyte-testing-tools';
 import fs from 'fs-extra';
 
@@ -210,6 +210,62 @@ describe('index', () => {
       source,
       configOrPath: 'config.json',
       catalogOrPath: 'faros_projects/catalog.json',
+      checkRecordsData: (records) => {
+        expect(records).toMatchSnapshot();
+      },
+    });
+  });
+
+  test('streams - faros users', async () => {
+    const gitlab = {
+      getGroups: jest.fn().mockResolvedValue([
+        {
+          id: '1',
+          parent_id: null,
+          name: 'Test Group',
+          path: 'test-group',
+          web_url: 'https://gitlab.com/test-group',
+          description: 'Test group description',
+          visibility: 'public',
+          created_at: '2021-01-01T00:00:00Z',
+          updated_at: '2021-01-01T00:00:00Z',
+        },
+      ]),
+      getGroupMembers: jest.fn().mockResolvedValue([
+        {
+          id: 1,
+          username: 'user1',
+          name: 'Test User 1',
+          email: 'user1@example.com',
+          state: 'active',
+          web_url: 'https://gitlab.com/user1',
+          created_at: '2021-01-01T00:00:00Z',
+          updated_at: '2021-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          username: 'user2',
+          name: 'Test User 2',
+          email: 'user2@example.com',
+          state: 'active',
+          web_url: 'https://gitlab.com/user2',
+          created_at: '2021-02-01T00:00:00Z',
+          updated_at: '2021-02-01T00:00:00Z',
+        },
+      ]),
+    };
+
+    const groupFilter = {
+      getGroups: jest.fn().mockResolvedValue(['test-group']),
+    };
+
+    jest.spyOn(GitLab, 'instance').mockResolvedValue(gitlab as any);
+    jest.spyOn(GroupFilter, 'instance').mockReturnValue(groupFilter as any);
+
+    await sourceReadTest({
+      source,
+      configOrPath: 'config.json',
+      catalogOrPath: 'users/catalog.json',
       checkRecordsData: (records) => {
         expect(records).toMatchSnapshot();
       },

--- a/sources/gitlab-source/test/resources/users/catalog.json
+++ b/sources/gitlab-source/test/resources/users/catalog.json
@@ -1,0 +1,37 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "faros_users",
+        "json_schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "group": {
+              "type": "string"
+            },
+            "username": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "web_url": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added support for fetching GitLab users through a new `faros_users` stream
- Implemented functionality to retrieve group members from GitLab API
- Added comprehensive test coverage for the new users stream

## Test plan
- [ ] Unit tests pass for the new users stream
- [ ] Integration tests validate proper user data retrieval
- [ ] Schema validation for farosUsers.json
- [ ] Verify group members are fetched correctly with proper pagination

🤖 Generated with [Claude Code](https://claude.ai/code)