### PR TITLE
Enhance error logging with record count in stream slice processing

### DIFF
--- a/faros-airbyte-cdk/src/sources/source-base.ts
+++ b/faros-airbyte-cdk/src/sources/source-base.ts
@@ -396,7 +396,7 @@ export abstract class AirbyteSourceBase<
         this.logger.error(
           `Encountered an error while processing ${streamName} stream slice ${JSON.stringify(
             slice
-          )}: ${e.message ?? JSON.stringify(e)}`,
+          )}: ${e.message ?? JSON.stringify(e)}. Emitted ${sliceRecordCounter} records before failure.`,
           e.stack
         );
         yield this.sliceFailureState(


### PR DESCRIPTION
## Summary
• Add record count to error messages when stream slice processing fails to improve debugging visibility

## Test plan
- [ ] Verify error messages include record count when slice processing fails
- [ ] Test with various stream configurations to ensure logging works consistently
- [ ] Confirm no regression in existing error handling behavior

🤖 Generated with [Claude Code](https://claude.ai/code)