### PR TITLE
Add survey respondent team id column name fallback to "What is your team?" for OOTB surveys

### DIFF
--- a/destinations/airbyte-faros-destination/src/converters/abstract-surveys/surveys.ts
+++ b/destinations/airbyte-faros-destination/src/converters/abstract-surveys/surveys.ts
@@ -49,6 +49,8 @@ export interface SurveysConfig {
   exclude_columns?: ReadonlyArray<string>;
 }
 
+const RespondentTeamIdColumnFallback = 'What is your team?';
+
 export abstract class AbstractSurveys extends Converter {
   abstract getSurveyId(record: AirbyteRecord): string | undefined;
   abstract getTableName(record: AirbyteRecord): string | undefined;
@@ -542,7 +544,8 @@ export abstract class AbstractSurveys extends Converter {
           row,
           this.config.column_names_mapping.respondent_team_name_column_name
         )
-      );
+      ) ??
+      AbstractSurveys.getColumnValue(row, RespondentTeamIdColumnFallback);
 
     if (!uid) {
       return undefined;


### PR DESCRIPTION
## Description
Add "What is your team?" as respondent team id column name fallback, used for out OOTB surveys, so there is no manual configuration needed on the source. Now team id will can be read by default from this column.
> Provide description here

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
