### PR TITLE
FAI-17432: Fix TestRails listSuites method to properly paginate results

### DIFF
--- a/sources/testrails-source/src/testrails/testrails-client.ts
+++ b/sources/testrails-source/src/testrails/testrails-client.ts
@@ -11,6 +11,7 @@ import {
   PagedResponse,
   PagedResults,
   PagedRuns,
+  PagedSuites,
   PagedTests,
   TestRailsCase,
   TestRailsCaseType,
@@ -96,8 +97,16 @@ export class TestRailsClient {
    * @param projectId The project to retrieve suites for
    * @returns The TestRails suites
    */
+  @Memoize()
   async listSuites(projectId: string): Promise<TestRailsSuite[]> {
-    return this.get(`/get_suites/${projectId}`);
+    const suites = [];
+    for await (const suite of this.paginate(
+      `/get_suites/${projectId}`,
+      (res: PagedSuites) => res.suites
+    )) {
+      suites.push(suite);
+    }
+    return suites;
   }
 
   /**

--- a/sources/testrails-source/src/testrails/testrails-models.ts
+++ b/sources/testrails-source/src/testrails/testrails-models.ts
@@ -38,6 +38,10 @@ export interface TestRailsSuite {
   readonly completed_on: number;
 }
 
+export interface PagedSuites extends PagedResponse {
+  readonly suites: TestRailsSuite[];
+}
+
 export interface TestRailsCase {
   readonly id: number;
   readonly title: string;


### PR DESCRIPTION
## Summary
- Fixed the `listSuites` method in TestRails client to properly paginate through all suites
- Previously, the method was attempting to fetch all suites in a single API call which would fail for projects with many suites
- Added the missing `PagedSuites` interface to support paginated responses
- Breaking change in API response in https://support.testrail.com/hc/en-us/articles/39188927555092-TestRail-9-3-1-Default-1020

## Changes
1. Updated `listSuites` method to use the `paginate` helper function (consistent with other list methods)
2. Added `PagedSuites` interface to `testrails-models.ts`
3. Added `@Memoize()` decorator for performance optimization

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Manual testing with a TestRails instance that has many suites to verify pagination works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)