### PR TITLE
FAI-16829: Add usage stream to CircleCI source

### DIFF
--- a/sources/circleci-source/package.json
+++ b/sources/circleci-source/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@types/glob-to-regexp": "^0.4.4",
     "axios": "^1.8.4",
+    "csv-parse": "^5.5.0",
     "faros-airbyte-cdk": "*",
     "faros-airbyte-common": "*",
     "glob-to-regexp": "0.4.1",

--- a/sources/circleci-source/resources/schemas/usage.json
+++ b/sources/circleci-source/resources/schemas/usage.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "organization_id": {
+      "type": "string",
+      "description": "The unique identifier for the organization"
+    },
+    "organization_name": {
+      "type": "string",
+      "description": "The name of the organization"
+    },
+    "job_id": {
+      "type": "string",
+      "description": "The unique identifier for the job"
+    },
+    "job_run_date": {
+      "type": "string",
+      "format": "date",
+      "description": "The date when the job was run"
+    },
+    "compute_credits": {
+      "type": "number",
+      "description": "Credits used for compute resources"
+    },
+    "dlc_credits": {
+      "type": "number",
+      "description": "Credits used for DLC (Docker Layer Caching)"
+    },
+    "user_credits": {
+      "type": "number",
+      "description": "Credits used for user-based resources"
+    },
+    "storage_credits": {
+      "type": "number",
+      "description": "Credits used for storage"
+    },
+    "network_credits": {
+      "type": "number",
+      "description": "Credits used for network resources"
+    },
+    "lease_credits": {
+      "type": "number",
+      "description": "Credits used for lease resources"
+    },
+    "lease_overage_credits": {
+      "type": "number",
+      "description": "Credits used for lease overage"
+    },
+    "ipranges_credits": {
+      "type": "number",
+      "description": "Credits used for IP ranges"
+    },
+    "total_credits": {
+      "type": "number",
+      "description": "Total credits used"
+    }
+  },
+  "required": [
+    "organization_id",
+    "organization_name",
+    "job_id",
+    "job_run_date",
+    "compute_credits",
+    "dlc_credits",
+    "user_credits",
+    "storage_credits",
+    "network_credits",
+    "lease_credits",
+    "lease_overage_credits",
+    "ipranges_credits",
+    "total_credits"
+  ]
+}

--- a/sources/circleci-source/src/index.ts
+++ b/sources/circleci-source/src/index.ts
@@ -15,7 +15,7 @@ import VError from 'verror';
 
 import {CircleCI, CircleCIConfig} from './circleci/circleci';
 import {Faros} from './faros/faros';
-import {Pipelines, Projects, Tests} from './streams';
+import {Pipelines, Projects, Tests, Usage} from './streams';
 
 /** The main entry point. */
 export function mainCommand(): Command {
@@ -120,6 +120,7 @@ export class CircleCISource extends AirbyteSourceBase<CircleCIConfig> {
       new Projects(config, this.logger),
       new Pipelines(config, this.logger),
       new Tests(config, this.logger),
+      new Usage(config, this.logger),
     ];
   }
 

--- a/sources/circleci-source/src/streams/common.ts
+++ b/sources/circleci-source/src/streams/common.ts
@@ -1,7 +1,7 @@
 import {AirbyteLogger, AirbyteStreamBase} from 'faros-airbyte-cdk';
 import {bucket} from 'faros-airbyte-common/common';
 
