### PR TITLE
feat: support JSON array format for test input files

### DIFF
--- a/destinations/airbyte-faros-destination/test/converters/faros_gitlab.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/faros_gitlab.test.ts
@@ -26,7 +26,7 @@ describe('faros_gitlab', () => {
     await destinationWriteTest({
       configPath,
       catalogPath: 'test/resources/faros_gitlab/catalog.json',
-      inputRecordsPath: 'faros_gitlab/all-streams.log',
+      inputRecordsPath: 'faros_gitlab/all-streams.json',
       checkRecordsData: (records) => expect(records).toMatchSnapshot(),
     });
   });

--- a/destinations/airbyte-faros-destination/test/resources/faros_gitlab/all-streams.json
+++ b/destinations/airbyte-faros-destination/test/resources/faros_gitlab/all-streams.json
@@ -1,0 +1,132 @@
+[
+  {
+    "record": {
+      "stream": "mytestsource__gitlab__faros_groups",
+      "emitted_at": 1747764794080,
+      "data": {
+        "id": "12372707",
+        "name": "farosai",
+        "path": "farosai",
+        "web_url": "https://gitlab.com/groups/farosai",
+        "description": "",
+        "visibility": "private",
+        "created_at": "2021-06-11T22:27:18.521Z",
+        "updated_at": null
+      }
+    },
+    "type": "RECORD"
+  },
+  {
+    "record": {
+      "stream": "mytestsource__gitlab__faros_projects",
+      "emitted_at": 1748613815838,
+      "data": {
+        "id": "40360007",
+        "name": "FarosCE test",
+        "path": "farosce-test",
+        "path_with_namespace": "farosai/farosce-test",
+        "web_url": "https://gitlab.com/farosai/farosce-test",
+        "description": "Test project for FarosCE GitLab integration",
+        "visibility": "private",
+        "created_at": "2022-10-19T16:40:22.162Z",
+        "updated_at": "2024-10-15T18:38:58.340Z",
+        "namespace": {
+          "id": "12372707",
+          "name": "farosai",
+          "path": "farosai",
+          "kind": "group",
+          "full_path": "farosai"
+        },
+        "default_branch": "master",
+        "archived": false,
+        "group_id": "12372707",
+        "syncRepoData": true
+      }
+    },
+    "type": "RECORD"
+  },
+  {
+    "record": {
+      "stream": "mytestsource__gitlab__faros_users",
+      "emitted_at": 1748972847044,
+      "data": {
+        "id": 12279282,
+        "username": "ypc-faros",
+        "name": "Yandry Perez",
+        "email": null,
+        "state": "active",
+        "web_url": "https://gitlab.com/ypc-faros",
+        "created_at": "2022-08-11T20:36:01.136Z",
+        "updated_at": null,
+        "group_id": "12372707"
+      }
+    },
+    "type": "RECORD"
+  },
+  {
+    "type": "RECORD",
+    "record": {
+      "stream": "mytestsource__gitlab__faros_tags",
+      "emitted_at": 1749592209338,
+      "data": {
+        "name": "v0.4.0",
+        "title": "Release version 0.4.0",
+        "commit_id": "06a959fe1025f8eaa8ca7a6db1ac812ef1116e6d",
+        "group_id": "12372707",
+        "project_path": "faros-events-cli"
+      }
+    }
+  },
+  {
+    "record": {
+      "stream": "mytestsource__gitlab__faros_commits",
+      "emitted_at": 1749654331865,
+      "data": {
+        "id": "8617223c1e31c8454c65c397b54bac653c32c3f4",
+        "short_id": "8617223c",
+        "created_at": "2025-06-04T18:12:02.000+00:00",
+        "parent_ids": ["e43e8c4678c8cc8942dd724dded62643a818a16d"],
+        "title": "ypc test commit 1",
+        "message": "ypc test commit 1",
+        "author_name": "Yandry Perez",
+        "author_email": "ypc@faros.ai",
+        "authored_date": "2025-06-04T18:12:02.000+00:00",
+        "committer_name": "Yandry Perez",
+        "committer_email": "ypc@faros.ai",
+        "committed_date": "2025-06-04T18:12:02.000+00:00",
+        "web_url": "https://gitlab.com/farosai/testy/-/commit/8617223c1e31c8454c65c397b54bac653c32c3f4",
+        "branch": "main",
+        "author_username": "ypc-faros",
+        "group_id": "12372707",
+        "project_path": "testy"
+      }
+    },
+    "type": "RECORD"
+  },
+  {
+    "record": {
+      "stream": "mytestsource__gitlab__faros_commits",
+      "emitted_at": 1749654331866,
+      "data": {
+        "id": "123456789abcdef123456789abcdef1234567890",
+        "short_id": "123456789",
+        "created_at": "2025-06-05T10:30:00.000+00:00",
+        "parent_ids": ["8617223c1e31c8454c65c397b54bac653c32c3f4"],
+        "title": "Automated commit without author",
+        "message": "This commit has no resolved author username",
+        "author_name": "Unknown Author",
+        "author_email": "unknown@example.com",
+        "authored_date": "2025-06-05T10:30:00.000+00:00",
+        "committer_name": "CI Bot",
+        "committer_email": "ci@example.com",
+        "committed_date": "2025-06-05T10:30:00.000+00:00",
+        "web_url": "https://gitlab.com/farosai/testy/-/commit/123456789abcdef123456789abcdef1234567890",
+        "branch": "main",
+        "author_username": null,
+        "group_id": "12372707",
+        "project_path": "testy"
+      }
+    },
+    "type": "RECORD"
+  }
+]

--- a/faros-airbyte-testing-tools/src/destination-utils.ts
+++ b/faros-airbyte-testing-tools/src/destination-utils.ts
@@ -6,7 +6,7 @@ import {
 import {getLocal} from 'mockttp';
 import {Dictionary} from 'ts-essentials';
 
-import {CLI, read, readLines} from './cli';
+import {CLI, readLines} from './cli';
 import {initMockttp, tempConfig} from './destination-testing-tools';
 import {readTestResourceFile} from './testing-tools';
 
@@ -46,7 +46,22 @@ export const destinationWriteTest = async (
     '--dry-run',
   ]);
 
-  cli.stdin.end(readTestResourceFile(inputRecordsPath), 'utf8');
+  let content = readTestResourceFile(inputRecordsPath);
+  
+  // Check if the file is a .json file
+  if (inputRecordsPath.endsWith('.json')) {
+    try {
+      // Parse as JSON array and convert to line-delimited format
+      const jsonArray = JSON.parse(content);
+      if (Array.isArray(jsonArray)) {
+        content = jsonArray.map(record => JSON.stringify(record)).join('\n');
+      }
+    } catch (e) {
+      // If parsing fails, use content as-is
+    }
+  }
+  
+  cli.stdin.end(content, 'utf8');
 
   const stdoutLines = await readLines(cli.stdout);
   const matches: string[] = [];


### PR DESCRIPTION
## Summary
- Add support for JSON array format in test input files (`.json` extension)
- Convert `faros_gitlab` test data from line-delimited JSON (`.log`) to human-readable JSON array (`.json`)
- Update test helpers to automatically convert JSON arrays to line-delimited format for backward compatibility

## Test plan
- [x] Update `destinationWriteTest` to detect and convert `.json` files
- [x] Convert existing `faros_gitlab/all-streams.log` to `all-streams.json`
- [x] Update test to use new file format
- [x] Ensure backward compatibility for existing `.log` files

🤖 Generated with [Claude Code](https://claude.ai/code)