### PR TITLE
Optimize converter registry test performance

### DIFF
--- a/destinations/airbyte-faros-destination/test/converter-registry.test.ts
+++ b/destinations/airbyte-faros-destination/test/converter-registry.test.ts
@@ -38,10 +38,17 @@ describe('converter registry', () => {
     return res;
   }
 
-  test('load all converters', async () => {
-    const streams = listStreams('src/converters');
+  test('load sample converters', async () => {
+    // Test a small sample of converters to verify registry functionality
+    // Individual converter tests already verify specific converter behavior
+    const sampleStreams = [
+      new StreamName('github', 'users'),
+      new StreamName('jira', 'projects'),
+      new StreamName('bitbucket-server', 'users'), // Include bitbucket edge case
+    ];
+    
     let converterCount = 0;
-    for (const stream of streams) {
+    for (const stream of sampleStreams) {
       const converter = sut.getConverter(stream);
 
       if (converter && converter.convert) {


### PR DESCRIPTION
This test loads ALL converters and takes a long time to complete.

We already cover that codepath for all converters which have specific tests in the destination. E.g., for GitHub, all the stream converters included [here](https://github.com/faros-ai/airbyte-connectors/blob/3e3b7ab7dfc569953b15a8661df63243fe322a77/destinations/airbyte-faros-destination/test/converters/faros_github.test.ts#L56) are covered, since the converter loading is in the codepath of the destination run.

We should cover all converters in unit tests as a best practice anyway, so I'd prefer we test the core functionality of the converter registry + only a small sample of specific converters.

![Screenshot 2025-06-10 at 4 41 58 PM](https://github.com/user-attachments/assets/42c87c71-8aaf-4b34-90cf-476ac4afaf7f)

## Summary
- Replace expensive "load all converters" test with targeted sample test
- Reduces test execution time from 5+ minutes to seconds
- Maintains coverage of core registry functionality including bitbucket edge case

## Test plan
- [x] Verify modified test still passes and covers key functionality
- [x] Confirm significant performance improvement in test execution time
- [x] Ensure bitbucket-server edge case is still tested

🤖 Generated with [Claude Code](https://claude.ai/code)