-import {CircleCIConfig} from '../circleci/circleci';
+import {CircleCI, CircleCIConfig} from '../circleci/circleci';
 
 export abstract class StreamWithProjectSlices extends AirbyteStreamBase {
   constructor(
@@ -30,6 +30,34 @@ export abstract class StreamWithProjectSlices extends AirbyteStreamBase {
   }
 }
 
-export type StreamSlice = {
+export type ProjectSlice = {
   projectSlug: string;
+};
+
+export abstract class StreamWithOrganizationSlices extends AirbyteStreamBase {
+  constructor(
+    protected readonly cfg: CircleCIConfig,
+    protected readonly logger: AirbyteLogger
+  ) {
+    super(logger);
+  }
+
+  async *streamSlices(): AsyncGenerator<OrganizationSlice> {
+    const circleCI = CircleCI.instance(this.cfg, this.logger);
+    const organizations = await circleCI.getAllOrganizations();
+
+    for (const org of organizations) {
+      yield {
+        orgId: org.id,
+        orgSlug: org.slug,
+        orgName: org.name,
+      };
+    }
+  }
+}
+
+export type OrganizationSlice = {
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
 };

--- a/sources/circleci-source/src/streams/index.ts
+++ b/sources/circleci-source/src/streams/index.ts
@@ -1,3 +1,4 @@
 export {Projects} from './projects';
 export {Pipelines} from './pipelines';
 export {Tests} from './tests';
+export {Usage} from './usage';

--- a/sources/circleci-source/src/streams/pipelines.ts
+++ b/sources/circleci-source/src/streams/pipelines.ts
@@ -3,7 +3,7 @@ import {Pipeline} from 'faros-airbyte-common/circleci';
 import {Dictionary} from 'ts-essentials';
 
 import {CircleCI} from '../circleci/circleci';
-import {StreamSlice, StreamWithProjectSlices} from './common';
+import {ProjectSlice, StreamWithProjectSlices} from './common';
 
 type PipelineState = Dictionary<{lastUpdatedAt?: string}>;
 
@@ -23,7 +23,7 @@ export class Pipelines extends StreamWithProjectSlices {
   async *readRecords(
     syncMode: SyncMode,
     cursorField?: string[],
-    streamSlice?: StreamSlice,
+    streamSlice?: ProjectSlice,
     streamState?: PipelineState
   ): AsyncGenerator<Pipeline, any, unknown> {
     const circleCI = CircleCI.instance(this.cfg, this.logger);

--- a/sources/circleci-source/src/streams/tests.ts
+++ b/sources/circleci-source/src/streams/tests.ts
@@ -3,7 +3,7 @@ import {TestMetadata} from 'faros-airbyte-common/circleci';
 import {Dictionary} from 'ts-essentials';
 
 import {CircleCI} from '../circleci/circleci';
-import {StreamSlice, StreamWithProjectSlices} from './common';
+import {ProjectSlice, StreamWithProjectSlices} from './common';
 
 type TestsState = Dictionary<{lastUpdatedAt?: string}>;
 
@@ -23,7 +23,7 @@ export class Tests extends StreamWithProjectSlices {
   async *readRecords(
     syncMode: SyncMode,
     cursorField?: string[],
-    streamSlice?: StreamSlice,
+    streamSlice?: ProjectSlice,
     streamState?: TestsState
   ): AsyncGenerator<TestMetadata, any, unknown> {
     const circleCI = CircleCI.instance(this.cfg, this.logger);

--- a/sources/circleci-source/src/streams/usage.ts
+++ b/sources/circleci-source/src/streams/usage.ts
@@ -1,0 +1,201 @@
+import {SyncMode} from 'faros-airbyte-cdk';
+import {Dictionary} from 'ts-essentials';
+
+import {CircleCI, UsageExportJob,UsageRecord} from '../circleci/circleci';
+import {OrganizationSlice, StreamWithOrganizationSlices} from './common';
+
+interface UsageState {
+  start?: string;
+  end?: string;
+  job_id?: string;
+  state?: string;
+}
+
+type UsageStreamState = Dictionary<UsageState>;
+
+export class Usage extends StreamWithOrganizationSlices {
+  private syncTimestamp: Date;
+  private stateUpdates: Map<string, UsageState> = new Map();
+
+  getJsonSchema(): Dictionary<any, string> {
+    return require('../../resources/schemas/usage.json');
+  }
+
+  get primaryKey(): string[] {
+    return ['organization_id', 'job_run_date'];
+  }
+
+  async *readRecords(
+    syncMode: SyncMode,
+    cursorField?: string[],
+    streamSlice?: OrganizationSlice,
+    streamState?: UsageStreamState
+  ): AsyncGenerator<UsageRecord, any, unknown> {
+    const circleCI = CircleCI.instance(this.cfg, this.logger);
+
+    // Initialize sync timestamp once for all slices
+    if (!this.syncTimestamp) {
+      this.syncTimestamp = new Date();
+    }
+
+    const orgState = streamState?.[streamSlice.orgId] || {};
+    const now = this.syncTimestamp;
+
+    this.logger.info(
+      `Processing usage for organization ${streamSlice.orgName} (${streamSlice.orgId})`
+    );
+
+    // Check if we have an existing job
+    if (orgState.job_id) {
+      this.logger.debug(
+        `Found existing job ${orgState.job_id} in state ${orgState.state} for org ${streamSlice.orgId}`
+      );
+
+      if (orgState.state === 'created' || orgState.state === 'processing') {
+        // Check the status of the existing job
+        const jobStatus = await circleCI.getUsageExport(
+          streamSlice.orgId,
+          orgState.job_id
+        );
+
+        if (jobStatus.state === 'completed') {
+          this.logger.info(
+            `Usage export job ${orgState.job_id} completed for org ${streamSlice.orgId}`
+          );
+
+          // Update state to completed
+          this.stateUpdates.set(streamSlice.orgId, {
+            start: jobStatus.start,
+            end: jobStatus.end,
+            job_id: jobStatus.usage_export_job_id,
+            state: jobStatus.state,
+          });
+
+          // Download and parse the files
+          if (jobStatus.download_urls && jobStatus.download_urls.length > 0) {
+            yield* circleCI.downloadAndParseUsageFiles(
+              jobStatus.download_urls,
+              streamSlice.orgId,
+              streamSlice.orgName
+            );
+          }
+
+          return;
+        } else if (jobStatus.state === 'processing') {
+          this.logger.info(
+            `Usage export job ${orgState.job_id} still processing for org ${streamSlice.orgId}`
+          );
+          // Update state with current status
+          this.stateUpdates.set(streamSlice.orgId, {
+            start: jobStatus.start,
+            end: jobStatus.end,
+            job_id: jobStatus.usage_export_job_id,
+            state: jobStatus.state,
+          });
+          return;
+        } else if (jobStatus.state === 'failed') {
+          this.logger.warn(
+            `Usage export job ${orgState.job_id} failed for org ${streamSlice.orgId}, creating new export`
+          );
+
+          // Create new export with same start time unless it's too old
+          const existingStart = new Date(orgState.start);
+          const thirtyDaysAgo = new Date(now);
+          thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+          const startTime =
+            existingStart < thirtyDaysAgo ? thirtyDaysAgo : existingStart;
+
+          const newJob = await circleCI.createUsageExport(
+            streamSlice.orgId,
+            startTime.toISOString(),
+            now.toISOString()
+          );
+
+          this.logger.info(
+            `Created new usage export job ${newJob.usage_export_job_id} for org ${streamSlice.orgId}`
+          );
+
+          // Update state with new job
+          this.stateUpdates.set(streamSlice.orgId, {
+            start: newJob.start,
+            end: newJob.end,
+            job_id: newJob.usage_export_job_id,
+            state: newJob.state,
+          });
+
+          return;
+        }
+      }
+    }
+
+    // Check if we have a completed state, create incremental export
+    if (orgState.state === 'completed' && orgState.end) {
+      this.logger.info(
+        `Creating incremental usage export for org ${streamSlice.orgId} from ${orgState.end}`
+      );
+
+      const job = await circleCI.createUsageExport(
+        streamSlice.orgId,
+        orgState.end,
+        now.toISOString()
+      );
+
+      this.logger.info(
+        `Created incremental usage export job ${job.usage_export_job_id} for org ${streamSlice.orgId}`
+      );
+
+      // Update state with new job
+      this.stateUpdates.set(streamSlice.orgId, {
+        start: job.start,
+        end: job.end,
+        job_id: job.usage_export_job_id,
+        state: job.state,
+      });
+
+      return;
+    }
+
+    // First time processing this org - create initial export
+    const thirtyDaysAgo = new Date(now);
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    this.logger.info(
+      `Creating initial usage export for org ${streamSlice.orgId} from ${thirtyDaysAgo.toISOString()} to ${now.toISOString()}`
+    );
+
+    const job = await circleCI.createUsageExport(
+      streamSlice.orgId,
+      thirtyDaysAgo.toISOString(),
+      now.toISOString()
+    );
+
+    this.logger.info(
+      `Created initial usage export job ${job.usage_export_job_id} for org ${streamSlice.orgId}`
+    );
+
+    // Update state with new job
+    this.stateUpdates.set(streamSlice.orgId, {
+      start: job.start,
+      end: job.end,
+      job_id: job.usage_export_job_id,
+      state: job.state,
+    });
+  }
+
+  getUpdatedState(
+    currentStreamState: UsageStreamState,
+    latestRecord: UsageRecord
+  ): UsageStreamState {
+    // Apply any pending state updates
+    const newState = {...currentStreamState};
+
+    // Check if we have a state update for this organization
+    const stateUpdate = this.stateUpdates.get(latestRecord.organization_id);
+    if (stateUpdate) {
+      newState[latestRecord.organization_id] = stateUpdate;
+    }
+
+    return newState;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements new "usage" stream for CircleCI source with organization-based slicing
- Adds comprehensive usage export job management with state tracking
- Supports CSV decompression and parsing for usage credit data
- Implements proper retry logic and incremental sync capabilities

## Changes Made

### New Components
- **StreamWithOrganizationSlices**: Base class for organization-based slicing
- **Usage Stream**: New stream implementation with complex state management
- **Usage Schema**: JSON schema definition for usage records
- **API Extensions**: New methods for organization and usage export management

### Key Features
- **Organization Slicing**: Uses `/me/collaborations` endpoint to get all organizations
- **State Management**: Tracks export job status (created, processing, completed, failed) per organization
- **CSV Processing**: Downloads and parses `.csv.gz` files with proper field mapping
- **Retry Logic**: Handles failed exports with appropriate retry behavior
- **Incremental Sync**: Supports resuming from previous sync state
- **Time Synchronization**: Single timestamp used across all organizations

### Technical Details
- **Export Job Flow**: Creates → monitors → downloads → parses usage export jobs
- **State Tracking**: Maintains `start`, `end`, `job_id`, and `state` per organization
- **30-day Lookback**: Initial sync covers last 30 days of usage data
- **Error Handling**: Comprehensive error handling with logging and graceful degradation

🤖 Generated with [Claude Code](https://claude.ai/code)