### PR TITLE
Add cicd_Organization and cicd_Pipeline models to GitLab converters

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/gitlab/faros_groups.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/faros_groups.ts
@@ -8,6 +8,7 @@ import {GitlabConverter} from './common';
 export class FarosGroups extends GitlabConverter {
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_Organization',
+    'cicd_Organization',
   ];
 
   async convert(
@@ -26,6 +27,17 @@ export class FarosGroups extends GitlabConverter {
         type: {category: 'Group', detail: 'Group'},
         createdAt: Utils.toDate(group.created_at),
         source,
+      },
+    });
+
+    res.push({
+      model: 'cicd_Organization',
+      record: {
+        uid: group.id,
+        source,
+        name: group.name,
+        description: Utils.cleanAndTruncate(group.description),
+        url: group.web_url,
       },
     });
 

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/faros_projects.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/faros_projects.ts
@@ -13,6 +13,7 @@ export class FarosProjects extends GitlabConverter {
     'tms_Project',
     'tms_TaskBoard',
     'tms_TaskBoardProjectRelationship',
+    'cicd_Pipeline',
   ];
 
   async convert(
@@ -76,6 +77,17 @@ export class FarosProjects extends GitlabConverter {
       record: {
         board: projectKey,
         project: projectKey,
+      },
+    });
+
+    res.push({
+      model: 'cicd_Pipeline',
+      record: {
+        uid: projectName,
+        organization,
+        name: project.name ?? projectName,
+        description: Utils.cleanAndTruncate(project.description),
+        url: project.web_url,
       },
     });
 

--- a/destinations/airbyte-faros-destination/test/converters/CLAUDE.md
+++ b/destinations/airbyte-faros-destination/test/converters/CLAUDE.md
@@ -5,6 +5,8 @@
 When implementing a new faros converter, test coverage is essential. The approach differs depending on whether you're adding to an existing source or creating
 the first tests for a new source.
 
+> **⚠️ Remember**: Always run `npm run build` before testing to compile your TypeScript changes!
+
 ### Adding Tests to Existing Source
 
 #### 1. Add Test Data Record
@@ -56,26 +58,39 @@ Example:
 }
 ```
 
-#### 3. Run Tests Without Snapshot Update
+#### 3. Build the Code
 
-First, run the test to verify your converter produces the expected models:
+**IMPORTANT**: Always rebuild the TypeScript code before running tests to ensure your changes take effect:
+```bash
+npm run build
+```
+
+#### 4. Run Tests Without Snapshot Update
+
+After building, run the test to verify your converter produces the expected models:
+```bash
 npm test -- faros_gitlab.test.ts
+```
 
 Review the diff to ensure:
 - Correct number of records are processed
 - Expected destination models appear (e.g., cicd_Release, cicd_ReleaseTagAssociation)
 - Data transformations are correct
 
-#### 4. Update Snapshot
+#### 5. Update Snapshot
 
 If the output looks correct, update the snapshot:
+```bash
 npm test -- faros_gitlab.test.ts -u
+```
 
-This updates __snapshots__/faros_gitlab.test.ts.snap with your new models.
+This updates `__snapshots__/faros_gitlab.test.ts.snap` with your new models.
 
 ### Creating Tests for a New Source
 
 If you're writing the first faros tests for a new source:
+
+> **⚠️ Don't forget**: Run `npm run build` before testing your new converter!
 
 #### 1. Create Test File
 
@@ -150,12 +165,19 @@ Create catalog.json with your faros streams:
 
 Create all-streams.json with test records for each stream.
 
-Key Points
+### Key Points
 
+- **Always run `npm run build` before testing** - TypeScript changes must be compiled for tests to reflect your updates
 - No separate test file needed for existing sources - Tests are integrated into existing test suites
 - Create new test infrastructure for new sources following the established pattern
 - Use realistic test data - Base it on actual API responses but modify values
 - Verify transformations - Check that fields are mapped correctly
 - Follow existing patterns - Match the structure of other test records in the file
+
+### Common Testing Issues
+
+1. **Tests not reflecting code changes**: Always rebuild with `npm run build` before running tests
+2. **Snapshot mismatches**: Review the diff carefully before updating snapshots with `-u`
+3. **Missing test data**: Ensure your test records include all required fields for the converter
 
 This approach ensures comprehensive test coverage while maintaining consistency with the existing test infrastructure.

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_gitlab.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_gitlab.test.ts.snap
@@ -4,8 +4,8 @@ exports[`faros_gitlab process records from all streams 1`] = `
 Array [
   "Processed 10 records",
   "Processed records by stream: {\\\\\\"mytestsource__gitlab__faros_commits\\\\\\":2,\\\\\\"mytestsource__gitlab__faros_groups\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_issues\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_merge_request_reviews\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_merge_requests\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_projects\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_releases\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_tags\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_users\\\\\\":1}\\"},\\"type\\":\\"LOG\\"}",
