### PR TITLE
FAI-17286 Add support for custom headers in Jira source connector

### DIFF
--- a/sources/jira-source/resources/spec.json
+++ b/sources/jira-source/resources/spec.json
@@ -102,35 +102,46 @@
         "description": "Timeout in milliseconds for each request to the Jira API.",
         "default": 120000
       },
-      "use_users_prefix_search": {
+      "custom_headers": {
         "order": 14,
+        "type": "string",
+        "title": "Custom Headers",
+        "description": "JSON map of custom headers to include in all requests to the Jira API. Useful for authentication headers or other required headers.",
+        "multiline": true,
+        "default": "{}",
+        "examples": [
+          "{ \"X-API-Key\": \"your-api-key\", \"X-Custom-Header\": \"custom-value\" }"
+        ]
+      },
+      "use_users_prefix_search": {
+        "order": 15,
         "type": "boolean",
         "title": "Use Users Prefix Search",
         "default": false
       },
       "users_prefix_search_max_depth": {
-        "order": 15,
+        "order": 16,
         "type": "integer",
         "title": "Users Prefix Search Max Depth",
         "description": "Maximum depth for prefix search when use_users_prefix_search is enabled. Controls how many characters deep the search will go (e.g., 2 = 'aa', 3 = 'aaa').",
         "default": 2
       },
       "users_prefix_search_api_hard_limit": {
-        "order": 16,
+        "order": 17,
         "type": "integer",
         "title": "Users Prefix Search API Hard Limit",
         "description": "Number of results that indicates we've hit Jira's API search limit and should expand to deeper prefix searches.",
         "default": 1000
       },
       "use_faros_graph_boards_selection": {
-        "order": 17,
+        "order": 18,
         "type": "boolean",
         "title": "Use Faros Graph for Boards selection",
         "description": "Use Faros Graph for selecting which boards should be fetched (Faros credentials are required).",
         "default": false
       },
       "projects": {
-        "order": 18,
+        "order": 19,
         "title": "Project Keys",
         "description": "List of Jira project keys from which to fetch data. By default, all projects are included.",
         "type": "array",
@@ -143,7 +154,7 @@
         ]
       },
       "excluded_projects": {
-        "order": 19,
+        "order": 20,
         "title": "Excluded Project Keys",
         "description": "List of Jira project keys from which data won't be fetched. By default, no projects are excluded. If projects list is specified, this list will be ignored.",
         "type": "array",
@@ -156,21 +167,21 @@
         ]
       },
       "cutoff_days": {
-        "order": 20,
+        "order": 21,
         "type": "integer",
         "title": "Cutoff Days",
         "default": 90,
         "description": "Only fetch data updated after cutoff"
       },
       "cutoff_lag_days": {
-        "order": 21,
+        "order": 22,
         "type": "integer",
         "title": "Cutoff Lag Days",
         "default": 0,
         "description": "Apply lag to the end cutoff saved in the state. Objects updated after this will be rewritten during the next sync."
       },
       "boards": {
-        "order": 22,
+        "order": 23,
         "title": "Board IDs",
         "description": "List of Jira board IDs from which to fetch data. By default, all boards are included.",
         "type": "array",
@@ -179,7 +190,7 @@
         }
       },
       "excluded_boards": {
-        "order": 23,
+        "order": 24,
         "title": "Board IDs Excluded",
         "description": "List of Jira board IDs from which data won't be fetched. By default, no boards are excluded. If boards list is specified, this list will be ignored.",
         "type": "array",
@@ -188,7 +199,7 @@
         }
       },
       "run_mode": {
-        "order": 24,
+        "order": 25,
         "title": "Run Mode",
         "description": "Run mode for selecting the usage of the connector",
         "type": "string",
@@ -202,7 +213,7 @@
         ]
       },
       "custom_streams": {
-        "order": 25,
+        "order": 26,
         "title": "Custom Streams",
         "description": "List of streams to run when selected Run Mode is Custom (if empty, all available streams will run)",
         "type": "array",

--- a/sources/jira-source/src/index.ts
+++ b/sources/jira-source/src/index.ts
@@ -63,6 +63,15 @@ export class JiraSource extends AirbyteSourceBase<JiraConfig> {
   }
   async checkConnection(config: JiraConfig): Promise<[boolean, VError]> {
     try {
+      // Validate custom_headers JSON format if provided
+      if (config.custom_headers) {
+        try {
+          JSON.parse(config.custom_headers);
+        } catch (error) {
+          throw new VError('Invalid JSON format in custom_headers configuration');
+        }
+      }
+
       const jira = await Jira.instance(config, this.logger);
       const projectKeys = config.projects
         ? new Set(config.projects)

--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -242,7 +242,14 @@ export class Jira {
         headers: {
           'Accept-Language': 'en',
           'X-Force-Accept-Language': true,
-          ...(JSON.parse(cfg.custom_headers ?? '{}')),
+          ...(() => {
+            try {
+              return JSON.parse(cfg.custom_headers ?? '{}');
+            } catch (error) {
+              logger?.error(`Failed to parse custom_headers: ${error.message}`);
+              throw new VError('Invalid JSON in custom_headers configuration');
+            }
+          })(),
         },
         timeout: cfg.timeout ?? DEFAULT_TIMEOUT,
         // https://github.com/axios/axios/issues/5058#issuecomment-1272229926

--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -242,14 +242,7 @@ export class Jira {
         headers: {
           'Accept-Language': 'en',
           'X-Force-Accept-Language': true,
-          ...(() => {
-            try {
-              return JSON.parse(cfg.custom_headers ?? '{}');
-            } catch (error) {
-              logger?.error(`Failed to parse custom_headers: ${error.message}`);
-              throw new VError('Invalid JSON in custom_headers configuration');
-            }
-          })(),
+          ...(JSON.parse(cfg.custom_headers ?? '{}')),
         },
         timeout: cfg.timeout ?? DEFAULT_TIMEOUT,
         // https://github.com/axios/axios/issues/5058#issuecomment-1272229926

--- a/sources/jira-source/src/jira.ts
+++ b/sources/jira-source/src/jira.ts
@@ -83,6 +83,7 @@ export interface JiraConfig extends AirbyteConfig, RoundRobinConfig {
   readonly start_date?: string;
   readonly end_date?: string;
   readonly source_qualifier?: string;
+  readonly custom_headers?: string;
   // startDate and endDate are calculated from start_date, end_date, and cutoff_days
   startDate?: Date;
   endDate?: Date;
@@ -241,6 +242,7 @@ export class Jira {
         headers: {
           'Accept-Language': 'en',
           'X-Force-Accept-Language': true,
+          ...(JSON.parse(cfg.custom_headers ?? '{}')),
         },
         timeout: cfg.timeout ?? DEFAULT_TIMEOUT,
         // https://github.com/axios/axios/issues/5058#issuecomment-1272229926


### PR DESCRIPTION
## Summary
- Add custom_headers configuration option to allow users to specify custom headers for Jira API requests
- Useful for Jira servers that require specific authentication headers or other custom headers
- Follows the same pattern as replace_origin_map in the Faros destination (JSON string format)

## Changes
- Added `custom_headers` field to JiraConfig interface as optional string
- Updated spec.json to include custom_headers configuration with proper documentation
- Modified Jira client initialization to parse custom_headers JSON and include in baseRequestConfig
- Updated all order numbers in spec.json to accommodate new field

## Usage
Users can now configure custom headers by providing a JSON string:
```json
{
  "custom_headers": "{ \"X-API-Key\": \"your-api-key\", \"X-Custom-Header\": \"custom-value\" }"
}
```

## Test plan
- [x] Verify configuration parsing works correctly
- [x] Confirm headers are included in API requests
- [x] Test with empty/missing custom_headers (should default to {})
- [x] Validate JSON parsing error handling

🤖 Generated with [Claude Code](https://claude.ai/code)