### PR TITLE
gitlab-source: fix GraphQL closedAt rewrite to avoid field concatenation\n\nUse line-anchored removal to prevent joining adjacent fields (e.g., mergedAt + author -> mergedAtauthor). Adds throw-away test locally to verify behavior (not included in PR).

### DIFF
--- a/sources/gitlab-source/src/gitlab.ts
+++ b/sources/gitlab-source/src/gitlab.ts
@@ -360,8 +360,9 @@ export class GitLab {
     let query = MERGE_REQUESTS_QUERY;
 
     if (!hasClosedAt) {
-      // Remove closedAt field from the query
-      query = query.replace(/\s*closedAt\s*\n?/g, '');
+      // Remove only the line containing `closedAt` to avoid concatenating neighbors
+      // e.g., prevent `mergedAt` + `author` becoming `mergedAtauthor`
+      query = query.replace(/^[ \t]*closedAt\s*\r?\n/gm, '');
       this.logger.debug('Removed closedAt field from merge request query');
     }
 


### PR DESCRIPTION
## Description

> Provide description here

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
