### PR TITLE
FAI-16928: Add validation and logging for Azure-Workitems uid handling

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/azure-workitems/users.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-workitems/users.ts
@@ -3,14 +3,15 @@ import {User} from 'faros-airbyte-common/azure-devops';
 
 import {getUniqueName} from '../common/azure-devops';
 import {Common} from '../common/common';
-import {DestinationModel, DestinationRecord} from '../converter';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AzureWorkitemsConverter} from './common';
 
 export class Users extends AzureWorkitemsConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = ['tms_User'];
 
   async convert(
-    record: AirbyteRecord
+    record: AirbyteRecord,
+    ctx: StreamContext
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const source = this.streamName.source;
     const userItem = record.record.data as User;
@@ -18,6 +19,9 @@ export class Users extends AzureWorkitemsConverter {
 
     const uniqueName = getUniqueName(userItem);
     if (!uniqueName) {
+      ctx.logger.warn(
+        `Cannot create tms_User record due to missing uniqueName/principalName. UserItem: ${JSON.stringify(userItem)}`
+      );
       return res;
     }
 

--- a/destinations/airbyte-faros-destination/src/converters/azure-workitems/workitems.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-workitems/workitems.ts
@@ -1,4 +1,4 @@
-import {AirbyteRecord} from 'faros-airbyte-cdk';
+import {AirbyteLogger, AirbyteRecord} from 'faros-airbyte-cdk';
 import {
   WorkItemAssigneeRevision,
   WorkItemIterationRevision,
@@ -7,8 +7,9 @@ import {
 } from 'faros-airbyte-common/azure-devops';
 import {Utils} from 'faros-js-client';
 
+import {getUniqueName} from '../common/azure-devops';
 import {CategoryDetail} from '../common/common';
-import {DestinationModel, DestinationRecord} from '../converter';
+import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {AzureWorkitemsConverter} from './common';
 import {TaskKey, TaskStatusChange} from './models';
 export class Workitems extends AzureWorkitemsConverter {
@@ -29,7 +30,8 @@ export class Workitems extends AzureWorkitemsConverter {
   ];
 
   async convert(
-    record: AirbyteRecord
+    record: AirbyteRecord,
+    ctx: StreamContext
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const source = this.source;
     const WorkItem = record.record.data as WorkItemWithRevisions;
@@ -46,7 +48,8 @@ export class Workitems extends AzureWorkitemsConverter {
     );
     const assignees = this.convertAssigneeRevisions(
       taskKey,
-      WorkItem.revisions.assignees
+      WorkItem.revisions.assignees,
+      ctx?.logger
     );
     const sprintHistory = this.convertIterationRevisions(
       taskKey,
@@ -81,10 +84,12 @@ export class Workitems extends AzureWorkitemsConverter {
             WorkItem.fields['Microsoft.VSTS.Common.StateChangeDate']
           ),
           updatedAt: Utils.toDate(WorkItem.fields['System.ChangedDate']),
-          creator: {
-            uid: WorkItem.fields['System.CreatedBy']['uniqueName'],
-            source,
-          },
+          creator: WorkItem.fields['System.CreatedBy']?.['uniqueName']
+            ? {
+                uid: WorkItem.fields['System.CreatedBy']['uniqueName'],
+                source,
+              }
+            : null,
           sprint: WorkItem.fields['System.IterationId']
             ? {uid: String(WorkItem.fields['System.IterationId']), source}
             : null,
@@ -201,16 +206,29 @@ export class Workitems extends AzureWorkitemsConverter {
 
   private convertAssigneeRevisions(
     task: TaskKey,
-    assigneeRevisions: ReadonlyArray<WorkItemAssigneeRevision>
+    assigneeRevisions: ReadonlyArray<WorkItemAssigneeRevision>,
+    logger: AirbyteLogger
   ): ReadonlyArray<DestinationRecord> {
-    return assigneeRevisions.map((revision) => ({
-      model: 'tms_TaskAssignment',
-      record: {
-        task,
-        assignee: {uid: revision.assignee?.uniqueName, source: this.source},
-        assignedAt: Utils.toDate(revision.changedDate),
-      },
-    }));
+    return assigneeRevisions
+      .map((revision) => {
+        const uid = getUniqueName(revision.assignee);
+        if (uid) {
+          return {
+            model: 'tms_TaskAssignment',
+            record: {
+              task,
+              assignee: {uid: uid, source: this.source},
+              assignedAt: Utils.toDate(revision.changedDate),
+            },
+          };
+        } else {
+          logger?.warn(
+            `Missing assignee uniqueName in work item ${task.uid} revision. WorkItemId: ${task.uid}, Revision: ${JSON.stringify(revision)}`
+          );
+          return null;
+        }
+      })
+      .filter(Boolean) as DestinationRecord[];
   }
 
   private convertStateRevisions(

--- a/destinations/airbyte-faros-destination/src/converters/azure-workitems/workitems.ts
+++ b/destinations/airbyte-faros-destination/src/converters/azure-workitems/workitems.ts
@@ -207,7 +207,7 @@ export class Workitems extends AzureWorkitemsConverter {
   private convertAssigneeRevisions(
     task: TaskKey,
     assigneeRevisions: ReadonlyArray<WorkItemAssigneeRevision>,
-    logger: AirbyteLogger
+    logger?: AirbyteLogger
   ): ReadonlyArray<DestinationRecord> {
     return assigneeRevisions
       .map((revision) => {

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/common.ts
@@ -268,8 +268,6 @@ export abstract class GitlabConverter extends Converter {
     return res;
   }
 
-
-
   private getFinalUser(users: Array<PartialUser>): PartialUser {
     const finalUser: PartialUser = {};
     for (const user of users) {


### PR DESCRIPTION
# FAI-16928: Better handling for tms_Users in Azure-Workitems
from https://github.com/faros-ai/airbyte-connectors/pull/2080
## Problem
The Azure-Workitems connector was failing with errors:
```
Error processing input: cannot upsert null or undefined uid for model tms_User with keys {"source":"Azure-Workitems"}
```

This occurred when user references lacked valid identifiers (uid values), causing the GraphQL client to receive null/undefined uid values.

## Solution
Enhanced error handling and validation across the Azure-Workitems converter to prevent null/undefined uid values from being passed to the GraphQL client:

### Changes Made

1. **Enhanced users.ts logging** - Added detailed contextual logging when uniqueName is missing:
   - Logs full user item JSON for troubleshooting
   - Uses StreamContext logger for proper error tracking

2. **Added creator validation in workitems.ts** - Prevents null creator references:
   - Checks for uniqueName before creating creator reference
   - Returns null instead of invalid reference when uniqueName is missing

3. **Updated convertAssigneeRevisions method** - Added validation and logging for assignee references:
   - Validates assignee uniqueName before creating task assignments
   - Logs detailed context when assignee uniqueName is missing
   - Filters out invalid assignments to maintain data processing flow

## Key Benefits
- **Prevents GraphQL errors**: No more null/undefined uid values passed to the client
- **Maintains data flow**: Processing continues even when some user references are invalid
- **Improved troubleshooting**: Detailed logging helps identify problematic user data sources
- **Defensive programming**: Null-safe validation patterns prevent future similar issues

## Testing
- Lint checks passed with no TypeScript errors
- Changes maintain existing converter interface contracts
- Validation logic prevents invalid data from reaching GraphQL client

## Link to Devin run
https://app.devin.ai/sessions/403e50623825480595b995064596a0df

Requested by: chalenge@faros.ai
