### PR TITLE
FAI-16936 feat: add Azure Blob Storage support for sync log uploads

### DIFF
--- a/destinations/airbyte-faros-destination/src/sync.ts
+++ b/destinations/airbyte-faros-destination/src/sync.ts
@@ -7,6 +7,7 @@ import {
 } from 'faros-js-client';
 import {DEFAULT_AXIOS_CONFIG} from 'faros-js-client/lib/client';
 import {Dictionary} from 'ts-essentials';
+import {URL} from 'url';
 import {VError} from 'verror';
 
 import {LogContent} from './destination-logger';
@@ -209,7 +210,8 @@ class FarosSyncClient extends FarosClient {
       'content-md5': hash,
       'content-type': 'text/plain; charset=UTF-8',
     };
-    if (urlResp.uploadUrl.includes('windows.net')) {
+    const parsedUrl = new URL(urlResp.uploadUrl);
+    if (parsedUrl.host.endsWith('.windows.net')) {
       headers['x-ms-blob-type'] = 'BlockBlob';
     }
     const uploadResp = await this.attemptRequest(

--- a/destinations/airbyte-faros-destination/src/sync.ts
+++ b/destinations/airbyte-faros-destination/src/sync.ts
@@ -204,14 +204,16 @@ class FarosSyncClient extends FarosClient {
       this._axiosConfig ?? DEFAULT_AXIOS_CONFIG,
       this.logger
     );
+    const headers: Record<string, string> = {
+      'content-length': `${content.length}`,
+      'content-md5': hash,
+      'content-type': 'text/plain; charset=UTF-8',
+    };
+    if (urlResp.uploadUrl.includes('windows.net')) {
+      headers['x-ms-blob-type'] = 'BlockBlob';
+    }
     const uploadResp = await this.attemptRequest(
-      api.put(urlResp.uploadUrl, content, {
-        headers: {
-          'content-length': content.length,
-          'content-md5': hash,
-          'content-type': 'text/plain; charset=UTF-8',
-        },
-      }),
+      api.put(urlResp.uploadUrl, content, {headers}),
       'Failed to upload sync logs'
     );
     if (!uploadResp && !skipVerify) {

--- a/destinations/airbyte-faros-destination/src/sync.ts
+++ b/destinations/airbyte-faros-destination/src/sync.ts
@@ -206,12 +206,12 @@ class FarosSyncClient extends FarosClient {
       this.logger
     );
     const headers: Record<string, string> = {
-      'content-length': `${content.length}`,
+      'content-length': `${Buffer.byteLength(content, 'utf8')}`,
       'content-md5': hash,
       'content-type': 'text/plain; charset=UTF-8',
     };
     const parsedUrl = new URL(urlResp.uploadUrl);
-    if (parsedUrl.host.endsWith('.windows.net')) {
+    if (parsedUrl.hostname.endsWith('.blob.core.windows.net')) {
       headers['x-ms-blob-type'] = 'BlockBlob';
     }
     const uploadResp = await this.attemptRequest(


### PR DESCRIPTION
## Summary
- Add x-ms-blob-type header for Azure Blob Storage uploads
- Improve header structure for better maintainability
- Ensure compatibility with Azure Blob Storage endpoints

## Test plan
- [ ] Test sync log uploads to Azure Blob Storage endpoints
- [ ] Verify existing functionality remains intact for other storage types
- [ ] Confirm proper blob type is set for Azure uploads

🤖 Generated with [Claude Code](https://claude.ai/code)