### PR TITLE
FAI-17416: Add branch information to GitLab merge requests

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/common/vcs.ts
+++ b/destinations/airbyte-faros-destination/src/converters/common/vcs.ts
@@ -202,7 +202,7 @@ export class BranchCollector {
   private readonly collectedBranches = new Map<string, BranchKey>();
 
   collectBranch(branchName: string, repoKey: RepoKey): BranchKey | null {
-    if (!branchName) {
+    if (!branchName || !repoKey?.name || !repoKey?.organization?.uid) {
       return null;
     }
 

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/faros_merge_requests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/faros_merge_requests.ts
@@ -190,6 +190,12 @@ export class FarosMergeRequests extends GitlabConverter {
     return res;
   }
 
+  async onProcessingComplete(
+    ctx: StreamContext
+  ): Promise<ReadonlyArray<DestinationRecord>> {
+    return this.branchCollector.convertBranches();
+  }
+
   private extractIdFromGid(gid: string): number | null {
     // Extract numeric ID from GitLab GID format (e.g., gid://gitlab/Note/2559908301)
     // If it's already a number, return it as is

--- a/destinations/airbyte-faros-destination/src/converters/gitlab/faros_merge_requests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/gitlab/faros_merge_requests.ts
@@ -3,6 +3,7 @@ import {FarosMergeRequestOutput} from 'faros-airbyte-common/gitlab';
 import {Utils} from 'faros-js-client';
 import {toLower} from 'lodash';
 
+import {BranchCollector} from '../common/vcs';
 import {DestinationModel, DestinationRecord, StreamContext} from '../converter';
 import {GitlabConverter} from './common';
 
@@ -13,12 +14,15 @@ interface DiffStatsSummary {
 }
 
 export class FarosMergeRequests extends GitlabConverter {
+  private readonly branchCollector = new BranchCollector();
+
   readonly destinationModels: ReadonlyArray<DestinationModel> = [
     'vcs_PullRequest',
     'vcs_PullRequestComment',
     'vcs_PullRequestReview',
     'vcs_PullRequestLabel',
     'vcs_Label',
+    'vcs_Branch',
   ];
 
   id(record: AirbyteRecord): string {
@@ -48,6 +52,28 @@ export class FarosMergeRequests extends GitlabConverter {
 
     const res: DestinationRecord[] = [];
 
+    // Build source repository for cross-project MRs
+    const sourceRepository =
+      mergeRequest.sourceProjectId === mergeRequest.targetProjectId
+        ? repository
+        : {
+            name: mergeRequest.sourceProject?.path?.toLowerCase(),
+            uid: mergeRequest.sourceProject?.path?.toLowerCase(),
+            organization: {
+              uid: mergeRequest.sourceProject?.group?.id?.toLowerCase(),
+              source,
+            },
+          };
+
+    const sourceBranch = this.branchCollector.collectBranch(
+      mergeRequest.sourceBranch,
+      sourceRepository
+    );
+    const targetBranch = this.branchCollector.collectBranch(
+      mergeRequest.targetBranch,
+      repository
+    );
+
     // Create main vcs_PullRequest record
     res.push({
       model: 'vcs_PullRequest',
@@ -62,18 +88,31 @@ export class FarosMergeRequests extends GitlabConverter {
         mergedAt: Utils.toDate(mergeRequest.mergedAt),
         commentCount: mergeRequest.userNotesCount,
         commitCount: mergeRequest.commitCount,
-        diffStats: mergeRequest.diffStatsSummary ? {
-          linesAdded: (mergeRequest.diffStatsSummary as DiffStatsSummary).additions,
-          linesDeleted: (mergeRequest.diffStatsSummary as DiffStatsSummary).deletions,
-          filesChanged: (mergeRequest.diffStatsSummary as DiffStatsSummary).fileCount,
-        } : null,
-        author: mergeRequest.author_username 
+        diffStats: mergeRequest.diffStatsSummary
+          ? {
+              linesAdded: (mergeRequest.diffStatsSummary as DiffStatsSummary)
+                .additions,
+              linesDeleted: (mergeRequest.diffStatsSummary as DiffStatsSummary)
+                .deletions,
+              filesChanged: (mergeRequest.diffStatsSummary as DiffStatsSummary)
+                .fileCount,
+            }
+          : null,
+        author: mergeRequest.author_username
           ? {uid: mergeRequest.author_username, source}
           : null,
         mergeCommit: mergeRequest.mergeCommitSha
-          ? {repository, sha: mergeRequest.mergeCommitSha, uid: mergeRequest.mergeCommitSha}
+          ? {
+              repository,
+              sha: mergeRequest.mergeCommitSha,
+              uid: mergeRequest.mergeCommitSha,
+            }
           : null,
         repository,
+        sourceBranch,
+        sourceBranchName: mergeRequest.sourceBranch,
+        targetBranch,
+        targetBranchName: mergeRequest.targetBranch,
       },
     });
 
@@ -87,13 +126,13 @@ export class FarosMergeRequests extends GitlabConverter {
     if (mergeRequest.notes) {
       for (const note of mergeRequest.notes) {
         const numericId = this.extractIdFromGid(String(note.id));
-        
+
         res.push({
           model: 'vcs_PullRequestComment',
           record: {
             number: numericId,
             uid: note.id,
-            author: note.author_username 
+            author: note.author_username
               ? {uid: note.author_username, source}
               : null,
             comment: Utils.cleanAndTruncate(note.body),
@@ -116,7 +155,7 @@ export class FarosMergeRequests extends GitlabConverter {
               uid: reviewId.toString(),
               htmlUrl: null,
               pullRequest,
-              reviewer: note.author_username 
+              reviewer: note.author_username
                 ? {uid: note.author_username, source}
                 : null,
               submittedAt: createdAt,
@@ -157,7 +196,7 @@ export class FarosMergeRequests extends GitlabConverter {
     if (/^\d+$/.test(gid)) {
       return parseInt(gid, 10);
     }
-    
+
     // Extract the numeric part from GID format
     const parts = gid.split('/');
     const numericPart = parts.pop();
@@ -165,11 +204,11 @@ export class FarosMergeRequests extends GitlabConverter {
       return null;
     }
     const parsed = parseInt(numericPart, 10);
-    
+
     if (isNaN(parsed)) {
       return null;
     }
-    
+
     return parsed;
   }
 

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_gitlab.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_gitlab.test.ts.snap
@@ -4,8 +4,8 @@ exports[`faros_gitlab process records from all streams 1`] = `
 Array [
   "Processed 13 records",
   "Processed records by stream: {\\\\\\"mytestsource__gitlab__faros_commits\\\\\\":2,\\\\\\"mytestsource__gitlab__faros_deployments\\\\\\":3,\\\\\\"mytestsource__gitlab__faros_groups\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_issues\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_merge_request_reviews\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_merge_requests\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_projects\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_releases\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_tags\\\\\\":1,\\\\\\"mytestsource__gitlab__faros_users\\\\\\":1}\\"},\\"type\\":\\"LOG\\"}",
-  "Would write 46 records",
-  "Would write records by model: {\\\\\\"cicd_Artifact\\\\\\":2,\\\\\\"cicd_ArtifactCommitAssociation\\\\\\":2,\\\\\\"cicd_ArtifactDeployment\\\\\\":2,\\\\\\"cicd_Build\\\\\\":2,\\\\\\"cicd_BuildCommitAssociation\\\\\\":2,\\\\\\"cicd_Deployment\\\\\\":3,\\\\\\"cicd_Organization\\\\\\":1,\\\\\\"cicd_Pipeline\\\\\\":1,\\\\\\"cicd_Release\\\\\\":1,\\\\\\"cicd_ReleaseTagAssociation\\\\\\":1,\\\\\\"compute_Application\\\\\\":4,\\\\\\"faros_VcsRepositoryOptions\\\\\\":1,\\\\\\"tms_Label\\\\\\":1,\\\\\\"tms_Project\\\\\\":1,\\\\\\"tms_Task\\\\\\":1,\\\\\\"tms_TaskAssignment\\\\\\":1,\\\\\\"tms_TaskBoard\\\\\\":1,\\\\\\"tms_TaskBoardProjectRelationship\\\\\\":1,\\\\\\"tms_TaskBoardRelationship\\\\\\":1,\\\\\\"tms_TaskProjectRelationship\\\\\\":1,\\\\\\"tms_TaskTag\\\\\\":1,\\\\\\"vcs_Commit\\\\\\":2,\\\\\\"vcs_Label\\\\\\":1,\\\\\\"vcs_Membership\\\\\\":1,\\\\\\"vcs_Organization\\\\\\":1,\\\\\\"vcs_PullRequest\\\\\\":1,\\\\\\"vcs_PullRequestComment\\\\\\":2,\\\\\\"vcs_PullRequestLabel\\\\\\":1,\\\\\\"vcs_PullRequestReview\\\\\\":3,\\\\\\"vcs_Repository\\\\\\":1,\\\\\\"vcs_Tag\\\\\\":1,\\\\\\"vcs_User\\\\\\":1}\\"},\\"type\\":\\"LOG\\"}",
+  "Would write 48 records",
+  "Would write records by model: {\\\\\\"cicd_Artifact\\\\\\":2,\\\\\\"cicd_ArtifactCommitAssociation\\\\\\":2,\\\\\\"cicd_ArtifactDeployment\\\\\\":2,\\\\\\"cicd_Build\\\\\\":2,\\\\\\"cicd_BuildCommitAssociation\\\\\\":2,\\\\\\"cicd_Deployment\\\\\\":3,\\\\\\"cicd_Organization\\\\\\":1,\\\\\\"cicd_Pipeline\\\\\\":1,\\\\\\"cicd_Release\\\\\\":1,\\\\\\"cicd_ReleaseTagAssociation\\\\\\":1,\\\\\\"compute_Application\\\\\\":4,\\\\\\"faros_VcsRepositoryOptions\\\\\\":1,\\\\\\"tms_Label\\\\\\":1,\\\\\\"tms_Project\\\\\\":1,\\\\\\"tms_Task\\\\\\":1,\\\\\\"tms_TaskAssignment\\\\\\":1,\\\\\\"tms_TaskBoard\\\\\\":1,\\\\\\"tms_TaskBoardProjectRelationship\\\\\\":1,\\\\\\"tms_TaskBoardRelationship\\\\\\":1,\\\\\\"tms_TaskProjectRelationship\\\\\\":1,\\\\\\"tms_TaskTag\\\\\\":1,\\\\\\"vcs_Branch\\\\\\":2,\\\\\\"vcs_Commit\\\\\\":2,\\\\\\"vcs_Label\\\\\\":1,\\\\\\"vcs_Membership\\\\\\":1,\\\\\\"vcs_Organization\\\\\\":1,\\\\\\"vcs_PullRequest\\\\\\":1,\\\\\\"vcs_PullRequestComment\\\\\\":2,\\\\\\"vcs_PullRequestLabel\\\\\\":1,\\\\\\"vcs_PullRequestReview\\\\\\":3,\\\\\\"vcs_Repository\\\\\\":1,\\\\\\"vcs_Tag\\\\\\":1,\\\\\\"vcs_User\\\\\\":1}\\"},\\"type\\":\\"LOG\\"}",
   "Skipped 0 records",
   "Errored 0 records",
 ]
@@ -847,6 +847,36 @@ Array [
       },
       "uid": "103",
       "url": null,
+    },
+  },
+  Object {
+    "vcs_Branch": Object {
+      "name": "feature/add-new-feature",
+      "repository": Object {
+        "name": "testy",
+        "organization": Object {
+          "source": "GitLab",
+          "uid": "12372707",
+        },
+        "uid": "testy",
+      },
+      "source": "GitLab",
+      "uid": "feature/add-new-feature",
+    },
+  },
+  Object {
+    "vcs_Branch": Object {
+      "name": "main",
+      "repository": Object {
+        "name": "testy",
+        "organization": Object {
+          "source": "GitLab",
+          "uid": "12372707",
+        },
+        "uid": "testy",
+      },
+      "source": "GitLab",
+      "uid": "main",
     },
   },
 ]

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_gitlab.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/faros_gitlab.test.ts.snap
@@ -242,10 +242,36 @@ Array [
         "uid": "testy",
       },
       "source": "GitLab",
+      "sourceBranch": Object {
+        "name": "feature/add-new-feature",
+        "repository": Object {
+          "name": "testy",
+          "organization": Object {
+            "source": "GitLab",
+            "uid": "12372707",
+          },
+          "uid": "testy",
+        },
+        "uid": "feature/add-new-feature",
+      },
+      "sourceBranchName": "feature/add-new-feature",
       "state": Object {
         "category": "Open",
         "detail": "opened",
       },
+      "targetBranch": Object {
+        "name": "main",
+        "repository": Object {
+          "name": "testy",
+          "organization": Object {
+            "source": "GitLab",
+            "uid": "12372707",
+          },
+          "uid": "testy",
+        },
+        "uid": "main",
+      },
+      "targetBranchName": "main",
       "title": "test MR",
       "uid": "3",
       "updatedAt": "2025-06-13T01:52:18.000Z",

--- a/destinations/airbyte-faros-destination/test/resources/faros_gitlab/all-streams.json
+++ b/destinations/airbyte-faros-destination/test/resources/faros_gitlab/all-streams.json
@@ -175,6 +175,17 @@
           "fileCount": 1
         },
         "mergeCommitSha": null,
+        "sourceBranch": "feature/add-new-feature",
+        "targetBranch": "main",
+        "sourceProjectId": "gid://gitlab/Project/40360007",
+        "targetProjectId": "gid://gitlab/Project/40360007",
+        "sourceProject": {
+          "id": "gid://gitlab/Project/40360007",
+          "path": "testy",
+          "group": {
+            "id": "12372707"
+          }
+        },
         "group_id": "12372707",
         "project_path": "testy"
       }

--- a/faros-airbyte-common/src/gitlab/types.ts
+++ b/faros-airbyte-common/src/gitlab/types.ts
@@ -81,6 +81,17 @@ export type FarosMergeRequestOutput = {
     NoteSchema,
     'id' | 'body' | 'created_at' | 'updated_at'
   >)[];
+  sourceBranch?: string;
+  targetBranch?: string;
+  sourceProjectId?: string;
+  targetProjectId?: string;
+  sourceProject?: {
+    id: string;
+    path: string;
+    group: {
+      id: string;
+    };
+  };
 } & Pick<
   Camelize<MergeRequestSchema>,
   | 'iid'
@@ -135,12 +146,7 @@ export type FarosReleaseOutput = {
   project_path: string;
 } & Pick<
   ReleaseSchema,
-  | 'tag_name'
-  | 'name'
-  | 'description'
-  | 'created_at'
-  | 'released_at'
-  | '_links'
+  'tag_name' | 'name' | 'description' | 'created_at' | 'released_at' | '_links'
 >;
 
 export type FarosDeploymentOutput = {

--- a/faros-airbyte-common/src/gitlab/types.ts
+++ b/faros-airbyte-common/src/gitlab/types.ts
@@ -146,7 +146,12 @@ export type FarosReleaseOutput = {
   project_path: string;
 } & Pick<
   ReleaseSchema,
-  'tag_name' | 'name' | 'description' | 'created_at' | 'released_at' | '_links'
+  | 'tag_name'
+  | 'name'
+  | 'description'
+  | 'created_at'
+  | 'released_at'
+  | '_links'
 >;
 
 export type FarosDeploymentOutput = {

--- a/sources/gitlab-source/resources/queries/merge-requests-query.gql
+++ b/sources/gitlab-source/resources/queries/merge-requests-query.gql
@@ -42,6 +42,17 @@ query mergeRequests($fullPath: ID!, $pageSize: Int = 40, $cursor: String, $updat
         state
         title
         webUrl
+        sourceBranch
+        targetBranch
+        sourceProjectId
+        targetProjectId
+        sourceProject {
+          id
+          path
+          group {
+            id
+          }
+        }
         notes(first: $pageSize) {
           pageInfo {
             endCursor

--- a/sources/gitlab-source/resources/schemas/farosMergeRequests.json
+++ b/sources/gitlab-source/resources/schemas/farosMergeRequests.json
@@ -92,6 +92,37 @@
     },
     "mergeCommitSha": {
       "type": ["string", "null"]
+    },
+    "sourceBranch": {
+      "type": ["string", "null"]
+    },
+    "targetBranch": {
+      "type": ["string", "null"]
+    },
+    "sourceProjectId": {
+      "type": ["string", "null"]
+    },
+    "targetProjectId": {
+      "type": ["string", "null"]
+    },
+    "sourceProject": {
+      "type": ["object", "null"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "group": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "required": [

--- a/sources/gitlab-source/src/gitlab.ts
+++ b/sources/gitlab-source/src/gitlab.ts
@@ -401,6 +401,11 @@ export class GitLab {
             'userNotesCount',
             'diffStatsSummary',
             'mergeCommitSha',
+            'sourceBranch',
+            'targetBranch',
+            'sourceProjectId',
+            'targetProjectId',
+            'sourceProject',
           ]),
         };
       }


### PR DESCRIPTION
## Summary
- Add branch information (sourceBranch, targetBranch, sourceProjectId, targetProjectId, sourceProject) to GitLab merge requests
- Port functionality from GitLab feed commit 4cc9660d97ff32fd740f74376004428708c7d278 to both source and destination
- Enable proper branch tracking and cross-project merge request support
- **Complete implementation**: Both branch collection AND branch record output

## Changes Made

### Source Changes
- Updated GraphQL query to fetch branch fields from GitLab API
- Added branch field definitions to JSON schema
- Updated TypeScript types to include optional branch fields
- Modified gitlab.ts to include branch information in output

### Destination Changes  
- Added BranchCollector integration for branch processing
- Implemented cross-project merge request logic for sourceRepository
- Added branch fields to vcs_PullRequest records
- **Added onProcessingComplete method to output collected vcs_Branch records**
- Updated test data and snapshots to include branch information

## Test Results
✅ **All GitLab source tests pass (48/48)**
✅ **All GitLab destination tests pass (3/3)**  
✅ **Branch records properly created**: 2 vcs_Branch records per merge request
✅ **Total record count increased**: 46 → 48 records in tests
✅ **Model counts updated**: Added "vcs_Branch":2 to test output

## Test Plan
- [x] All GitLab source tests pass (48/48)
- [x] All GitLab destination tests pass (3/3)
- [x] Code properly linted and formatted
- [x] Backward compatibility maintained with optional fields
- [x] Branch records properly output via onProcessingComplete
- [x] Snapshots updated to reflect new vcs_Branch records

🤖 Generated with [Claude Code](https://claude.ai/code)