### PR TITLE
Revert "Optimize Docker build for selective connector copying"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,12 @@ FROM node:22-alpine AS builder
 
 WORKDIR /home/node/airbyte
 
-# Get the connector path argument early
-ARG path
-RUN test -n "$path" && \
-    echo "path argument is set to: $path" || \
-    (echo "'path' argument is not set, e.g --build-arg path=destinations/airbyte-faros-destination" && false)
-
 COPY turbo.json .tsconfig.json package.json package-lock.json ./
 RUN sed -i "/jest/d" package.json
 COPY ./faros-airbyte-cdk ./faros-airbyte-cdk
 COPY ./faros-airbyte-common ./faros-airbyte-common
-# Only copy the specific connector being built
-COPY ./$path ./$path
+COPY ./sources ./sources
+COPY ./destinations ./destinations
 
 RUN apk -U upgrade && \
     apk add --no-cache --virtual .gyp python3 py3-setuptools make g++ && \
@@ -37,6 +31,8 @@ WORKDIR /home/node/airbyte
 COPY --from=builder /home/node/airbyte/node_modules ./node_modules
 COPY --from=builder /home/node/airbyte/faros-airbyte-cdk ./faros-airbyte-cdk
 COPY --from=builder /home/node/airbyte/faros-airbyte-common ./faros-airbyte-common
+COPY --from=builder /home/node/airbyte/sources ./sources
+COPY --from=builder /home/node/airbyte/destinations ./destinations
 
 COPY ./docker ./docker
 
@@ -44,12 +40,11 @@ ARG version
 RUN test -n "$version" || (echo "'version' argument is not set, e.g --build-arg version=x.y.z" && false)
 ENV CONNECTOR_VERSION=$version
 
-# Reuse the path argument from build stage
 ARG path
+RUN test -n "$path" && \
+    echo "path argument is set to: $path" || \
+    (echo "'path' argument is not set, e.g --build-arg path=destinations/airbyte-faros-destination" && false)
 ENV CONNECTOR_PATH=$path
-
-# Copy only the specific connector from builder
-COPY --from=builder /home/node/airbyte/$path ./$path
 
 RUN ln -s "/home/node/airbyte/$CONNECTOR_PATH/bin/main" "/home/node/airbyte/main"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20792,7 +20792,6 @@
         "faros-airbyte-common": "*",
         "typescript-memoize": "^1.1.0",
         "undici": "^6.21.2",
-        "url-template": "^2.0.8",
         "verror": "^1.10.1"
       },
       "devDependencies": {

--- a/sources/github-source/package.json
+++ b/sources/github-source/package.json
@@ -36,7 +36,6 @@
     "faros-airbyte-common": "*",
     "typescript-memoize": "^1.1.0",
     "undici": "^6.21.2",
-    "url-template": "^2.0.8",
     "verror": "^1.10.1"
   },
   "jest": {


### PR DESCRIPTION
Reverts faros-ai/airbyte-connectors#2070

The optimization makes each connector build have a different build context (`COPY ./sources/github-source` vs `COPY ./sources/jira-source`), so Docker can't reuse layers between different connectors like it could before when all connectors shared the same `COPY ./sources ./sources` instruction. This turns ~50
  fast cached builds into ~50 slow fresh builds, causing the 20-minute timeout.