### PR TITLE
Update Azure WorkItems stream to use calculateUpdatedStreamState from CDK

### DIFF
--- a/sources/azure-workitems-source/src/streams/workitems.ts
+++ b/sources/azure-workitems-source/src/streams/workitems.ts
@@ -1,5 +1,9 @@
 import {ProjectReference} from 'azure-devops-node-api/interfaces/ReleaseInterfaces';
-import {StreamState, SyncMode} from 'faros-airbyte-cdk';
+import {
+  calculateUpdatedStreamState,
+  StreamState,
+  SyncMode,
+} from 'faros-airbyte-cdk';
 import {WorkItemWithRevisions} from 'faros-airbyte-common/azure-devops';
 import {Utils} from 'faros-js-client';
 import {Dictionary} from 'ts-essentials';
@@ -36,18 +40,13 @@ export class Workitems extends StreamWithProjectSlices {
     currentStreamState: StreamState,
     latestRecord: WorkItemWithRevisions
   ): StreamState {
-    const currentState =
-      currentStreamState?.[latestRecord.project.name]?.cutoff ?? 0;
-    const newState = Math.max(
-      currentState,
-      Utils.toDate(latestRecord.fields['System.ChangedDate']).getTime()
+    const latestRecordCutoff = Utils.toDate(
+      latestRecord.fields['System.ChangedDate']
     );
-
-    return {
-      ...currentStreamState,
-      [latestRecord.project.name]: {
-        cutoff: newState,
-      },
-    };
+    return calculateUpdatedStreamState(
+      latestRecordCutoff,
+      currentStreamState,
+      latestRecord.project.name
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Replace manual state calculation with standardized CDK function `calculateUpdatedStreamState`
- Align Azure WorkItems stream with pattern used across other connectors (GitHub, Jira, Azure Pipelines)  
- Simplify `getUpdatedState` method from 11 lines to 6 lines while maintaining identical functionality

## Changes Made
- Import `calculateUpdatedStreamState` from `faros-airbyte-cdk`
- Update `getUpdatedState` method to use the standardized function
- State tracking per project using `System.ChangedDate` remains unchanged

## Benefits
- **Consistency**: Follows same pattern as other connectors
- **Reliability**: Uses tested CDK function with proper null safety
- **Maintainability**: Reduces code duplication across connectors

## Test Plan
- [x] Build passes successfully
- [x] Linting passes 
- [x] All existing tests pass (5/5)
- [x] Functionality verified to be identical

🤖 Generated with [Claude Code](https://claude.ai/code)