-  "Would write 27 records",
-  "Would write records by model: {\\\\\\"cicd_Release\\\\\\":1,\\\\\\"cicd_ReleaseTagAssociation\\\\\\":1,\\\\\\"faros_VcsRepositoryOptions\\\\\\":1,\\\\\\"tms_Label\\\\\\":1,\\\\\\"tms_Project\\\\\\":1,\\\\\\"tms_Task\\\\\\":1,\\\\\\"tms_TaskAssignment\\\\\\":1,\\\\\\"tms_TaskBoard\\\\\\":1,\\\\\\"tms_TaskBoardProjectRelationship\\\\\\":1,\\\\\\"tms_TaskBoardRelationship\\\\\\":1,\\\\\\"tms_TaskProjectRelationship\\\\\\":1,\\\\\\"tms_TaskTag\\\\\\":1,\\\\\\"vcs_Commit\\\\\\":2,\\\\\\"vcs_Label\\\\\\":1,\\\\\\"vcs_Membership\\\\\\":1,\\\\\\"vcs_Organization\\\\\\":1,\\\\\\"vcs_PullRequest\\\\\\":1,\\\\\\"vcs_PullRequestComment\\\\\\":2,\\\\\\"vcs_PullRequestLabel\\\\\\":1,\\\\\\"vcs_PullRequestReview\\\\\\":3,\\\\\\"vcs_Repository\\\\\\":1,\\\\\\"vcs_Tag\\\\\\":1,\\\\\\"vcs_User\\\\\\":1}\\"},\\"type\\":\\"LOG\\"}",
+  "Would write 29 records",
+  "Would write records by model: {\\\\\\"cicd_Organization\\\\\\":1,\\\\\\"cicd_Pipeline\\\\\\":1,\\\\\\"cicd_Release\\\\\\":1,\\\\\\"cicd_ReleaseTagAssociation\\\\\\":1,\\\\\\"faros_VcsRepositoryOptions\\\\\\":1,\\\\\\"tms_Label\\\\\\":1,\\\\\\"tms_Project\\\\\\":1,\\\\\\"tms_Task\\\\\\":1,\\\\\\"tms_TaskAssignment\\\\\\":1,\\\\\\"tms_TaskBoard\\\\\\":1,\\\\\\"tms_TaskBoardProjectRelationship\\\\\\":1,\\\\\\"tms_TaskBoardRelationship\\\\\\":1,\\\\\\"tms_TaskProjectRelationship\\\\\\":1,\\\\\\"tms_TaskTag\\\\\\":1,\\\\\\"vcs_Commit\\\\\\":2,\\\\\\"vcs_Label\\\\\\":1,\\\\\\"vcs_Membership\\\\\\":1,\\\\\\"vcs_Organization\\\\\\":1,\\\\\\"vcs_PullRequest\\\\\\":1,\\\\\\"vcs_PullRequestComment\\\\\\":2,\\\\\\"vcs_PullRequestLabel\\\\\\":1,\\\\\\"vcs_PullRequestReview\\\\\\":3,\\\\\\"vcs_Repository\\\\\\":1,\\\\\\"vcs_Tag\\\\\\":1,\\\\\\"vcs_User\\\\\\":1}\\"},\\"type\\":\\"LOG\\"}",
   "Skipped 0 records",
   "Errored 0 records",
 ]
@@ -24,6 +24,15 @@ Array [
         "detail": "Group",
       },
       "uid": "12372707",
+    },
+  },
+  Object {
+    "cicd_Organization": Object {
+      "description": "",
+      "name": "farosai",
+      "source": "GitLab",
+      "uid": "12372707",
+      "url": "https://gitlab.com/groups/farosai",
     },
   },
   Object {
@@ -73,6 +82,19 @@ Array [
         "uid": "12372707/farosce-test",
       },
       "source": "GitLab",
+    },
+  },
+  Object {
+    "cicd_Pipeline": Object {
+      "description": "Test project for FarosCE GitLab integration",
+      "name": "FarosCE test",
+      "organization": Object {
+        "source": "GitLab",
+        "uid": "12372707",
+      },
+      "source": "GitLab",
+      "uid": "farosce-test",
+      "url": "https://gitlab.com/farosai/farosce-test",
     },
   },
   Object {


### PR DESCRIPTION
## Summary
- Added `cicd_Organization` model to `faros_groups.ts` converter
- Added `cicd_Pipeline` model to `faros_projects.ts` converter  
- Updated test snapshots to include new CI/CD models
- Enhanced CLAUDE.md testing guide with build reminders

## Details
This PR implements CI/CD model generation for GitLab converters to support deployment tracking and pipeline analysis.

### Changes Made
1. **faros_groups.ts**: Now writes `cicd_Organization` with GitLab group data
2. **faros_projects.ts**: Now writes `cicd_Pipeline` with GitLab project data
3. **Test Coverage**: Updated snapshots showing 2 additional records (29 total vs 27)
4. **Documentation**: Added build step reminders to prevent common testing issues

### Field Mappings
- **cicd_Organization**: uid, source, name, description, url
- **cicd_Pipeline**: uid, organization (reference), name, description, url

## Test plan
- [x] Built TypeScript code with `npm run build`
- [x] Ran GitLab converter tests: `npm test -- faros_gitlab.test.ts`
- [x] Verified new models appear in test output:
  - `cicd_Organization`: 1 record
  - `cicd_Pipeline`: 1 record
- [x] Updated test snapshots with expected output
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)