### PR TITLE
FAI-17065 feat: Add graphql_page_size to gitlab-source

### DIFF
--- a/sources/gitlab-source/resources/spec.json
+++ b/sources/gitlab-source/resources/spec.json
@@ -208,35 +208,42 @@
         "description": "Maximum number of items in a paginated response",
         "default": 100
       },
-      "timeout": {
+      "graphql_page_size": {
         "order": 19,
+        "type": "integer",
+        "title": "GraphQL Page Size",
+        "description": "Maximum number of items in a paginated GraphQL response",
+        "default": 50
+      },
+      "timeout": {
+        "order": 20,
         "type": "integer",
         "title": "Request Timeout",
         "description": "Timeout in milliseconds for each request to the GitLab API",
         "default": 120000
       },
       "concurrency_limit": {
-        "order": 20,
+        "order": 21,
         "type": "integer",
         "title": "Concurrency limit",
         "description": "Maximum concurrency to run with",
         "default": 4
       },
       "backfill": {
-        "order": 21,
+        "order": 22,
         "type": "boolean",
         "title": "Backfill",
         "description": "Backfill data from the start date to the end date.",
         "default": false
       },
       "start_date": {
-        "order": 22,
+        "order": 23,
         "type": "string",
         "title": "Start Date",
         "description": "The date from which to start syncing data."
       },
       "end_date": {
-        "order": 23,
+        "order": 24,
         "type": "string",
         "title": "End Date",
         "description": "The date at which to stop syncing data."
@@ -246,7 +253,7 @@
         "title": "Fetch Public Groups",
         "description": "Fetch public groups",
         "default": false,
-        "order": 24
+        "order": 25
       }
     }
   }

--- a/sources/gitlab-source/src/gitlab.ts
+++ b/sources/gitlab-source/src/gitlab.ts
@@ -37,6 +37,7 @@ export const DEFAULT_REJECT_UNAUTHORIZED = true;
 export const DEFAULT_RUN_MODE = RunMode.Full;
 export const DEFAULT_CUTOFF_DAYS = 90;
 export const DEFAULT_PAGE_SIZE = 100;
+export const DEFAULT_GRAPHQL_PAGE_SIZE = 50;
 export const DEFAULT_TIMEOUT_MS = 120_000;
 export const DEFAULT_CONCURRENCY = 4;
 export const DEFAULT_BACKFILL = false;
@@ -49,6 +50,7 @@ export class GitLab {
   private readonly client: InstanceType<typeof GitlabClient>;
   private readonly gqlClient: GraphQLClient;
   protected readonly pageSize: number;
+  protected readonly graphqlPageSize: number;
   protected readonly fetchPublicGroups: boolean;
   public readonly userCollector: UserCollector;
 
@@ -70,6 +72,8 @@ export class GitLab {
     });
 
     this.pageSize = config.page_size ?? DEFAULT_PAGE_SIZE;
+    this.graphqlPageSize =
+      config.graphql_page_size ?? DEFAULT_GRAPHQL_PAGE_SIZE;
     this.fetchPublicGroups =
       config.fetch_public_groups ?? DEFAULT_FETCH_PUBLIC_GROUPS;
     this.userCollector = new UserCollector(logger);
@@ -299,7 +303,7 @@ export class GitLab {
       try {
         const result: any = await this.gqlClient.request(MERGE_REQUESTS_QUERY, {
           fullPath: projectPath,
-          pageSize: this.pageSize,
+          pageSize: this.graphqlPageSize,
           cursor,
           updatedAfter: since?.toISOString(),
           updatedBefore: until?.toISOString(),

--- a/sources/gitlab-source/src/types.ts
+++ b/sources/gitlab-source/src/types.ts
@@ -24,6 +24,7 @@ export interface GitLabConfig extends AirbyteConfig, RoundRobinConfig {
   readonly graph?: string;
   readonly cutoff_days?: number;
   readonly page_size?: number;
+  readonly graphql_page_size?: number;
   readonly timeout?: number;
   readonly concurrency_limit?: number;
   readonly start_date?: string;


### PR DESCRIPTION
This commit introduces the `graphql_page_size` configuration option to the GitLab source connector. This allows users to control the page size for GraphQL queries, which can be useful for performance tuning and avoiding timeouts with large datasets.

The following changes are included:

- Added `graphql_page_size` to the `spec.json`
- Added `graphql_page_size` to the `GitLabConfig` type
- Implemented the `graphql_page_size` in the `GitLab` client for merge request queries.

## Description

> Provide description here

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
