### PR TITLE
Add Azure DevOps work item to pull request linking functionality

### DIFF
--- a/faros-airbyte-common/src/azure-devops/types.ts
+++ b/faros-airbyte-common/src/azure-devops/types.ts
@@ -150,3 +150,14 @@ export interface AdditionalField {
   name: string;
   value: string;
 }
+
+export interface WorkItemPullRequest {
+  readonly repositoryId: string;
+  readonly pullRequestId: number;
+  readonly url: string;
+  readonly projectId: string;
+}
+
+export interface WorkItemWithPullRequestsAndRevisions extends WorkItemWithRevisions {
+  pullRequests: ReadonlyArray<WorkItemPullRequest>;
+}

--- a/sources/azure-workitems-source/test_files/workitem_with_pullrequests.json
+++ b/sources/azure-workitems-source/test_files/workitem_with_pullrequests.json
@@ -1,0 +1,60 @@
+{
+  "id": 12345,
+  "rev": 1,
+  "fields": {
+    "System.AreaPath": "Project\\Team\\Component",
+    "System.TeamProject": "MyProject",
+    "System.WorkItemType": "Task",
+    "System.State": "Active",
+    "System.Title": "Implement new feature",
+    "System.CreatedDate": "2024-01-15T10:00:00Z",
+    "System.ChangedDate": "2024-01-15T10:00:00Z",
+    "Faros": {
+      "WorkItemStateCategory": {
+        "name": "Active",
+        "category": "InProgress"
+      }
+    }
+  },
+  "relations": [
+    {
+      "rel": "ArtifactLink",
+      "url": "vstfs:///Git/PullRequestId/proj-123/repo-456/789",
+      "attributes": {
+        "name": "pull request"
+      }
+    },
+    {
+      "rel": "ArtifactLink", 
+      "url": "vstfs:///Git/PullRequestId/proj-123/repo-456/790",
+      "attributes": {
+        "name": "pull request"
+      }
+    }
+  ],
+  "revisions": {
+    "states": [],
+    "assignees": [],
+    "iterations": []
+  },
+  "additionalFields": [],
+  "project": {
+    "id": "proj-123",
+    "name": "MyProject",
+    "url": "https://dev.azure.com/myorg/proj-123"
+  },
+  "pullRequests": [
+    {
+      "repositoryId": "repo-456",
+      "pullRequestId": 789,
+      "url": "vstfs:///Git/PullRequestId/proj-123/repo-456/789",
+      "projectId": "proj-123"
+    },
+    {
+      "repositoryId": "repo-456", 
+      "pullRequestId": 790,
+      "url": "vstfs:///Git/PullRequestId/proj-123/repo-456/790",
+      "projectId": "proj-123"
+    }
+  ]
+}


### PR DESCRIPTION
This implementation adds the ability for Azure DevOps Boards connector to query pull requests from work item Development sections and create Task Pull Request relationships, mirroring the Jira connector's GitHub PR integration.

Changes:
- Add WorkItemPullRequest and WorkItemWithPullRequestsAndRevisions types to azure-devops common
- Update Azure DevOps workitems source to extract pull request artifact links from relations
- Add pull request URL parsing for vstfs:///Git/PullRequestId/{projectId}/{repositoryId}/{pullRequestId} format
- Add tms_TaskPullRequestAssociation converter for creating Task-PR relationships
- Extract organization from project URL for proper repository identification
- Add test data for work items with pull request associations

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

> Provide description here

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
