### PR TITLE
FAI-17607 Fix Bitbucket source bucketing by adding applyRoundRobinBucketing call

### DIFF
--- a/sources/bitbucket-source/src/index.ts
+++ b/sources/bitbucket-source/src/index.ts
@@ -8,7 +8,10 @@ import {
   AirbyteState,
   AirbyteStreamBase,
 } from 'faros-airbyte-cdk';
-import {calculateDateRange} from 'faros-airbyte-common/common';
+import {
+  applyRoundRobinBucketing,
+  calculateDateRange,
+} from 'faros-airbyte-common/common';
 import VError from 'verror';
 
 import {Bitbucket, DEFAULT_CUTOFF_DAYS, DEFAULT_RUN_MODE} from './bitbucket';
@@ -95,15 +98,21 @@ export class BitbucketSource extends AirbyteSourceBase<BitbucketConfig> {
       cutoff_days: config.cutoff_days ?? DEFAULT_CUTOFF_DAYS,
       logger: this.logger.info.bind(this.logger),
     });
+
+    const {config: newConfig, state: newState} = applyRoundRobinBucketing(
+      config,
+      state,
+      this.logger.info.bind(this.logger)
+    );
     return {
       config: {
-        ...config,
+        ...newConfig,
         requestedStreams,
         startDate,
         endDate,
       },
       catalog: {streams},
-      state,
+      state: newState,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Fix missing applyRoundRobinBucketing call in Bitbucket source that prevented proper bucketing functionality
- Add required import from faros-airbyte-common/common
- Align Bitbucket source implementation with other sources (GitHub, GitLab, Jira, CircleCI)

## Problem
The Bitbucket source was missing the `applyRoundRobinBucketing` call in its `onBeforeRead` method. This prevented:
- Bucket configuration from being processed for round-robin execution
- Origin name from getting the proper bucket suffix (e.g., `__bucket__1`)
- Destination from receiving the processed bucket configuration

## Changes
1. **Added import**: Import `applyRoundRobinBucketing` from `faros-airbyte-common/common`
2. **Added bucketing call**: Call `applyRoundRobinBucketing` in `onBeforeRead` method
3. **Used processed config**: Return the processed config and state instead of original

## Testing
- Verified the fix aligns with working implementations in GitHub, GitLab, Jira, and CircleCI sources
- The change ensures bucket configuration gets passed to the destination for proper origin naming

🤖 Generated with [Claude Code](https://claude.ai/code)