### PR TITLE
FAI-18321 | Add rate limiting for Cursor AI commit metrics API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20793,6 +20793,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "bottleneck": "^2.19.5",
         "faros-airbyte-cdk": "*",
         "faros-airbyte-common": "*",
         "verror": "^1.10.1"

--- a/sources/cursor-source/package.json
+++ b/sources/cursor-source/package.json
@@ -26,6 +26,7 @@
     "watch": "tsc -b -w src test"
   },
   "dependencies": {
+    "bottleneck": "^2.19.5",
     "faros-airbyte-cdk": "*",
     "faros-airbyte-common": "*",
     "verror": "^1.10.1"


### PR DESCRIPTION
## Summary
- Add Bottleneck rate limiter to Cursor source connector
- Implement 50 requests per minute limit for AI commit metrics API endpoint
- Wrap `/analytics/ai-code/commits` API calls with rate limiter to prevent hitting API rate limits

## Changes
- Added `bottleneck` dependency to cursor-source package
- Created `limiterAICodeTrackingAPI` Bottleneck instance with 50 req/min configuration
- Wrapped `getAiCommitMetrics()` API call with rate limiter using `.schedule()`

## Test plan
- [x] All existing cursor-source tests pass (9/9)
- [x] TypeScript compilation successful
- [x] Rate limiter properly initialized with correct configuration
- [x] API calls wrapped without breaking existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)