### PR TITLE
Add faros_deployments stream to GitLab source

### DIFF
--- a/faros-airbyte-common/src/gitlab/types.ts
+++ b/faros-airbyte-common/src/gitlab/types.ts
@@ -1,6 +1,7 @@
 import {
   Camelize,
   CommitSchema,
+  DeploymentSchema,
   EventSchema,
   GroupSchema,
   IssueSchema,
@@ -141,3 +142,9 @@ export type FarosReleaseOutput = {
   | 'released_at'
   | '_links'
 >;
+
+export type FarosDeploymentOutput = {
+  readonly __brand: 'FarosDeployment';
+  group_id: string;
+  path_with_namespace: string;
+} & DeploymentSchema;

--- a/sources/gitlab-source/resources/schemas/farosDeployments.json
+++ b/sources/gitlab-source/resources/schemas/farosDeployments.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "number"
+    },
+    "iid": {
+      "type": "number"
+    },
+    "ref": {
+      "type": "string"
+    },
+    "sha": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "user": {
+      "type": "object"
+    },
+    "deployable": {
+      "type": ["object", "null"]
+    },
+    "environment": {
+      "type": "object"
+    },
+    "group_id": {
+      "type": "string"
+    },
+    "path_with_namespace": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "iid",
+    "ref",
+    "sha",
+    "created_at",
+    "updated_at",
+    "status",
+    "environment",
+    "group_id",
+    "path_with_namespace"
+  ]
+}

--- a/sources/gitlab-source/src/index.ts
+++ b/sources/gitlab-source/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from './gitlab';
 import {RunMode, RunModeStreams} from './streams/common';
 import {FarosCommits} from './streams/faros_commits';
+import {FarosDeployments} from './streams/faros_deployments';
 import {FarosGroups} from './streams/faros_groups';
 import {FarosIssues} from './streams/faros_issues';
 import {FarosMergeRequestReviews} from './streams/faros_merge_request_reviews';
@@ -73,6 +74,7 @@ export class GitLabSource extends AirbyteSourceBase<GitLabConfig> {
     const farosClient = this.makeFarosClient(config);
     return [
       new FarosCommits(config, this.logger, farosClient),
+      new FarosDeployments(config, this.logger, farosClient),
       new FarosGroups(config, this.logger, farosClient),
       new FarosIssues(config, this.logger, farosClient),
       new FarosMergeRequests(config, this.logger, farosClient),

--- a/sources/gitlab-source/src/streams/common.ts
+++ b/sources/gitlab-source/src/streams/common.ts
@@ -43,6 +43,7 @@ export const MinimumStreamNames = [
 
 export const FullStreamNames = [
   'faros_commits',
+  'faros_deployments',
   'faros_groups',
   'faros_issues',
   'faros_merge_requests',
@@ -56,6 +57,7 @@ export const FullStreamNames = [
 // fill as streams are developed
 export const CustomStreamNames = [
   'faros_commits',
+  'faros_deployments',
   'faros_groups',
   'faros_issues',
   'faros_merge_requests',

--- a/sources/gitlab-source/src/streams/faros_deployments.ts
+++ b/sources/gitlab-source/src/streams/faros_deployments.ts
@@ -1,0 +1,69 @@
+import {StreamKey, SyncMode} from 'faros-airbyte-cdk';
+import {FarosDeploymentOutput} from 'faros-airbyte-common/gitlab';
+import {Utils} from 'faros-js-client';
+import {Dictionary} from 'ts-essentials';
+
+import {GitLab} from '../gitlab';
+import {
+  ProjectStreamSlice,
+  StreamBase,
+  StreamState,
+  StreamWithProjectSlices,
+} from './common';
+
+export class FarosDeployments extends StreamWithProjectSlices {
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/farosDeployments.json');
+  }
+
+  get primaryKey(): StreamKey {
+    return ['id', 'path_with_namespace'];
+  }
+
+  get cursorField(): string | string[] {
+    return 'updated_at';
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: ProjectStreamSlice,
+    streamState?: StreamState,
+  ): AsyncGenerator<FarosDeploymentOutput> {
+    const gitlab = await GitLab.instance(this.config, this.logger);
+    const stateKey = StreamBase.groupProjectKey(
+      streamSlice.group_id,
+      streamSlice.path_with_namespace,
+    );
+    const state = streamState?.[stateKey];
+    const [startDate, endDate] =
+      syncMode === SyncMode.INCREMENTAL
+        ? this.getUpdateRange(state?.cutoff)
+        : this.getUpdateRange();
+
+    for await (const deployment of gitlab.getDeployments(
+      streamSlice.path_with_namespace,
+      startDate,
+      endDate,
+    )) {
+      yield {
+        ...deployment,
+        group_id: streamSlice.group_id,
+        path_with_namespace: streamSlice.path_with_namespace,
+      } as FarosDeploymentOutput;
+    }
+  }
+
+  getUpdatedState(
+    currentStreamState: StreamState,
+    latestRecord: FarosDeploymentOutput,
+    slice: ProjectStreamSlice,
+  ): StreamState {
+    const latestRecordCutoff = Utils.toDate(latestRecord?.updated_at ?? 0);
+    return this.getUpdatedStreamState(
+      latestRecordCutoff,
+      currentStreamState,
+      StreamBase.groupProjectKey(slice.group_id, slice.path_with_namespace),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new `faros_deployments` stream to the GitLab source connector, porting functionality from the GitLab feed to support deployment data extraction.

### Key Features

- **Incremental Stream**: Uses `updated_at` as cursor field for efficient syncing
- **Project-Scoped**: Extends `StreamWithProjectSlices` for parallel project processing  
- **Raw Data Output**: Returns unprocessed GitLab deployment data for destination converters
- **User Collection**: Automatically collects user data for deployment creators and build users
- **Complete Deployment Info**: Includes deployable (build/job), environment, and commit data

### Implementation Details

- **Type Definition**: Added `FarosDeploymentOutput` type in `faros-airbyte-common`
- **GitLab Client**: New `getDeployments()` method with pagination and incremental support
- **Stream Implementation**: Full incremental stream following existing patterns
- **Schema**: JSON schema for deployment data validation
- **Configuration**: Added to Full and Custom run modes

### Data Structure

The stream returns deployment records containing:
- Core deployment fields (id, status, ref, sha, timestamps)
- Environment information (name, external_url, etc.)
- Deployable/build details with artifacts
- User information for deployment creator
- Project context (group_id, path_with_namespace)

This provides all necessary data for destination converters to create:
- `cicd_Deployment` entities
- `cicd_Artifact` entities  
- `cicd_ArtifactCommitAssociation` links
- `cicd_ArtifactDeployment` associations

## Test plan

- [x] TypeScript compilation passes
- [x] Build succeeds without errors
- [x] Follows existing stream patterns
- [ ] Integration test with GitLab API
- [ ] Verify incremental sync behavior
- [ ] Test with destination converters

🤖 Generated with [Claude Code](https://claude.ai/code)