### PR TITLE
Add faros_tags converter for GitLab

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/gitlab/faros_tags.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/faros_tags.ts
@@ -1,0 +1,43 @@
+import {AirbyteRecord} from 'faros-airbyte-cdk';
+import {toLower} from 'lodash';
+
+import {DestinationModel, DestinationRecord} from '../converter';
+import {GitlabConverter} from './common';
+
+export class FarosTags extends GitlabConverter {
+  readonly destinationModels: ReadonlyArray<DestinationModel> = ['vcs_Tag'];
+
+  id(record: AirbyteRecord): any {
+    const tag = record?.record?.data;
+    return `${tag?.name}_${tag?.commit_id}`;
+  }
+
+  async convert(
+    record: AirbyteRecord
+  ): Promise<ReadonlyArray<DestinationRecord>> {
+    const source = this.streamName.source;
+    const tag = record.record.data;
+
+    // Build repository key from group_id and project_path
+    const repository = {
+      name: toLower(tag.project_path),
+      uid: toLower(tag.project_path),
+      organization: {
+        uid: toLower(tag.group_id),
+        source,
+      },
+    };
+
+    return [
+      {
+        model: 'vcs_Tag',
+        record: {
+          name: tag.name,
+          message: tag.title,
+          commit: {sha: tag.commit_id, uid: tag.commit_id, repository},
+          repository,
+        },
+      },
+    ];
+  }
+}


### PR DESCRIPTION
## Summary
- Implements converter for the `faros_tags` stream in GitLab source
- The faros_tags stream includes group and project information directly, eliminating the need for stream dependencies

## Implementation Details
- Extends `GitlabConverter` base class
- Uses composite ID of tag name and commit_id for uniqueness
- Maps GitLab tag `title` field to the `message` field in destination model
- Builds repository key directly from `group_id` and `project_path`

## Test plan
- [ ] Verify converter loads correctly via ConverterRegistry
- [ ] Test with sample faros_tags stream data
- [ ] Ensure vcs_Tag records are created with correct repository references

🤖 Generated with [Claude Code](https://claude.ai/code)