### PR TITLE
FAI-17776: Add assignee changelog tracking for Asana tasks

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
+++ b/destinations/airbyte-faros-destination/src/converters/asana/tasks.ts
@@ -168,12 +168,30 @@ export class Tasks extends AsanaConverter {
       },
     });
 
-    if (task.assignee) {
+    // Process assignee revisions for complete assignment history
+    if (task.assigneeRevisions && task.assigneeRevisions.length > 0) {
+      for (const revision of task.assigneeRevisions) {
+        if (revision.assignee?.gid) {
+          res.push({
+            model: 'tms_TaskAssignment',
+            record: {
+              task: taskKey,
+              assignee: {uid: revision.assignee.gid, source},
+              assignedAt: Utils.toDate(revision.assignedAt),
+              unassignedAt: Utils.toDate(revision.unassignedAt),
+            },
+          });
+        }
+      }
+    } else if (task.assignee) {
+      // Fallback to current assignee if no revision history
       res.push({
         model: 'tms_TaskAssignment',
         record: {
           task: taskKey,
           assignee: {uid: task.assignee.gid, source},
+          assignedAt: null,
+          unassignedAt: null,
         },
       });
     }

--- a/destinations/airbyte-faros-destination/test/converters/__snapshots__/asana.test.ts.snap
+++ b/destinations/airbyte-faros-destination/test/converters/__snapshots__/asana.test.ts.snap
@@ -117,6 +117,7 @@ Array [
   Object {
     "model": "tms_TaskAssignment",
     "record": Object {
+      "assignedAt": null,
       "assignee": Object {
         "source": "Asana",
         "uid": "7440298482110",
@@ -125,6 +126,67 @@ Array [
         "source": "Asana",
         "uid": "1205346703408262",
       },
+      "unassignedAt": null,
+    },
+  },
+]
+`;
+
+exports[`asana tasks assignee revisions changelog 1`] = `
+Array [
+  Object {
+    "model": "tms_Task",
+    "record": Object {
+      "additionalFields": Array [],
+      "createdAt": 2023-08-24T15:52:00.014Z,
+      "description": "Task 1 notes",
+      "name": "Task 1",
+      "parent": null,
+      "resolvedAt": 2023-08-25T15:52:00.014Z,
+      "source": "Asana",
+      "status": Object {
+        "category": "Todo",
+        "detail": "incomplete",
+      },
+      "statusChangedAt": 2023-08-25T20:59:25.575Z,
+      "statusChangelog": Array [],
+      "type": Object {
+        "category": "Task",
+        "detail": "task",
+      },
+      "uid": "1205346703408262",
+      "updatedAt": 2023-08-25T20:59:25.575Z,
+      "url": "https://app.asana.com/0/1205346703408259/1205346703408262",
+    },
+  },
+  Object {
+    "model": "tms_TaskAssignment",
+    "record": Object {
+      "assignedAt": 2023-08-24T10:00:00.000Z,
+      "assignee": Object {
+        "source": "Asana",
+        "uid": "7440298482110",
+      },
+      "task": Object {
+        "source": "Asana",
+        "uid": "1205346703408262",
+      },
+      "unassignedAt": 2023-08-24T16:00:00.000Z,
+    },
+  },
+  Object {
+    "model": "tms_TaskAssignment",
+    "record": Object {
+      "assignedAt": 2023-08-24T16:00:00.000Z,
+      "assignee": Object {
+        "source": "Asana",
+        "uid": "7440298482111",
+      },
+      "task": Object {
+        "source": "Asana",
+        "uid": "1205346703408262",
+      },
+      "unassignedAt": undefined,
     },
   },
 ]

--- a/destinations/airbyte-faros-destination/test/converters/asana.test.ts
+++ b/destinations/airbyte-faros-destination/test/converters/asana.test.ts
@@ -103,6 +103,33 @@ describe('asana', () => {
       expect(res).toMatchSnapshot();
     });
 
+    test('assignee revisions changelog', async () => {
+      const record = AirbyteRecord.make('tasks', {
+        ...TASK,
+        assigneeRevisions: [
+          {
+            assignee: {
+              gid: '7440298482110',
+              name: 'John Doe',
+              resource_type: 'user',
+            },
+            assignedAt: '2023-08-24T10:00:00.000Z',
+            unassignedAt: '2023-08-24T16:00:00.000Z',
+          },
+          {
+            assignee: {
+              gid: '7440298482111',
+              name: 'Jane Smith',
+              resource_type: 'user',
+            },
+            assignedAt: '2023-08-24T16:00:00.000Z',
+          },
+        ],
+      });
+      const res = await converter.convert(record);
+      expect(res).toMatchSnapshot();
+    });
+
     test('parent', async () => {
       const record = AirbyteRecord.make('tasks', {
         ...TASK,

--- a/sources/asana-source/src/models.ts
+++ b/sources/asana-source/src/models.ts
@@ -152,6 +152,7 @@ export type Task = {
   };
   stories?: ReadonlyArray<Story>;
   comments?: ReadonlyArray<Story>;
+  assigneeRevisions?: ReadonlyArray<TaskAssigneeRevision>;
 };
 
 export type Project = {
@@ -304,3 +305,13 @@ export type Tag = {
     name?: string;
   };
 };
+
+export interface TaskAssigneeRevision {
+  readonly assignee?: {
+    gid?: string;
+    resource_type?: string;
+    name?: string;
+  };
+  readonly assignedAt: string;
+  readonly unassignedAt?: string;
+}

--- a/sources/asana-source/test/__snapshots__/index.test.ts.snap
+++ b/sources/asana-source/test/__snapshots__/index.test.ts.snap
@@ -160,6 +160,7 @@ Array [
 exports[`index streams - tasks 1`] = `
 Array [
   Object {
+    "assigneeRevisions": Array [],
     "comments": Array [
       Object {
         "created_at": "2021-01-01T01:00:00.000Z",


### PR DESCRIPTION
## Summary

• Implement comprehensive assignee tracking for Asana tasks similar to Azure Work Items and Jira issues  
• Add assignment lifecycle tracking with both assignment and unassignment events
• Leverage Asana's existing story event system for tracking assignment changes

## Technical Changes

• **asana-source**: Added `TaskAssigneeRevision` interface with `assignedAt`/`unassignedAt` fields for consistency with other implementations
• **asana-source**: Implemented `getAssigneeRevisions()` method that processes story events ('assigned'/'unassigned') to build assignment history
• **airbyte-faros-destination**: Updated Tasks converter to process `assigneeRevisions` and generate `TaskAssignment` records with proper lifecycle tracking
• **Test Coverage**: Added comprehensive test for assignee revisions scenario and updated existing assignee test to include new fields

## Implementation Details

The implementation follows the same pattern as Azure Work Items:
- Processes Asana story events with `resource_subtype` of 'assigned' and 'unassigned'  
- Creates revision records where each assignment tracks when it started (`assignedAt`) and optionally when it ended (`unassignedAt`)
- Only includes actual assignments (not unassignment events) in the final revision list
- Maintains fallback support for tasks with only current assignee and no revision history

## Test Plan

- [x] Source tests pass with new assigneeRevisions field in Task interface
- [x] Destination converter tests pass with realistic assignee revision scenarios  
- [x] Snapshot tests updated to verify correct TaskAssignment record generation
- [x] Test coverage includes both assignee revision tracking and fallback scenarios
- [x] All builds compile successfully across the monorepo

🤖 Generated with [Claude Code](https://claude.ai/code)