### PR TITLE
Add progress tracking for Airbyte sync streams and slices

### DIFF
--- a/faros-airbyte-cdk/src/sources/streams/stream-base.ts
+++ b/faros-airbyte-cdk/src/sources/streams/stream-base.ts
@@ -145,6 +145,19 @@ export abstract class AirbyteStreamBase {
   }
 
   /**
+   * Override to return the total number of slices this stream will generate.
+   * This enables progress tracking showing (X/Y) slice progress.
+   * Return undefined if the count cannot be determined efficiently.
+   */
+  async getSliceCount(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamState?: Dictionary<any>
+  ): Promise<number | undefined> {
+    return undefined;
+  }
+
+  /**
    * Percentage of slices (expressed as decimal from 0 to 1) that have to error
    * for the stream to count as a failure instead of a partial success.
    */


### PR DESCRIPTION
## Summary
Adds progress tracking to Airbyte syncs to provide better visibility into sync progress:

• **Stream Progress**: Shows `(X/Y)` format for stream processing order  
• **Slice Progress**: Opt-in approach using new `getSliceCount()` method
  - Streams implementing `getSliceCount()` show `(X/Y)` slice progress
  - Other streams show incremental `#X` slice counters

## Implementation Details

### Stream Progress
- Added `streamIndex` and `totalStreams` tracking in main sync loop
- Updated logging to show: `Syncing repositories stream (2/5) in incremental mode`

### Slice Progress  
- Added optional `getSliceCount()` method to `AirbyteStreamBase`
- Default implementation returns `undefined` (opt-in behavior)
- Streams can override to provide total slice count when known upfront
- Updated slice logging to show progress when available

## Example Output

**With slice progress (when stream implements getSliceCount()):**
```
Syncing repositories stream (2/5) in incremental mode
Started processing repositories stream slice {"repo": "project1"} (1/15)
Finished processing repositories stream slice {"repo": "project1"} (1/15). Read 67 records
```

**Without slice progress (default):**
```
Syncing users stream (1/5) in full mode  
Started processing users stream slice #1: {"org": "acme"}
Finished processing users stream slice #1: {"org": "acme"}. Read 245 records
```

## Benefits

- **Zero performance impact** for existing streams
- **Backward compatible** - no changes required for existing sources
- **Opt-in slice progress** - streams can add when beneficial
- **Clean architecture** - separates progress logic from business data

## Test plan
- [x] All existing tests pass
- [x] No new linting issues  
- [x] Stream progress shows correctly in test output
- [x] Slice progress defaults to incremental counters (as expected)
- [x] Method-based approach works with async slice counting

🤖 Generated with [Claude Code](https://claude.ai/code)