### PR TITLE
FAI-17561: Fix stack overflow issues in GitHub converters

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/github/faros_copilot_usage.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/faros_copilot_usage.ts
@@ -570,21 +570,19 @@ export class FarosCopilotUsage extends GitHubConverter {
     const res: DestinationRecord[] = [];
     // make sure we delete old records without model for the same partition
     // that could have been written to avoid duplicated / redundant data
-    res.push(
-      ...Object.entries(this.recordsWithoutModelForDeletion).map(
-        ([uid, {day}]) => ({
-          model: 'vcs_AssistantMetric__Deletion',
-          record: {
-            flushRequired: false,
-            where: {
-              uid,
-              startedAt: day, // include to benefit from the index on startedAt and improve performance
-            },
+    for (const [uid, {day}] of Object.entries(this.recordsWithoutModelForDeletion)) {
+      res.push({
+        model: 'vcs_AssistantMetric__Deletion',
+        record: {
+          flushRequired: false,
+          where: {
+            uid,
+            startedAt: day, // include to benefit from the index on startedAt and improve performance
           },
-        })
-      ),
-      FLUSH
-    );
+        },
+      });
+    }
+    res.push(FLUSH);
     return res;
   }
 }

--- a/destinations/airbyte-faros-destination/src/converters/github/faros_pull_requests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/faros_pull_requests.ts
@@ -293,11 +293,23 @@ export class FarosPullRequests extends GitHubConverter {
     ctx: StreamContext
   ): Promise<ReadonlyArray<DestinationRecord>> {
     const res: DestinationRecord[] = [];
-    res.push(...this.convertBranches());
-    res.push(...this.convertLabels());
-    res.push(...this.convertUsers());
-    res.push(...this.fileCollector.convertFiles());
-    res.push(...this.convertPRFileAssociations());
+    
+    for (const record of this.convertBranches()) {
+      res.push(record);
+    }
+    for (const record of this.convertLabels()) {
+      res.push(record);
+    }
+    for (const record of this.convertUsers()) {
+      res.push(record);
+    }
+    for (const record of this.fileCollector.convertFiles()) {
+      res.push(record);
+    }
+    for (const record of this.convertPRFileAssociations()) {
+      res.push(record);
+    }
+    
     return res;
   }
 

--- a/destinations/airbyte-faros-destination/src/converters/github/faros_pull_requests.ts
+++ b/destinations/airbyte-faros-destination/src/converters/github/faros_pull_requests.ts
@@ -292,13 +292,13 @@ export class FarosPullRequests extends GitHubConverter {
   async onProcessingComplete(
     ctx: StreamContext
   ): Promise<ReadonlyArray<DestinationRecord>> {
-    return [
-      ...this.convertBranches(),
-      ...this.convertLabels(),
-      ...this.convertUsers(),
-      ...this.fileCollector.convertFiles(),
-      ...this.convertPRFileAssociations(),
-    ];
+    const res: DestinationRecord[] = [];
+    res.push(...this.convertBranches());
+    res.push(...this.convertLabels());
+    res.push(...this.convertUsers());
+    res.push(...this.fileCollector.convertFiles());
+    res.push(...this.convertPRFileAssociations());
+    return res;
   }
 
   private collectBranch(


### PR DESCRIPTION
## Summary
- Fixed "Maximum call stack size exceeded" errors in GitHub converters when processing large datasets
- Replaced problematic spread operator patterns with safer alternatives
- Updated `faros_copilot_usage.ts` to use loop instead of spread for deletion records  
- Updated `faros_pull_requests.ts` to use individual push calls instead of array literal spread

## Test plan
- [ ] Test with large datasets that previously caused stack overflow
- [ ] Verify functionality remains the same for normal-sized datasets
- [ ] Run existing converter tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)