### PR TITLE
Optimize Docker build for selective connector copying

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20792,6 +20792,7 @@
         "faros-airbyte-common": "*",
         "typescript-memoize": "^1.1.0",
         "undici": "^6.21.2",
+        "url-template": "^2.0.8",
         "verror": "^1.10.1"
       },
       "devDependencies": {

--- a/sources/github-source/package.json
+++ b/sources/github-source/package.json
@@ -36,6 +36,7 @@
     "faros-airbyte-common": "*",
     "typescript-memoize": "^1.1.0",
     "undici": "^6.21.2",
+    "url-template": "^2.0.8",
     "verror": "^1.10.1"
   },
   "jest": {


### PR DESCRIPTION
Note from @ypc-faros : I also built ALL the connectors locally, although that will happen in the release, so I'll keep an eye on that. Will also run the airbyte connectors tests and monitor syncs in dev (once we upgrade) for potential problems.

In the image below, you can see the size reduction between this PR (first pair) and #2066 (second pair) and before both optimizations (last pair).

Images are now ~30% of the size before the optimizations.

![Screenshot 2025-06-04 at 6 37 47 PM](https://github.com/user-attachments/assets/1defbf85-c6ae-4311-92fb-2bf0d1962672)


## Summary
- Optimize Dockerfile to only copy the specific connector being built instead of all sources and destinations
- Add missing url-template dependency for github-source to fix build errors

## Test plan
- [x] Verify docker build works with destinations: `docker build . --build-arg path=destinations/airbyte-faros-destination --build-arg version=0.0.1 -t test`
- [x] Verify docker build works with sources: `docker build . --build-arg path=sources/github-source --build-arg version=0.0.1 -t test`
- [x] Confirm reduced build context and image size
- [x] Validate symlink creation still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)